### PR TITLE
Varios reemplazos recomendados por PHP Code Sniffer

### DIFF
--- a/Core/Base/DataBase.php
+++ b/Core/Base/DataBase.php
@@ -99,7 +99,7 @@ class DataBase {
                     break;
             }
 
-            if (self::$engine != NULL) {
+            if (self::$engine !== NULL) {
                 self::$utils = new DataBase\DataBaseUtils(self::$engine);
             }
         }
@@ -126,7 +126,7 @@ class DataBase {
      * @return array
      */
     public function getTables() {
-        if (count(self::$tables) == 0) {
+        if (count(self::$tables) === 0) {
             self::$tables = self::$engine->listTables(self::$link);
         }
 
@@ -202,7 +202,7 @@ class DataBase {
         $error = '';
         self::$link = self::$engine->connect($error);
 
-        if ($error != '') {
+        if ($error !== '') {
             self::$miniLog->critical($error);
         }
 

--- a/Core/Base/DataBase/DataBaseUtils.php
+++ b/Core/Base/DataBase/DataBaseUtils.php
@@ -54,7 +54,7 @@ class DataBaseUtils {
     private function searchInArray($items, $index, $value) {
         $result = [];
         foreach ($items as $column) {
-            if ($column[$index] == $value) {
+            if ($column[$index] === $value) {
                 $result = $column;
                 break;
             }
@@ -74,7 +74,7 @@ class DataBaseUtils {
         $db = strtolower($dbType);
         $xml = strtolower($xmlType);
 
-        $result = ((FS_CHECK_DB_TYPES != 1) || self::$engine->compareDataTypes($db, $xml) || ($xml == 'serial') || (substr($db, 0, 4) == 'time' && substr($xml, 0, 4) == 'time'));
+        $result = ((FS_CHECK_DB_TYPES !== 1) || self::$engine->compareDataTypes($db, $xml) || ($xml === 'serial') || (substr($db, 0, 4) === 'time' && substr($xml, 0, 4) === 'time'));
 
         return $result;
     }
@@ -89,7 +89,7 @@ class DataBaseUtils {
     public function compareColumns($tableName, $xmlCols, $dbCols) {
         $result = '';
         foreach ($xmlCols as $xml_col) {
-            if (strtolower($xml_col['tipo']) == 'integer') {
+            if (strtolower($xml_col['tipo']) === 'integer') {
                 /**
                  * Desde la pestaña avanzado el panel de control se puede cambiar
                  * el tipo de entero a usar en las columnas.
@@ -107,11 +107,11 @@ class DataBaseUtils {
                 $result .= self::$engine->sqlAlterModifyColumn($tableName, $xml_col);
             }
 
-            if ($column['default'] != $xml_col['defecto']) {
+            if ($column['default'] !== $xml_col['defecto']) {
                 $result .= self::$engine->sqlAlterConstraintDefault($tableName, $xml_col);
             }
 
-            if ($column['is_nullable'] != $xml_col['nulo']) {
+            if ($column['is_nullable'] !== $xml_col['nulo']) {
                 $result .= self::$engine->sqlAlterConstraintNull($tableName, $xml_col);
             }
         }
@@ -141,7 +141,7 @@ class DataBaseUtils {
 
         if (!empty($xmlCons) && !$deleteOnly && FS_FOREIGN_KEYS) {
             foreach ($xmlCons as $xml_con) {
-                if (substr($xml_con['consulta'], 0, 7) == 'PRIMARY') {
+                if (substr($xml_con['consulta'], 0, 7) === 'PRIMARY') {
                     continue;
                 }
 

--- a/Core/Base/DataBase/Mysql.php
+++ b/Core/Base/DataBase/Mysql.php
@@ -92,7 +92,7 @@ class Mysql implements DatabaseEngine {
             return NULL;
         }
 
-        $result = new \mysqli(FS_DB_HOST, FS_DB_USER, FS_DB_PASS, FS_DB_NAME, intval(FS_DB_PORT));
+        $result = new \mysqli(FS_DB_HOST, FS_DB_USER, FS_DB_PASS, FS_DB_NAME, (int)FS_DB_PORT);
         if ($result->connect_error) {
             $error = $result->connect_error;
             return NULL;
@@ -257,7 +257,7 @@ class Mysql implements DatabaseEngine {
      * @return boolean
      */
     private function compareDataTypeNumeric($dbType, $xmlType) {
-        return (substr($dbType, 0, 4) == 'int(' && $xmlType == 'INTEGER') || (substr($dbType, 0, 6) == 'double' && $xmlType == 'double precision');
+        return (substr($dbType, 0, 4) === 'int(' && $xmlType === 'INTEGER') || (substr($dbType, 0, 6) === 'double' && $xmlType === 'double precision');
     }
 
     /**
@@ -267,9 +267,9 @@ class Mysql implements DatabaseEngine {
      * @return boolean
      */
     private function compareDataTypeChar($dbType, $xmlType) {
-        $result = (substr($xmlType, 0, 18) == 'character varying(');
+        $result = (substr($xmlType, 0, 18) === 'character varying(');
         if ($result) {
-            $result = (substr($dbType, 0, 8) == 'varchar(') || (substr($dbType, 0, 5) == 'char(');
+            $result = (substr($dbType, 0, 8) === 'varchar(') || (substr($dbType, 0, 5) === 'char(');
         }
         return $result;
     }
@@ -281,7 +281,7 @@ class Mysql implements DatabaseEngine {
      * @return boolean
      */
     public function compareDataTypes($dbType, $xmlType) {
-        $result = (($dbType == $xmlType) || ($dbType == 'tinyint(1)' && $xmlType == 'boolean') || (substr($dbType, 8, -1) == substr($xmlType, 18, -1)) || (substr($dbType, 5, -1) == substr($xmlType, 18, -1)));
+        $result = (($dbType === $xmlType) || ($dbType === 'tinyint(1)' && $xmlType === 'boolean') || (substr($dbType, 8, -1) === substr($xmlType, 18, -1)) || (substr($dbType, 5, -1) === substr($xmlType, 18, -1)));
 
         if (!$result) {
             $result = $this->compareDataTypeNumeric($dbType, $xmlType);
@@ -336,7 +336,7 @@ class Mysql implements DatabaseEngine {
 
         /// ¿La tabla no usa InnoDB?
         $data = $this->select($link, "SHOW TABLE STATUS FROM `" . FS_DB_NAME . "` LIKE '" . $tableName . "';");
-        if ($data && $data[0]['Engine'] != 'InnoDB') {
+        if ($data && $data[0]['Engine'] !== 'InnoDB') {
             $result = $this->exec($link, "ALTER TABLE " . $tableName . " ENGINE=InnoDB;");
             if (!$result) {
                 $error = 'Imposible convertir la tabla ' . $tableName . ' a InnoDB.'
@@ -377,17 +377,17 @@ class Mysql implements DatabaseEngine {
      * @return string
      */
     private function getConstraints($colData) {
-        $notNull = ($colData['nulo'] == 'NO');
+        $notNull = ($colData['nulo'] === 'NO');
         $result = ' NULL';
         if ($notNull) {
             $result = ' NOT' . $result;
         }
 
-        $defaultNull = ($colData['defecto'] == NULL);
+        $defaultNull = ($colData['defecto'] === NULL);
         if ($defaultNull && !$notNull) {
             $result .= ' DEFAULT NULL';
         } else {
-            if ($colData['defecto'] != '') {
+            if ($colData['defecto'] !== '') {
                 $result .= ' DEFAULT ' . $colData['defecto'];
             }
         }
@@ -401,9 +401,9 @@ class Mysql implements DatabaseEngine {
      * @return string
      */
     private function getTypeAndConstraints($colData) {
-        $type = strtolower($colData['tipo']) == 'integer' ? FS_DB_INTEGER : strtolower($colData['tipo']);
+        $type = strtolower($colData['tipo']) === 'integer' ? FS_DB_INTEGER : strtolower($colData['tipo']);
 
-        $contraints = ($type == 'serial') ? ' NOT NULL AUTO_INCREMENT' : $this->getConstraints($colData);
+        $contraints = ($type === 'serial') ? ' NOT NULL AUTO_INCREMENT' : $this->getConstraints($colData);
 
         return ' ' . $type . $contraints;
     }

--- a/Core/Base/DataBase/Postgresql.php
+++ b/Core/Base/DataBase/Postgresql.php
@@ -45,7 +45,7 @@ class Postgresql implements DatabaseEngine {
     public function columnFromData($colData) {
         $colData['extra'] = NULL;
 
-        if ($colData['character_maximum_length'] != NULL) {
+        if ($colData['character_maximum_length'] !== NULL) {
             $colData['type'] .= '(' . $colData['character_maximum_length'] . ')';
         }
 
@@ -220,7 +220,7 @@ class Postgresql implements DatabaseEngine {
      * @return boolean
      */
     public function compareDataTypes($dbType, $xmlType) {
-        return ($dbType == $xmlType);
+        return ($dbType === $xmlType);
     }
 
     /**
@@ -257,7 +257,7 @@ class Postgresql implements DatabaseEngine {
      */
     public function checkSequence($link, $tableName, $default, $colname) {
         $aux = explode("'", $default);
-        if (count($aux) == 3) {
+        if (count($aux) === 3) {
             $data = $this->select($link, $this->sqlSequenceExists($aux[1]));
             if (!$data) {             /// ¿Existe esa secuencia?
                 $data = $this->select($link, "SELECT MAX(" . $colname . ")+1 as num FROM " . $tableName . ";");
@@ -290,7 +290,7 @@ class Postgresql implements DatabaseEngine {
                 continue;
             }
 
-            if (FS_FOREIGN_KEYS || substr($res['consulta'], 0, 11) != 'FOREIGN KEY') {
+            if (FS_FOREIGN_KEYS || substr($res['consulta'], 0, 11) !== 'FOREIGN KEY') {
                 $sql .= ', CONSTRAINT ' . $res['nombre'] . ' ' . $res['consulta'];
             }
         }
@@ -395,7 +395,7 @@ class Postgresql implements DatabaseEngine {
         foreach ($columns as $col) {
             $fields .= ', ' . $col['nombre'] . ' ' . $col['tipo'];
 
-            if ($col['nulo'] == 'NO') {
+            if ($col['nulo'] === 'NO') {
                 $fields .= ' NOT NULL';
             }
 
@@ -427,7 +427,7 @@ class Postgresql implements DatabaseEngine {
             $sql .= ' DEFAULT ' . $colData['defecto'];
         }
 
-        if ($colData['nulo'] == 'NO') {
+        if ($colData['nulo'] === 'NO') {
             $sql .= ' NOT NULL';
         }
 
@@ -465,7 +465,7 @@ class Postgresql implements DatabaseEngine {
      * @return string
      */
     public function sqlAlterConstraintNull($tableName, $colData) {
-        $action = ($colData['nulo'] == 'YES') ? " DROP " : " SET ";
+        $action = ($colData['nulo'] === 'YES') ? " DROP " : " SET ";
         return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['nombre'] . $action . "NOT NULL;";
     }
 

--- a/Core/Base/IPFilter.php
+++ b/Core/Base/IPFilter.php
@@ -41,7 +41,7 @@ class IPFilter {
             if ($file) {
                 while (!feof($file)) {
                     $line = explode(';', trim(fgets($file)));
-                    if (count($line) == 3 && intval($line[2]) > time()) { /// if not expired
+                    if (count($line) === 3 && (int)$line[2] > time()) { /// if not expired
                         $this->ipList[] = ['ip' => $line[0], 'count' => (int) $line[1], 'expire' => (int) $line[2]];
                     }
                 }
@@ -55,7 +55,7 @@ class IPFilter {
         $banned = FALSE;
 
         foreach ($this->ipList as $line) {
-            if ($line['ip'] == $ip && $line['count'] > self::MAX_ATTEMPTS) {
+            if ($line['ip'] === $ip && $line['count'] > self::MAX_ATTEMPTS) {
                 $banned = TRUE;
                 break;
             }
@@ -67,7 +67,7 @@ class IPFilter {
     public function setAttempt($ip) {
         $found = FALSE;
         foreach ($this->ipList as $key => $line) {
-            if ($line['ip'] == $ip) {
+            if ($line['ip'] === $ip) {
                 $this->ipList[$key]['count'] ++;
                 $this->ipList[$key]['expire'] = $line['expire'] + self::BAN_SECONDS;
                 break;

--- a/Core/Base/Model.php
+++ b/Core/Base/Model.php
@@ -111,7 +111,7 @@ trait Model {
             self::$tableName = $tableName;
         }
 
-        if ($tableName != '' && !in_array($tableName, self::$checkedTables) && $this->checkTable($tableName)) {
+        if ($tableName !== '' && !in_array($tableName, self::$checkedTables) && $this->checkTable($tableName)) {
             $this->miniLog->debug('Table ' . $tableName . ' checked.');
             self::$checkedTables[] = $tableName;
             $this->cache->set('fs_checked_tables', self::$checkedTables);
@@ -158,7 +158,7 @@ trait Model {
             }
 
             foreach (self::$fields as $field) {
-                if ($field['name'] == $key) {
+                if ($field['name'] === $key) {
                     $type = strstr($field['type'], '(');
                     switch ($type) {
                         case 'tinyint':
@@ -424,7 +424,7 @@ trait Model {
      * @return boolean
      */
     public function str2bool($val) {
-        return ($val == 't' || $val == '1');
+        return ($val === 't' || $val === '1');
     }
 
     /**
@@ -470,7 +470,7 @@ trait Model {
                  */
                 $dbCons = $this->dataBase->getConstraints($tableName);
                 $sql2 = $this->dataBase->compareConstraints($tableName, $xmlCons, $dbCons, TRUE);
-                if ($sql2 != '') {
+                if ($sql2 !== '') {
                     if (!$this->dataBase->exec($sql2)) {
                         $this->miniLog->critical('Error al comprobar la tabla ' . $tableName);
                     }
@@ -491,7 +491,7 @@ trait Model {
                 $sql .= $this->install();
             }
 
-            if ($sql != '' && !$this->dataBase->exec($sql)) {
+            if ($sql !== '' && !$this->dataBase->exec($sql)) {
                 $this->miniLog->critical('Error al comprobar la tabla ' . $tableName);
                 $done = FALSE;
             }
@@ -527,11 +527,11 @@ trait Model {
                         $columns[$key]['tipo'] = (string) $col->tipo;
 
                         $columns[$key]['nulo'] = 'YES';
-                        if ($col->nulo && strtolower($col->nulo) == 'no') {
+                        if ($col->nulo && strtolower($col->nulo) === 'no') {
                             $columns[$key]['nulo'] = 'NO';
                         }
 
-                        if ($col->defecto == '') {
+                        if ($col->defecto === '') {
                             $columns[$key]['defecto'] = NULL;
                         } else {
                             $columns[$key]['defecto'] = (string) $col->defecto;

--- a/Core/Base/Utils.php
+++ b/Core/Base/Utils.php
@@ -83,7 +83,7 @@ trait Utils {
             return( abs($f1 - $f2) < 6 / pow(10, $precision + 1) );
         }
 
-        return( bccomp((string) $f1, (string) $f2, $precision) == 0 );
+        return( bccomp((string) $f1, (string) $f2, $precision) === 0 );
     }
 
     /**

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -187,7 +187,7 @@ class Agente {
         $sql = "SELECT MAX(" . $this->dataBase->sql2int('codagente') . ") as cod FROM " . $this->tableName() . ";";
         $cod = $this->dataBase->select($sql);
         if ($cod) {
-            return 1 + intval($cod[0]['cod']);
+            return 1 + (int)$cod[0]['cod'];
         }
 
         return 1;

--- a/Core/Model/Almacen.php
+++ b/Core/Model/Almacen.php
@@ -130,7 +130,7 @@ class Almacen {
      * @return boolean
      */
     public function isDefault() {
-        return ( $this->codalmacen == $this->defaultItems->codAlmacen() );
+        return ( $this->codalmacen === $this->defaultItems->codAlmacen() );
     }
 
     /**

--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -116,7 +116,7 @@ class Divisa {
      * @return boolean
      */
     public function isDefault() {
-        return ( $this->coddivisa == $this->defaultItems->codDivisa() );
+        return ( $this->coddivisa === $this->defaultItems->codDivisa() );
     }
 
     /**
@@ -132,9 +132,9 @@ class Divisa {
             $this->miniLog->alert($this->i18n->trans('bage-cod-invalid'));
         } else if (isset($this->codiso) && !preg_match("/^[A-Z0-9]{1,3}$/i", $this->codiso)) {
             $this->miniLog->alert($this->i18n->trans('iso-cod-invalid'));
-        } else if ($this->tasaconv == 0) {
+        } else if ($this->tasaconv === 0) {
             $this->miniLog->alert($this->i18n->trans('conversion-rate-not-0'));
-        } else if ($this->tasaconvcompra == 0) {
+        } else if ($this->tasaconvcompra === 0) {
             $this->miniLog->alert($this->i18n->trans('conversion-rate-pruchases-not-0'));
         } else {
             $this->cache->delete('m_divisa_all');

--- a/Core/Model/Ejercicio.php
+++ b/Core/Model/Ejercicio.php
@@ -131,7 +131,7 @@ class Ejercicio {
      * @return boolean
      */
     public function abierto() {
-        return ($this->estado == 'ABIERTO');
+        return ($this->estado === 'ABIERTO');
     }
 
     /**
@@ -154,7 +154,7 @@ class Ejercicio {
 
         $cod = $this->dataBase->select("SELECT MAX(" . $this->dataBase->sql2int('codejercicio') . ") as cod FROM " . $this->tableName() . ";");
         if ($cod) {
-            return sprintf('%04s', (1 + intval($cod[0]['cod'])));
+            return sprintf('%04s', (1 + (int)$cod[0]['cod']));
         }
 
         return '0001';
@@ -177,7 +177,7 @@ class Ejercicio {
      * @return boolean
      */
     public function isDefault() {
-        return ($this->codejercicio == $this->defaultItems->codEjercicio());
+        return ($this->codejercicio === $this->defaultItems->codEjercicio());
     }
 
     /**

--- a/Core/Model/FormaPago.php
+++ b/Core/Model/FormaPago.php
@@ -116,7 +116,7 @@ class FormaPago {
      * @return boolean
      */
     public function isDefault() {
-        return ( $this->codpago == $this->defaultItems->codPago() );
+        return ( $this->codpago === $this->defaultItems->codPago() );
     }
 
     /**
@@ -150,14 +150,14 @@ class FormaPago {
         /// validamos los días de pago
         $array_dias = array();
         foreach (str_getcsv($dias_de_pago) as $d) {
-            if (intval($d) >= 1 && intval($d) <= 31) {
-                $array_dias[] = intval($d);
+            if ((int)$d >= 1 && (int)$d <= 31) {
+                $array_dias[] = (int)$d;
             }
         }
 
-        if ($array_dias != NULL) {
+        if ($array_dias !== NULL) {
             foreach ($array_dias as $i => $dia_de_pago) {
-                if ($i == 0) {
+                if ($i === 0) {
                     $fecha = $this->calcularVencimiento2($fecha_inicio, $dia_de_pago);
                 } else {
                     /// si hay varios dias de pago, elegimos la fecha más cercana
@@ -179,7 +179,7 @@ class FormaPago {
      * @return string
      */
     private function calcularVencimiento2($fecha_inicio, $dia_de_pago = 0) {
-        if ($dia_de_pago == 0) {
+        if ($dia_de_pago === 0) {
             return date('d-m-Y', strtotime($fecha_inicio . ' ' . $this->vencimiento));
         }
 
@@ -196,7 +196,7 @@ class FormaPago {
         }
 
         /// ahora elegimos un dia, pero que quepa en el mes, no puede ser 31 de febrero
-        $tmp_dia = min(array($dia_de_pago, intval(date('t', strtotime($fecha)))));
+        $tmp_dia = min(array($dia_de_pago, (int)date('t', strtotime($fecha))));
 
         /// y por último generamos la fecha
         return date('d-m-Y', strtotime($tmp_dia . '-' . $tmp_mes . '-' . $tmp_anyo));

--- a/Core/Model/Page.php
+++ b/Core/Model/Page.php
@@ -83,11 +83,11 @@ class Page {
     }
 
     public function isDefault() {
-        return ( $this->name == $this->defaultItems->defaultPage() );
+        return ( $this->name === $this->defaultItems->defaultPage() );
     }
 
     public function showing() {
-        return ( $this->name == $this->defaultItems->showingPage() );
+        return ( $this->name === $this->defaultItems->showingPage() );
     }
 
 }

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -324,7 +324,7 @@ class Pais {
      * @return boolean
      */
     public function isDefault() {
-        return ( $this->codpais == $this->defaultItems->codPais() );
+        return ( $this->codpais === $this->defaultItems->codPais() );
     }
 
     /**

--- a/Core/Model/Serie.php
+++ b/Core/Model/Serie.php
@@ -110,7 +110,7 @@ class Serie {
      * @return boolean
      */
     public function isDefault() {
-        return ( $this->codserie == $this->defaultItems->codSerie() );
+        return ( $this->codserie === $this->defaultItems->codSerie() );
     }
 
     /**


### PR DESCRIPTION
- Reemplazada comparación estricta en donde es posible hacerlo
- Reemplazados intval($x) por (int)$x, supuestamente es x6 más rápido