### PR TITLE
Evitar que aparezca warning si falla la conexión

### DIFF
--- a/Core/Base/DataBase/Mysql.php
+++ b/Core/Base/DataBase/Mysql.php
@@ -92,8 +92,8 @@ class Mysql implements DatabaseEngine {
             return NULL;
         }
 
-        $result = new \mysqli(FS_DB_HOST, FS_DB_USER, FS_DB_PASS, FS_DB_NAME, (int)FS_DB_PORT);
-        if ($result->connect_error) {
+        $result = @new \mysqli(FS_DB_HOST, FS_DB_USER, FS_DB_PASS, FS_DB_NAME, (int)FS_DB_PORT);
+        if ($result->connect_errno) {
             $error = $result->connect_error;
             return NULL;
         }


### PR DESCRIPTION
Ocultar warning si falla conexión de base de datos y capturar texto de error