### PR TITLE
Acumulación de cambios para reducir todos los mensajes de PHP-CS al máximo posible

### DIFF
--- a/Core/App/App.php
+++ b/Core/App/App.php
@@ -84,9 +84,7 @@ abstract class App
 
     /**
      * Inicializa la app.
-     *
      * @param string $folder Carpeta de trabajo de FacturaScripts
-     *
      * @throws InvalidArgumentException
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException

--- a/Core/App/App.php
+++ b/Core/App/App.php
@@ -33,7 +33,7 @@ abstract class App {
 
     /**
      * Gestor de acceso a cache.
-     * @var Base\Cache 
+     * @var Base\Cache
      */
     protected $cache;
 
@@ -81,7 +81,12 @@ abstract class App {
 
     /**
      * Inicializa la app.
+     *
      * @param string $folder Carpeta de trabajo de FacturaScripts
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function __construct($folder = '') {
         $this->cache = new Base\Cache($folder);
@@ -126,5 +131,4 @@ abstract class App {
         $ipFilter = new Base\IPFilter($this->folder);
         return $ipFilter->isBanned($this->request->getClientIp());
     }
-
 }

--- a/Core/App/App.php
+++ b/Core/App/App.php
@@ -21,16 +21,19 @@
 namespace FacturaScripts\Core\App;
 
 use FacturaScripts\Core\Base;
+use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
 
 /**
  * Description of App
  *
  * @author Carlos García Gómez
  */
-abstract class App {
-
+abstract class App
+{
     /**
      * Gestor de acceso a cache.
      * @var Base\Cache
@@ -84,11 +87,12 @@ abstract class App {
      *
      * @param string $folder Carpeta de trabajo de FacturaScripts
      *
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($folder = '') {
+    public function __construct($folder = '')
+    {
         $this->cache = new Base\Cache($folder);
         $this->dataBase = new Base\DataBase();
         $this->folder = $folder;
@@ -103,14 +107,16 @@ abstract class App {
      * Conecta a la base de datos.
      * @return bool
      */
-    public function connect() {
+    public function connect()
+    {
         return $this->dataBase->connect();
     }
 
     /**
      * Cierra la conexión a la base de datos.
      */
-    public function close() {
+    public function close()
+    {
         $this->dataBase->close();
     }
 
@@ -119,15 +125,17 @@ abstract class App {
     /**
      * Vuelca los datos en la salida estándar.
      */
-    public function render() {
+    public function render()
+    {
         $this->response->send();
     }
 
     /**
      * Devuelve TRUE si la IP del cliente ha sido baneada.
-     * @return boolean
+     * @return bool
      */
-    protected function isIPBanned() {
+    protected function isIPBanned()
+    {
         $ipFilter = new Base\IPFilter($this->folder);
         return $ipFilter->isBanned($this->request->getClientIp());
     }

--- a/Core/App/App.php
+++ b/Core/App/App.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *
@@ -118,6 +117,10 @@ abstract class App
         $this->dataBase->close();
     }
 
+    /**
+     * TODO
+     * @return mixed
+     */
     abstract public function run();
 
     /**

--- a/Core/App/AppAPI.php
+++ b/Core/App/AppAPI.php
@@ -20,6 +20,8 @@
 
 namespace FacturaScripts\Core\App;
 
+use Symfony\Component\HttpFoundation\Response;
+
 /**
  * Description of App
  *
@@ -29,6 +31,8 @@ class AppAPI extends App {
 
     /**
      * Ejecuta la API.
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException
      */
     public function run() {
         $this->response->headers->set('Content-Type', 'text/plain');
@@ -42,5 +46,4 @@ class AppAPI extends App {
             /// implementar
         }
     }
-
 }

--- a/Core/App/AppAPI.php
+++ b/Core/App/AppAPI.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/App/AppAPI.php
+++ b/Core/App/AppAPI.php
@@ -20,21 +20,24 @@
 
 namespace FacturaScripts\Core\App;
 
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
+use UnexpectedValueException;
 
 /**
  * Description of App
  *
  * @author Carlos García Gómez
  */
-class AppAPI extends App {
-
+class AppAPI extends App
+{
     /**
      * Ejecuta la API.
-     * @throws \InvalidArgumentException
-     * @throws \UnexpectedValueException
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
      */
-    public function run() {
+    public function run()
+    {
         $this->response->headers->set('Content-Type', 'text/plain');
         if (!$this->dataBase->connected()) {
             $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);

--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -100,9 +100,7 @@ class AppController extends App
 
     /**
      * Carga y procesa el controlador $pageName.
-     *
      * @param string $pageName nombre del controlador
-     *
      * @throws InvalidArgumentException
      * @throws Twig_Error_Loader
      * @throws Twig_Error_Runtime

--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -21,6 +21,7 @@
 namespace FacturaScripts\Core\App;
 
 use DebugBar\StandardDebugBar;
+use FacturaScripts\Core\Base\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -32,7 +33,7 @@ class AppController extends App {
 
     /**
      * Controlador cargado.
-     * @var Controller 
+     * @var Controller
      */
     private $controller;
 
@@ -42,6 +43,13 @@ class AppController extends App {
      */
     private $debugBar;
 
+    /**
+     * AppController constructor.
+     * @param string $folder
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($folder = '') {
         parent::__construct($folder);
         $this->controller = NULL;
@@ -50,6 +58,11 @@ class AppController extends App {
 
     /**
      * Selecciona y ejecuta el controlador pertinente.
+     * @throws \InvalidArgumentException
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
+     * @throws \UnexpectedValueException
      */
     public function run() {
         if (!$this->dataBase->connected()) {
@@ -67,7 +80,14 @@ class AppController extends App {
 
     /**
      * Carga y procesa el controlador $pageName.
+     *
      * @param string $pageName nombre del controlador
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
+     * @throws \UnexpectedValueException
      */
     private function loadController($pageName) {
         $controllerName = "FacturaScripts\\Dinamic\\Controller\\{$pageName}";
@@ -102,7 +122,14 @@ class AppController extends App {
     /**
      * Crea el HTML con la plantilla seleccionada. Aunque los datos no se volcarán
      * hasta ejecutar render()
+     *
      * @param string $template archivo html a utilizar
+     *
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
      */
     private function renderHtml($template) {
         /// cargamos el motor de plantillas
@@ -128,7 +155,8 @@ class AppController extends App {
         if (FS_DEBUG) {
             unset($twigOptions['cache']);
             $twigOptions['debug'] = TRUE;
-            $templateVars['debugBarRender'] = $this->debugBar->getJavascriptRenderer('vendor/maximebf/debugbar/src/DebugBar/Resources/');
+            $baseUrl = 'vendor/maximebf/debugbar/src/DebugBar/Resources/';
+            $templateVars['debugBarRender'] = $this->debugBar->getJavascriptRenderer($baseUrl);
 
             /// añadimos del log a debugBar
             foreach ($this->miniLog->read(['debug']) as $msg) {
@@ -146,5 +174,4 @@ class AppController extends App {
             $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
-
 }

--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -55,9 +55,7 @@ class AppController extends App
 
     /**
      * AppController constructor.
-     *
      * @param string $folder
-     *
      * @throws InvalidArgumentException
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
@@ -95,9 +93,7 @@ class AppController extends App
 
     /**
      * Carga y procesa el controlador $pageName.
-     *
      * @param string $pageName nombre del controlador
-     *
      * @throws InvalidArgumentException
      * @throws Twig_Error_Loader
      * @throws Twig_Error_Runtime
@@ -138,9 +134,7 @@ class AppController extends App
     /**
      * Crea el HTML con la plantilla seleccionada. Aunque los datos no se volcarán
      * hasta ejecutar render()
-     *
      * @param string $template archivo html a utilizar
-     *
      * @throws InvalidArgumentException
      * @throws UnexpectedValueException
      * @throws Twig_Error_Loader

--- a/Core/App/AppCron.php
+++ b/Core/App/AppCron.php
@@ -20,18 +20,21 @@
 
 namespace FacturaScripts\Core\App;
 
+use UnexpectedValueException;
+
 /**
  * Description of App
  *
  * @author Carlos García Gómez
  */
-class AppCron extends App {
-
+class AppCron extends App
+{
     /**
      * Ejecuta el cron.
-     * @throws \UnexpectedValueException
+     * @throws UnexpectedValueException
      */
-    public function run() {
+    public function run()
+    {
         $this->response->headers->set('Content-Type', 'text/plain');
         if ($this->dataBase->connected()) {
             /// implementar

--- a/Core/App/AppCron.php
+++ b/Core/App/AppCron.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/App/AppCron.php
+++ b/Core/App/AppCron.php
@@ -20,10 +20,6 @@
 
 namespace FacturaScripts\Core\App;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use DebugBar\StandardDebugBar;
-
 /**
  * Description of App
  *
@@ -33,6 +29,7 @@ class AppCron extends App {
 
     /**
      * Ejecuta el cron.
+     * @throws \UnexpectedValueException
      */
     public function run() {
         $this->response->headers->set('Content-Type', 'text/plain');
@@ -42,5 +39,4 @@ class AppCron extends App {
             $this->response->setContent('DB-ERROR');
         }
     }
-
 }

--- a/Core/Base/Cache.php
+++ b/Core/Base/Cache.php
@@ -20,24 +20,31 @@
 
 namespace FacturaScripts\Core\Base;
 
+/**
+ * Class Cache
+ * @package FacturaScripts\Core\Base
+ */
 class Cache {
-    
+
     /**
      * El motor utilizado para la cache.
-     * @var Cache\FileCache 
+     * @var Cache\FileCache
      */
     private static $engine;
-    
+
     /**
      * Constructor por defecto.
+     *
      * @param string $folder carpeta de trabajo
+     *
+     * @throws \RuntimeException
      */
     public function __construct($folder = '') {
-        if(!isset(self::$engine)) {
+        if (self::$engine === NULL) {
             self::$engine = new Cache\FileCache($folder);
         }
     }
-    
+
     /**
      * Devuelve el contenido asociado a esa $key que hay en la cache.
      * @param string $key
@@ -46,7 +53,7 @@ class Cache {
     public function get($key) {
         return self::$engine->get($key);
     }
-    
+
     /**
      * Guarda en la cache el contenido y lo asocia a $key
      * @param string $key
@@ -56,7 +63,7 @@ class Cache {
     public function set($key, $content) {
         return self::$engine->set($key, $content);
     }
-    
+
     /**
      * Elimina de la cache el contenido asociado a la $key
      * @param string $key
@@ -65,13 +72,12 @@ class Cache {
     public function delete($key) {
         return self::$engine->delete($key);
     }
-    
+
     /**
-     * Limpia todo el contenido de la cache.
+     * Limpia el contenido de la cache al completo.
      * @return bool
      */
     public function clear() {
         return self::$engine->clear();
     }
-
 }

--- a/Core/Base/Cache.php
+++ b/Core/Base/Cache.php
@@ -20,15 +20,18 @@
 
 namespace FacturaScripts\Core\Base;
 
+use FacturaScripts\Core\Base\Cache\FileCache;
+use RuntimeException;
+
 /**
  * Class Cache
  * @package FacturaScripts\Core\Base
  */
-class Cache {
-
+class Cache
+{
     /**
      * El motor utilizado para la cache.
-     * @var Cache\FileCache
+     * @var FileCache
      */
     private static $engine;
 
@@ -37,11 +40,12 @@ class Cache {
      *
      * @param string $folder carpeta de trabajo
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
-    public function __construct($folder = '') {
-        if (self::$engine === NULL) {
-            self::$engine = new Cache\FileCache($folder);
+    public function __construct($folder = '')
+    {
+        if (self::$engine === null) {
+            self::$engine = new FileCache($folder);
         }
     }
 
@@ -50,7 +54,8 @@ class Cache {
      * @param string $key
      * @return mixed
      */
-    public function get($key) {
+    public function get($key)
+    {
         return self::$engine->get($key);
     }
 
@@ -60,7 +65,8 @@ class Cache {
      * @param mixed $content
      * @return bool
      */
-    public function set($key, $content) {
+    public function set($key, $content)
+    {
         return self::$engine->set($key, $content);
     }
 
@@ -69,7 +75,8 @@ class Cache {
      * @param string $key
      * @return bool
      */
-    public function delete($key) {
+    public function delete($key)
+    {
         return self::$engine->delete($key);
     }
 
@@ -77,7 +84,8 @@ class Cache {
      * Limpia el contenido de la cache al completo.
      * @return bool
      */
-    public function clear() {
+    public function clear()
+    {
         return self::$engine->clear();
     }
 }

--- a/Core/Base/Cache.php
+++ b/Core/Base/Cache.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/Cache/FileCache.php
+++ b/Core/Base/Cache/FileCache.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/Cache/FileCache.php
+++ b/Core/Base/Cache/FileCache.php
@@ -42,9 +42,7 @@ class FileCache
 
     /**
      * FileCache constructor.
-     *
      * @param string $folder
-     *
      * @throws RuntimeException
      */
     public function __construct($folder = '')

--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -28,8 +28,8 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Carlos García Gómez
  */
-class Controller {
-
+class Controller
+{
     /**
      * Gestor de acceso a cache.
      * @var Cache
@@ -86,7 +86,8 @@ class Controller {
      * @param MiniLog $miniLog
      * @param string $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className) {
+    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    {
         $this->cache = $cache;
         $this->className = $className;
         $this->dispatcher = new EventDispatcher();
@@ -101,7 +102,8 @@ class Controller {
      * Devuelve el template HTML a utilizar para este controlador.
      * @return string
      */
-    public function getTemplate() {
+    public function getTemplate()
+    {
         return $this->template;
     }
 
@@ -109,7 +111,8 @@ class Controller {
      * Establece el template HTML a utilizar para este controlador.
      * @param string $template
      */
-    public function setTemplate($template) {
+    public function setTemplate($template)
+    {
         $this->template = $template;
     }
 
@@ -117,14 +120,16 @@ class Controller {
      * Devuelve la url del controlador actual.
      * @return string
      */
-    public function url() {
+    public function url()
+    {
         return 'index.php?page=' . $this->className;
     }
 
     /**
      * Ejecuta la lógica del controlador.
      */
-    public function run() {
+    public function run()
+    {
         $this->dispatcher->dispatch('pre-run');
     }
 }

--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,13 +45,13 @@ class Controller {
 
     /**
      * Gestor de eventos.
-     * @var EventDispatcher 
+     * @var EventDispatcher
      */
     protected $dispatcher;
 
     /**
      * Motor de traducción.
-     * @var Translator 
+     * @var Translator
      */
     protected $i18n;
 
@@ -63,7 +63,7 @@ class Controller {
 
     /**
      * Request sobre la que podemos hacer consultas.
-     * @var Request 
+     * @var Request
      */
     public $request;
 
@@ -96,15 +96,15 @@ class Controller {
         $this->template = $this->className . '.html';
         $this->title = $this->className;
     }
-    
+
     /**
      * Devuelve el template HTML a utilizar para este controlador.
-     * @return type
+     * @return string
      */
     public function getTemplate() {
         return $this->template;
     }
-    
+
     /**
      * Establece el template HTML a utilizar para este controlador.
      * @param string $template
@@ -127,5 +127,4 @@ class Controller {
     public function run() {
         $this->dispatcher->dispatch('pre-run');
     }
-
 }

--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -20,7 +20,8 @@
 
 namespace FacturaScripts\Core\Base;
 
-use FacturaScripts\Core\Model;
+use FacturaScripts\Core\Model\Empresa;
+use FacturaScripts\Core\Model\User;
 use RuntimeException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -55,7 +56,7 @@ class Controller
     
     /**
      * Empresa seleccionada.
-     * @var Model\Empresa
+     * @var Empresa
      */
     public $empresa;
 
@@ -97,7 +98,7 @@ class Controller
     
     /**
      * Usuario que ha iniciado sesión.
-     * @var Model\User
+     * @var User
      */
     public $user;
 
@@ -120,7 +121,7 @@ class Controller
         $this->className = $className;
         $this->dispatcher = new EventDispatcher();
         
-        $empresa = new Model\Empresa();
+        $empresa = new Empresa();
         $this->empresa = $empresa->getDefault();
         
         $this->i18n = $i18n;

--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DataBase.php
+++ b/Core/Base/DataBase.php
@@ -162,7 +162,7 @@ class DataBase
     /**
      * Devuelve una array con las restricciones de una tabla.
      * @param string $tableName
-     * @param boolean $extended
+     * @param bool $extended
      * @return array
      */
     public function getConstraints($tableName, $extended = false)
@@ -196,7 +196,7 @@ class DataBase
 
     /**
      * Devuelve TRUE si se está conestado a la base de datos.
-     * @return boolean
+     * @return bool
      */
     public function connected()
     {
@@ -205,7 +205,7 @@ class DataBase
 
     /**
      * Conecta a la base de datos.
-     * @return boolean
+     * @return bool
      */
     public function connect()
     {
@@ -225,7 +225,7 @@ class DataBase
 
     /**
      * Desconecta de la base de datos.
-     * @return boolean
+     * @return bool
      */
     public function close()
     {
@@ -246,7 +246,7 @@ class DataBase
 
     /**
      * Indica hay una transacción abierta
-     * @return boolean
+     * @return bool
      */
     public function inTransaction()
     {
@@ -255,7 +255,7 @@ class DataBase
 
     /**
      * Inicia una transaccion en la base de datos
-     * @return boolean
+     * @return bool
      */
     public function beginTransaction()
     {
@@ -270,7 +270,7 @@ class DataBase
 
     /**
      * Graba las sentencias ejecutadas en la base de datos
-     * @return boolean
+     * @return bool
      */
     public function commit()
     {
@@ -285,7 +285,7 @@ class DataBase
 
     /**
      * Deshace las sentencias ejecutadas en la base de datos
-     * @return boolean
+     * @return bool
      */
     public function rollback()
     {
@@ -343,7 +343,7 @@ class DataBase
      * Si la transaccion la ha abierto en la llamada la cierra confirmando o descartando
      * según haya ido bien o haya dado algún error
      * @param string $sql
-     * @return boolean
+     * @return bool
      */
     public function exec($sql)
     {
@@ -410,7 +410,7 @@ class DataBase
     /**
      * Realiza comprobaciones extra a la tabla.
      * @param string $tableName
-     * @return boolean
+     * @return bool
      */
     public function checkTableAux($tableName)
     {
@@ -428,7 +428,7 @@ class DataBase
      * @param string $tableName
      * @param array $xmlCols
      * @param array $xmlCons
-     * @return boolean
+     * @return bool
      */
     public function generateTable($tableName, $xmlCols, $xmlCons)
     {
@@ -440,8 +440,8 @@ class DataBase
      * @param string $tableName
      * @param array $xmlCons
      * @param array $dbCons
-     * @param boolean $deleteOnly
-     * @return boolean
+     * @param bool $deleteOnly
+     * @return bool
      */
     public function compareConstraints($tableName, $xmlCons, $dbCons, $deleteOnly = false)
     {

--- a/Core/Base/DataBase.php
+++ b/Core/Base/DataBase.php
@@ -327,7 +327,7 @@ class DataBase
 
         self::$miniLog->sql($sql); /// añadimos la consulta sql al historial
         $result = self::$engine->select(self::$link, $sql);
-        if (!$result) {
+        if (empty($result)) {
             self::$miniLog->sql(self::$engine->errorMessage(self::$link));
             return [];
         }

--- a/Core/Base/DataBase.php
+++ b/Core/Base/DataBase.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,7 +40,7 @@ class DataBase {
 
     /**
      * Enlace al motor de base de datos seleccionado en la configuración
-     * @var DataBase\DatabaseEngine 
+     * @var DataBase\DatabaseEngine
      */
     private static $engine;
 
@@ -58,13 +58,13 @@ class DataBase {
 
     /**
      * Nº de selects ejecutados.
-     * @var integer 
+     * @var integer
      */
     private static $totalSelects;
 
     /**
      * Nº de transacciones ejecutadas.
-     * @var integer 
+     * @var integer
      */
     private static $totalTransactions;
 
@@ -279,7 +279,7 @@ class DataBase {
      * Ejecuta una sentencia SQL de tipo select, y devuelve un array con los resultados,
      * o false en caso de fallo.
      * @param string $sql
-     * @return mixed
+     * @return array|bool
      */
     public function select($sql) {
         return $this->selectLimit($sql, 0, 0);
@@ -293,7 +293,7 @@ class DataBase {
      * @param string $sql
      * @param integer $limit
      * @param integer $offset
-     * @return mixed
+     * @return bool|array
      */
     public function selectLimit($sql, $limit = FS_ITEM_LIMIT, $offset = 0) {
         if (!$this->connected()) {
@@ -320,7 +320,7 @@ class DataBase {
      * Para hacer selects, mejor usar select() o selecLimit().
      * Si no hay transacción abierta se inicia una, se ejecutan las consultas
      * Si la transaccion la ha abierto en la llamada la cierra confirmando o descartando
-     * según haya ido todo bien o haya dado algún error
+     * según haya ido bien o haya dado algún error
      * @param string $sql
      * @return boolean
      */
@@ -338,7 +338,7 @@ class DataBase {
                 if ($result) {
                     $result = $this->commit();
                 } else {
-                    $this->rollback();                    
+                    $this->rollback();
                 }
             }
         }
@@ -358,7 +358,7 @@ class DataBase {
 
     /**
      * Devuelve el motor de base de datos usado y la versión.
-     * @return mixed
+     * @return string|bool
      */
     public function version() {
         if (!$this->connected()) {
@@ -371,7 +371,7 @@ class DataBase {
     /**
      * Devuelve TRUE si la tabla existe, FALSE en caso contrario.
      * @param string $tableName
-     * @param mixed $list
+     * @param bool|array $list
      * @return boolean
      */
     public function tableExists($tableName, $list = FALSE) {
@@ -379,7 +379,7 @@ class DataBase {
             $list = $this->getTables();
         }
 
-        return in_array($tableName, $list);
+        return in_array($tableName, $list, FALSE);
     }
 
     /**
@@ -460,5 +460,4 @@ class DataBase {
     public function sql2int($colName) {
         return self::$engine->sql2int($colName);
     }
-
 }

--- a/Core/Base/DataBase.php
+++ b/Core/Base/DataBase.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2015-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DataBase/DataBaseUtils.php
+++ b/Core/Base/DataBase/DataBaseUtils.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,7 +32,7 @@ class DataBaseUtils {
 
     /**
      * Enlace al motor de base de datos seleccionado en la configuración
-     * @var DatabaseEngine 
+     * @var DatabaseEngine
      */
     private static $engine;
 
@@ -74,7 +74,15 @@ class DataBaseUtils {
         $db = strtolower($dbType);
         $xml = strtolower($xmlType);
 
-        $result = ((FS_CHECK_DB_TYPES !== '1') || self::$engine->compareDataTypes($db, $xml) || ($xml === 'serial') || (substr($db, 0, 4) === 'time' && substr($xml, 0, 4) === 'time'));
+        $result = (
+            (FS_CHECK_DB_TYPES !== '1') ||
+            self::$engine->compareDataTypes($db, $xml) ||
+            ($xml === 'serial') ||
+            (
+                strpos($db, 'time') === 0 &&
+                strpos($xml, 'time') === 0
+            )
+        );
 
         return $result;
     }
@@ -107,7 +115,7 @@ class DataBaseUtils {
                 $result .= self::$engine->sqlAlterModifyColumn($tableName, $xml_col);
             }
 
-            if ($column['default'] !== $xml_col['defecto']) {
+            if ($column['default'] === NULL && $xml_col['defecto'] === '') {
                 $result .= self::$engine->sqlAlterConstraintDefault($tableName, $xml_col);
             }
 
@@ -141,7 +149,7 @@ class DataBaseUtils {
 
         if (!empty($xmlCons) && !$deleteOnly && FS_FOREIGN_KEYS === '1') {
             foreach ($xmlCons as $xml_con) {
-                if (substr($xml_con['consulta'], 0, 7) === 'PRIMARY') {
+                if (strpos($xml_con['consulta'], 'PRIMARY') === 0) {
                     continue;
                 }
 
@@ -165,5 +173,4 @@ class DataBaseUtils {
     public function generateTable($tableName, $xmlCols, $xmlCons) {
         return self::$engine->sqlCreateTable($tableName, $xmlCols, $xmlCons);
     }
-
 }

--- a/Core/Base/DataBase/DataBaseUtils.php
+++ b/Core/Base/DataBase/DataBaseUtils.php
@@ -28,8 +28,8 @@ namespace FacturaScripts\Core\Base\DataBase;
  * @author Carlos García Gómez <neorazorx@gmail.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-class DataBaseUtils {
-
+class DataBaseUtils
+{
     /**
      * Enlace al motor de base de datos seleccionado en la configuración
      * @var DatabaseEngine
@@ -40,7 +40,8 @@ class DataBaseUtils {
      * Construye y prepara la clase para su uso
      * @param DatabaseEngine $engine
      */
-    public function __construct($engine) {
+    public function __construct($engine)
+    {
         self::$engine = $engine;
     }
 
@@ -51,7 +52,8 @@ class DataBaseUtils {
      * @param string $value
      * @return array
      */
-    private function searchInArray($items, $index, $value) {
+    private function searchInArray($items, $index, $value)
+    {
         $result = [];
         foreach ($items as $column) {
             if ($column[$index] === $value) {
@@ -68,9 +70,10 @@ class DataBaseUtils {
      * Devuelve TRUE si son iguales.
      * @param string $dbType
      * @param string $xmlType
-     * @return boolean
+     * @return bool
      */
-    public function compareDataTypes($dbType, $xmlType) {
+    public function compareDataTypes($dbType, $xmlType)
+    {
         $db = strtolower($dbType);
         $xml = strtolower($xmlType);
 
@@ -94,7 +97,8 @@ class DataBaseUtils {
      * @param array $dbCols
      * @return string
      */
-    public function compareColumns($tableName, $xmlCols, $dbCols) {
+    public function compareColumns($tableName, $xmlCols, $dbCols)
+    {
         $result = '';
         foreach ($xmlCols as $xml_col) {
             if (strtolower($xml_col['tipo']) === 'integer') {
@@ -115,7 +119,7 @@ class DataBaseUtils {
                 $result .= self::$engine->sqlAlterModifyColumn($tableName, $xml_col);
             }
 
-            if ($column['default'] === NULL && $xml_col['defecto'] === '') {
+            if ($column['default'] === null && $xml_col['defecto'] !== '') {
                 $result .= self::$engine->sqlAlterConstraintDefault($tableName, $xml_col);
             }
 
@@ -132,14 +136,15 @@ class DataBaseUtils {
      * @param string $tableName
      * @param array $xmlCons
      * @param array $dbCons
-     * @param boolean $deleteOnly
+     * @param bool $deleteOnly
      * @return string
      */
-    public function compareConstraints($tableName, $xmlCons, $dbCons, $deleteOnly = FALSE) {
+    public function compareConstraints($tableName, $xmlCons, $dbCons, $deleteOnly = false)
+    {
         $result = '';
 
         foreach ($dbCons as $db_con) {
-            if (strpos('PRIMARY;UNIQUE', $db_con['name']) === FALSE) {
+            if (strpos('PRIMARY;UNIQUE', $db_con['name']) === false) {
                 $column = $this->searchInArray($xmlCons, 'nombre', $db_con['name']);
                 if (empty($column)) {
                     $result .= self::$engine->sqlDropConstraint($tableName, $db_con);
@@ -170,7 +175,8 @@ class DataBaseUtils {
      * @param array $xmlCons
      * @return string
      */
-    public function generateTable($tableName, $xmlCols, $xmlCons) {
+    public function generateTable($tableName, $xmlCols, $xmlCons)
+    {
         return self::$engine->sqlCreateTable($tableName, $xmlCols, $xmlCons);
     }
 }

--- a/Core/Base/DataBase/DataBaseUtils.php
+++ b/Core/Base/DataBase/DataBaseUtils.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2015-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DataBase/DatabaseEngine.php
+++ b/Core/Base/DataBase/DatabaseEngine.php
@@ -20,14 +20,16 @@
 
 namespace FacturaScripts\Core\Base\DataBase;
 
+use mysqli;
+
 /**
  * Interface para cada uno de los motores de base de datos compatibles
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-interface DatabaseEngine {
-
+interface DatabaseEngine
+{
     /**
      * Genera el SQL para establecer las restricciones proporcionadas.
      * @param array $xmlCons
@@ -42,7 +44,8 @@ interface DatabaseEngine {
 
     /**
      * Información sobre el motor de base de datos
-     * @param mixed $link
+     * @param mysqli|resource $link
+     * @return string
      */
     public function version($link);
 
@@ -54,53 +57,54 @@ interface DatabaseEngine {
 
     /**
      * Cierra la conexión con la base de datos
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function close($link);
 
     /**
      * Último mensaje de error generado un operación con la BD
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function errorMessage($link);
 
     /**
      * Inicia una transacción sobre la conexión
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function beginTransaction($link);
 
     /**
      * Confirma las operaciones realizadas sobre la conexión
      * desde el beginTransaction
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function commit($link);
 
     /**
      * Deshace las operaciones realizadas sobre la conexión
      * desde el beginTransaction
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function rollback($link);
 
     /**
      * Indica si la conexión tiene una transacción abierta
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function inTransaction($link);
 
     /**
      * Ejecuta una sentencia de datos sobre la conexión
-     * @param mixed $link
+     * @param mysqli|resource $link
      * @param string $sql
+     * @return array
      */
     public function select($link, $sql);
 
     /**
      * Ejecuta una sentencia DDL sobre la conexión.
      * Si no hay transacción abierta crea una y la finaliza
-     * @param mixed $link
+     * @param mysqli|resource $link
      * @param string $sql
      */
     public function exec($link, $sql);
@@ -114,13 +118,13 @@ interface DatabaseEngine {
 
     /**
      * Lista de tablas existentes en la conexión
-     * @param mixed $link
+     * @param mysqli|resource $link
      */
     public function listTables($link);
 
     /**
      * Escapa la cadena indicada
-     * @param mixed $link
+     * @param mysqli|resource $link
      * @param string $str
      */
     public function escapeString($link, $str);
@@ -138,7 +142,7 @@ interface DatabaseEngine {
 
     /**
      * Comprueba la existencia de una secuencia
-     * @param mixed $link
+     * @param mysqli|resource $link
      * @param string $tableName
      * @param string $default
      * @param string $colname
@@ -147,7 +151,7 @@ interface DatabaseEngine {
 
     /**
      * Comprobación adicional a la existencia de una tabla
-     * @param mixed $link
+     * @param mysqli|resource $link
      * @param string $tableName
      * @param string $error
      */

--- a/Core/Base/DataBase/DatabaseEngine.php
+++ b/Core/Base/DataBase/DatabaseEngine.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,7 +22,7 @@ namespace FacturaScripts\Core\Base\DataBase;
 
 /**
  * Interface para cada uno de los motores de base de datos compatibles
- * 
+ *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */

--- a/Core/Base/DataBase/DatabaseEngine.php
+++ b/Core/Base/DataBase/DatabaseEngine.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2015-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DataBase/Mysql.php
+++ b/Core/Base/DataBase/Mysql.php
@@ -374,9 +374,9 @@ class Mysql implements DatabaseEngine
 
         /// ¿La tabla no usa InnoDB?
         $data = $this->select($link, 'SHOW TABLE STATUS FROM `' . FS_DB_NAME . "` LIKE '" . $tableName . "';");
-        if ($data && $data[0]['Engine'] !== 'InnoDB') {
+        if (!empty($data) && $data[0]['Engine'] !== 'InnoDB') {
             $result = $this->exec($link, 'ALTER TABLE ' . $tableName . ' ENGINE=InnoDB;');
-            if (empty($result)) {
+            if ($result) {
                 $error = 'Imposible convertir la tabla ' . $tableName . ' a InnoDB.'
                         . ' Imprescindible para FacturaScripts.';
             }

--- a/Core/Base/DataBase/Mysql.php
+++ b/Core/Base/DataBase/Mysql.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DataBase/Mysql.php
+++ b/Core/Base/DataBase/Mysql.php
@@ -334,7 +334,7 @@ class Mysql implements DatabaseEngine
     {
         $tables = [];
         $aux = $this->select($link, 'SHOW TABLES;');
-        if ($aux) {
+        if (!empty($aux)) {
             foreach ($aux as $a) {
                 $key = 'Tables_in_' . FS_DB_NAME;
                 if (isset($a[$key])) {
@@ -376,7 +376,7 @@ class Mysql implements DatabaseEngine
         $data = $this->select($link, 'SHOW TABLE STATUS FROM `' . FS_DB_NAME . "` LIKE '" . $tableName . "';");
         if ($data && $data[0]['Engine'] !== 'InnoDB') {
             $result = $this->exec($link, 'ALTER TABLE ' . $tableName . ' ENGINE=InnoDB;');
-            if (!$result) {
+            if (empty($result)) {
                 $error = 'Imposible convertir la tabla ' . $tableName . ' a InnoDB.'
                         . ' Imprescindible para FacturaScripts.';
             }

--- a/Core/Base/DataBase/Postgresql.php
+++ b/Core/Base/DataBase/Postgresql.php
@@ -20,20 +20,23 @@
 
 namespace FacturaScripts\Core\Base\DataBase;
 
+use Exception;
+
 /**
  * Clase para conectar a PostgreSQL.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-class Postgresql implements DatabaseEngine {
-
+class Postgresql implements DatabaseEngine
+{
     /**
      * Devuelve el motor de base de datos y la versión.
      * @param resource $link
      * @return string
      */
-    public function version($link) {
+    public function version($link)
+    {
         return 'POSTGRESQL ' . pg_version($link)['server'];
     }
 
@@ -42,10 +45,11 @@ class Postgresql implements DatabaseEngine {
      * @param array $colData
      * @return array
      */
-    public function columnFromData($colData) {
-        $colData['extra'] = NULL;
+    public function columnFromData($colData)
+    {
+        $colData['extra'] = null;
 
-        if ($colData['character_maximum_length'] !== NULL) {
+        if ($colData['character_maximum_length'] !== null) {
             $colData['type'] .= '(' . $colData['character_maximum_length'] . ')';
         }
 
@@ -55,18 +59,21 @@ class Postgresql implements DatabaseEngine {
     /**
      * Conecta a la base de datos.
      * @param string $error
-     * @return boolean|null
+     * @return bool|null
      */
-    public function connect(&$error) {
+    public function connect(&$error)
+    {
         if (!function_exists('pg_connect')) {
             $error = 'No tienes instalada la extensión de PHP para PostgreSQL.';
-            return NULL;
+            return null;
         }
 
-        $result = pg_connect('host=' . FS_DB_HOST . ' dbname=' . FS_DB_NAME . ' port=' . FS_DB_PORT . ' user=' . FS_DB_USER . ' password=' . FS_DB_PASS);
+        $string = 'host=' . FS_DB_HOST . ' dbname=' . FS_DB_NAME . ' port=' . FS_DB_PORT
+            . ' user=' . FS_DB_USER . ' password=' . FS_DB_PASS;
+        $result = pg_connect($string);
         if (!$result) {
             $error = pg_last_error();
-            return NULL;
+            return null;
         }
 
         $this->exec($result, 'SET DATESTYLE TO ISO, DMY;'); /// establecemos el formato de fecha para la conexión
@@ -77,9 +84,10 @@ class Postgresql implements DatabaseEngine {
     /**
      * Desconecta de la base de datos.
      * @param resource $link
-     * @return boolean
+     * @return bool
      */
-    public function close($link) {
+    public function close($link)
+    {
         return pg_close($link);
     }
 
@@ -88,34 +96,38 @@ class Postgresql implements DatabaseEngine {
      * @param resource $link
      * @return string
      */
-    public function errorMessage($link) {
+    public function errorMessage($link)
+    {
         return pg_last_error($link);
     }
 
     /**
      * Inicia una transacción SQL.
      * @param resource $link
-     * @return boolean
+     * @return bool
      */
-    public function beginTransaction($link) {
+    public function beginTransaction($link)
+    {
         return $this->exec($link, 'BEGIN TRANSACTION;');
     }
 
     /**
      * Guarda los cambios de una transacción SQL.
      * @param resource $link
-     * @return boolean
+     * @return bool
      */
-    public function commit($link) {
+    public function commit($link)
+    {
         return $this->exec($link, 'COMMIT;');
     }
 
     /**
      * Deshace los cambios de una transacción SQL.
      * @param resource $link
-     * @return boolean
+     * @return bool
      */
-    public function rollback($link) {
+    public function rollback($link)
+    {
         return $this->exec($link, 'ROLLBACK;');
     }
 
@@ -124,17 +136,18 @@ class Postgresql implements DatabaseEngine {
      * @param resource $link
      * @return bool
      */
-    public function inTransaction($link) {
+    public function inTransaction($link)
+    {
         $status = pg_transaction_status($link);
         switch ($status) {
             case PGSQL_TRANSACTION_ACTIVE:
             case PGSQL_TRANSACTION_INTRANS:
             case PGSQL_TRANSACTION_INERROR:
-                $result = TRUE;
+                $result = true;
                 break;
 
             default:
-                $result = FALSE;
+                $result = false;
                 break;
         }
         return $result;
@@ -142,14 +155,15 @@ class Postgresql implements DatabaseEngine {
 
     /**
      * Ejecuta una sentencia SQL y devuelve un array con los resultados en
-     * caso de $selectRows = TRUE, o false en caso de fallo.
+     * caso de $selectRows = true, o array vacío en caso de fallo.
      * @param resource $link
      * @param string $sql
      * @param bool $selectRows
-     * @return array|bool
+     * @return array
      */
-    private function runSql($link, $sql, $selectRows = TRUE) {
-        $result = FALSE;
+    private function runSql($link, $sql, $selectRows = true)
+    {
+        $result = [];
         try {
             $aux = pg_query($link, $sql);
             if ($aux) {
@@ -158,8 +172,8 @@ class Postgresql implements DatabaseEngine {
                 }
                 pg_free_result($aux);
             }
-        } catch (\Exception $e) {
-            $result = FALSE;
+        } catch (Exception $e) {
+            $result = [];
         }
 
         return $result;
@@ -169,9 +183,10 @@ class Postgresql implements DatabaseEngine {
      * Ejecuta una sentencia SQL de tipo select
      * @param resource $link
      * @param string $sql
-     * @return resource|FALSE
+     * @return array
      */
-    public function select($link, $sql) {
+    public function select($link, $sql)
+    {
         return $this->runSql($link, $sql);
     }
 
@@ -180,10 +195,11 @@ class Postgresql implements DatabaseEngine {
      * (inserts, updates o deletes).
      * @param resource $link
      * @param string $sql
-     * @return boolean
+     * @return bool
      */
-    public function exec($link, $sql) {
-        return $this->runSql($link, $sql, FALSE);
+    public function exec($link, $sql)
+    {
+        return (bool)$this->runSql($link, $sql, false);
     }
 
     /**
@@ -192,7 +208,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $str
      * @return string
      */
-    public function escapeString($link, $str) {
+    public function escapeString($link, $str)
+    {
         return pg_escape_string($link, $str);
     }
 
@@ -200,7 +217,8 @@ class Postgresql implements DatabaseEngine {
      * Devuelve el estilo de fecha del motor de base de datos.
      * @return string
      */
-    public function dateStyle() {
+    public function dateStyle()
+    {
         return 'd-m-Y';
     }
 
@@ -210,7 +228,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $colName
      * @return string
      */
-    public function sql2int($colName) {
+    public function sql2int($colName)
+    {
         return 'CAST(' . $colName . ' as INTEGER)';
     }
 
@@ -218,9 +237,10 @@ class Postgresql implements DatabaseEngine {
      * Compara los tipos de datos de una columna. Devuelve TRUE si son iguales.
      * @param string $dbType
      * @param string $xmlType
-     * @return boolean
+     * @return bool
      */
-    public function compareDataTypes($dbType, $xmlType) {
+    public function compareDataTypes($dbType, $xmlType)
+    {
         return ($dbType === $xmlType);
     }
 
@@ -229,7 +249,8 @@ class Postgresql implements DatabaseEngine {
      * @param resource $link
      * @return array
      */
-    public function listTables($link) {
+    public function listTables($link)
+    {
         $tables = [];
         $sql = 'SELECT tablename'
                 . ' FROM pg_catalog.pg_tables'
@@ -256,7 +277,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $default
      * @param string $colname
      */
-    public function checkSequence($link, $tableName, $default, $colname) {
+    public function checkSequence($link, $tableName, $default, $colname)
+    {
         $aux = explode("'", $default);
         if (count($aux) === 3) {
             $data = $this->select($link, $this->sqlSequenceExists($aux[1]));
@@ -269,13 +291,14 @@ class Postgresql implements DatabaseEngine {
 
     /**
      * Realiza comprobaciones extra a la tabla.
-     * @param mixed $link
+     * @param resource $link
      * @param string $tableName
      * @param string $error
      * @return bool
      */
-    public function checkTableAux($link, $tableName, &$error) {
-        return TRUE;
+    public function checkTableAux($link, $tableName, &$error)
+    {
+        return true;
     }
 
     /**
@@ -283,7 +306,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $xmlCons
      * @return string
      */
-    public function generateTableConstraints($xmlCons) {
+    public function generateTableConstraints($xmlCons)
+    {
         $sql = '';
 
         foreach ($xmlCons as $res) {
@@ -307,7 +331,8 @@ class Postgresql implements DatabaseEngine {
      * en la base de datos.
      * @return string
      */
-    public function sqlLastValue() {
+    public function sqlLastValue()
+    {
         return 'SELECT lastval() as num;';
     }
 
@@ -317,7 +342,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $tableName
      * @return string
      */
-    public function sqlColumns($tableName) {
+    public function sqlColumns($tableName)
+    {
         $sql = 'SELECT column_name as name, data_type as type,'
                 . 'character_maximum_length, column_default as default,'
                 . 'is_nullable'
@@ -335,7 +361,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $tableName
      * @return string
      */
-    public function sqlConstraints($tableName) {
+    public function sqlConstraints($tableName)
+    {
         $sql = 'SELECT tc.constraint_type as type, tc.constraint_name as name'
                 . ' FROM information_schema.table_constraints AS tc'
                 . " WHERE tc.table_name = '" . $tableName . "'"
@@ -350,7 +377,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $tableName
      * @return string
      */
-    public function sqlConstraintsExtended($tableName) {
+    public function sqlConstraintsExtended($tableName)
+    {
         $sql = 'SELECT tc.constraint_type as type, tc.constraint_name as name,'
                 . 'kcu.column_name,'
                 . 'ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name,'
@@ -382,7 +410,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $tableName
      * @return string
      */
-    public function sqlIndexes($tableName) {
+    public function sqlIndexes($tableName)
+    {
         return "SELECT indexname as Key_name FROM pg_indexes WHERE tablename = '" . $tableName . "';";
     }
 
@@ -393,7 +422,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $constraints
      * @return string
      */
-    public function sqlCreateTable($tableName, $columns, $constraints) {
+    public function sqlCreateTable($tableName, $columns, $constraints)
+    {
         $serials = ['serial', 'bigserial'];
         $fields = '';
         foreach ($columns as $col) {
@@ -403,7 +433,7 @@ class Postgresql implements DatabaseEngine {
                 $fields .= ' NOT NULL';
             }
 
-            if (in_array($col['tipo'], $serials, FALSE)) {
+            if (in_array($col['tipo'], $serials, false)) {
                 continue;
             }
 
@@ -423,7 +453,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $colData
      * @return string
      */
-    public function sqlAlterAddColumn($tableName, $colData) {
+    public function sqlAlterAddColumn($tableName, $colData)
+    {
         $sql = 'ALTER TABLE ' . $tableName
                 . ' ADD COLUMN ' . $colData['nombre'] . ' ' . $colData['tipo'];
 
@@ -444,7 +475,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $colData
      * @return string
      */
-    public function sqlAlterModifyColumn($tableName, $colData) {
+    public function sqlAlterModifyColumn($tableName, $colData)
+    {
         $sql = 'ALTER TABLE ' . $tableName
                 . ' ALTER COLUMN ' . $colData['nombre'] . ' TYPE ' . $colData['tipo'];
         return $sql . ';';
@@ -456,7 +488,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $colData
      * @return string
      */
-    public function sqlAlterConstraintDefault($tableName, $colData) {
+    public function sqlAlterConstraintDefault($tableName, $colData)
+    {
         $action = ($colData['defecto'] !== '') ? ' SET DEFAULT ' . $colData['defecto'] : ' DROP DEFAULT';
 
         return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['nombre'] . $action . ';';
@@ -468,7 +501,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $colData
      * @return string
      */
-    public function sqlAlterConstraintNull($tableName, $colData) {
+    public function sqlAlterConstraintNull($tableName, $colData)
+    {
         $action = ($colData['nulo'] === 'YES') ? ' DROP ' : ' SET ';
         return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['nombre'] . $action . 'NOT NULL;';
     }
@@ -479,7 +513,8 @@ class Postgresql implements DatabaseEngine {
      * @param array $colData
      * @return string
      */
-    public function sqlDropConstraint($tableName, $colData) {
+    public function sqlDropConstraint($tableName, $colData)
+    {
         return 'ALTER TABLE ' . $tableName . ' DROP CONSTRAINT ' . $colData['name'] . ';';
     }
 
@@ -490,7 +525,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $sql
      * @return string
      */
-    public function sqlAddConstraint($tableName, $constraintName, $sql) {
+    public function sqlAddConstraint($tableName, $constraintName, $sql)
+    {
         return 'ALTER TABLE ' . $tableName . ' ADD CONSTRAINT ' . $constraintName . ' ' . $sql . ';';
     }
 
@@ -499,7 +535,8 @@ class Postgresql implements DatabaseEngine {
      * @param string $seqName
      * @return string
      */
-    public function sqlSequenceExists($seqName) {
+    public function sqlSequenceExists($seqName)
+    {
         return "SELECT * FROM pg_class where relname = '" . $seqName . "';";
     }
 }

--- a/Core/Base/DataBase/Postgresql.php
+++ b/Core/Base/DataBase/Postgresql.php
@@ -258,7 +258,7 @@ class Postgresql implements DatabaseEngine
                 . ' ORDER BY tablename ASC;';
 
         $aux = $this->select($link, $sql);
-        if ($aux) {
+        if (!empty($aux)) {
             foreach ($aux as $a) {
                 $tables[] = $a['tablename'];
             }
@@ -282,7 +282,7 @@ class Postgresql implements DatabaseEngine
         $aux = explode("'", $default);
         if (count($aux) === 3) {
             $data = $this->select($link, $this->sqlSequenceExists($aux[1]));
-            if (!$data) {             /// ¿Existe esa secuencia?
+            if (empty($data)) {             /// ¿Existe esa secuencia?
                 $data = $this->select($link, 'SELECT MAX(' . $colname . ')+1 as num FROM ' . $tableName . ';');
                 $this->exec($link, 'CREATE SEQUENCE ' . $aux[1] . ' START ' . $data[0]['num'] . ';');
             }

--- a/Core/Base/DataBase/Postgresql.php
+++ b/Core/Base/DataBase/Postgresql.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DataBase/Postgresql.php
+++ b/Core/Base/DataBase/Postgresql.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,7 +22,7 @@ namespace FacturaScripts\Core\Base\DataBase;
 
 /**
  * Clase para conectar a PostgreSQL.
- * 
+ *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
@@ -69,7 +69,7 @@ class Postgresql implements DatabaseEngine {
             return NULL;
         }
 
-        $this->exec($result, "SET DATESTYLE TO ISO, DMY;"); /// establecemos el formato de fecha para la conexión
+        $this->exec($result, 'SET DATESTYLE TO ISO, DMY;'); /// establecemos el formato de fecha para la conexión
 
         return $result;
     }
@@ -122,6 +122,7 @@ class Postgresql implements DatabaseEngine {
     /**
      * Indica si la conexión está en transacción
      * @param resource $link
+     * @return bool
      */
     public function inTransaction($link) {
         $status = pg_transaction_status($link);
@@ -144,8 +145,8 @@ class Postgresql implements DatabaseEngine {
      * caso de $selectRows = TRUE, o false en caso de fallo.
      * @param resource $link
      * @param string $sql
-     * @param type $selectRows
-     * @return resource|FALSE
+     * @param bool $selectRows
+     * @return array|bool
      */
     private function runSql($link, $sql, $selectRows = TRUE) {
         $result = FALSE;
@@ -161,9 +162,9 @@ class Postgresql implements DatabaseEngine {
             $result = FALSE;
         }
 
-        return $result;        
+        return $result;
     }
-    
+
     /**
      * Ejecuta una sentencia SQL de tipo select
      * @param resource $link
@@ -175,7 +176,7 @@ class Postgresql implements DatabaseEngine {
     }
 
     /**
-     * Ejecuta sentencias SQL sobre la base de datos 
+     * Ejecuta sentencias SQL sobre la base de datos
      * (inserts, updates o deletes).
      * @param resource $link
      * @param string $sql
@@ -226,14 +227,14 @@ class Postgresql implements DatabaseEngine {
     /**
      * Devuelve un array con los nombres de las tablas de la base de datos.
      * @param resource $link
-     * @return string
+     * @return array
      */
     public function listTables($link) {
         $tables = [];
-        $sql = "SELECT tablename"
-                . " FROM pg_catalog.pg_tables"
+        $sql = 'SELECT tablename'
+                . ' FROM pg_catalog.pg_tables'
                 . " WHERE schemaname NOT IN ('pg_catalog','information_schema')"
-                . " ORDER BY tablename ASC;";
+                . ' ORDER BY tablename ASC;';
 
         $aux = $this->select($link, $sql);
         if ($aux) {
@@ -260,16 +261,18 @@ class Postgresql implements DatabaseEngine {
         if (count($aux) === 3) {
             $data = $this->select($link, $this->sqlSequenceExists($aux[1]));
             if (!$data) {             /// ¿Existe esa secuencia?
-                $data = $this->select($link, "SELECT MAX(" . $colname . ")+1 as num FROM " . $tableName . ";");
-                $this->exec($link, "CREATE SEQUENCE " . $aux[1] . " START " . $data[0]['num'] . ";");
+                $data = $this->select($link, 'SELECT MAX(' . $colname . ')+1 as num FROM ' . $tableName . ';');
+                $this->exec($link, 'CREATE SEQUENCE ' . $aux[1] . ' START ' . $data[0]['num'] . ';');
             }
         }
     }
 
     /**
      * Realiza comprobaciones extra a la tabla.
+     * @param mixed $link
      * @param string $tableName
-     * @return boolean
+     * @param string $error
+     * @return bool
      */
     public function checkTableAux($link, $tableName, &$error) {
         return TRUE;
@@ -285,12 +288,12 @@ class Postgresql implements DatabaseEngine {
 
         foreach ($xmlCons as $res) {
             $value = strtolower($res['consulta']);
-            if (strstr($value, 'primary key')) {
+            if (false !== strpos($value, 'primary key')) {
                 $sql .= ', ' . $res['consulta'];
                 continue;
             }
 
-            if (FS_FOREIGN_KEYS === '1' || substr($res['consulta'], 0, 11) !== 'FOREIGN KEY') {
+            if (FS_FOREIGN_KEYS === '1' || 0 !== strpos($res['consulta'], 'FOREIGN KEY')) {
                 $sql .= ', CONSTRAINT ' . $res['nombre'] . ' ' . $res['consulta'];
             }
         }
@@ -300,7 +303,7 @@ class Postgresql implements DatabaseEngine {
 
     /**
      * Devuleve el SQL para averiguar
-     * el último ID asignado al hacer un INSERT 
+     * el último ID asignado al hacer un INSERT
      * en la base de datos.
      * @return string
      */
@@ -309,19 +312,19 @@ class Postgresql implements DatabaseEngine {
     }
 
     /**
-     * Devuelve el SQL para averiguar 
+     * Devuelve el SQL para averiguar
      * la lista de las columnas de una tabla.
      * @param string $tableName
      * @return string
      */
     public function sqlColumns($tableName) {
-        $sql = "SELECT column_name as name, data_type as type,"
-                . "character_maximum_length, column_default as default,"
-                . "is_nullable"
-                . " FROM information_schema.columns"
+        $sql = 'SELECT column_name as name, data_type as type,'
+                . 'character_maximum_length, column_default as default,'
+                . 'is_nullable'
+                . ' FROM information_schema.columns'
                 . " WHERE table_catalog = '" . FS_DB_NAME . "'"
                 . " AND table_name = '" . $tableName . "'"
-                . " ORDER BY 1 ASC;";
+                . ' ORDER BY 1 ASC;';
 
         return $sql;
     }
@@ -333,11 +336,11 @@ class Postgresql implements DatabaseEngine {
      * @return string
      */
     public function sqlConstraints($tableName) {
-        $sql = "SELECT tc.constraint_type as type, tc.constraint_name as name"
-                . " FROM information_schema.table_constraints AS tc"
+        $sql = 'SELECT tc.constraint_type as type, tc.constraint_name as name'
+                . ' FROM information_schema.table_constraints AS tc'
                 . " WHERE tc.table_name = '" . $tableName . "'"
                 . " AND tc.constraint_type IN ('PRIMARY KEY','FOREIGN KEY','UNIQUE')"
-                . " ORDER BY 1 DESC, 2 ASC;";
+                . ' ORDER BY 1 DESC, 2 ASC;';
         return $sql;
     }
 
@@ -348,27 +351,27 @@ class Postgresql implements DatabaseEngine {
      * @return string
      */
     public function sqlConstraintsExtended($tableName) {
-        $sql = "SELECT tc.constraint_type as type, tc.constraint_name as name,"
-                . "kcu.column_name,"
-                . "ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name,"
-                . "rc.update_rule AS on_update, rc.delete_rule AS on_delete"
-                . " FROM information_schema.table_constraints AS tc"
-                . " LEFT JOIN information_schema.key_column_usage AS kcu"
-                . " ON kcu.constraint_schema = tc.constraint_schema"
-                . " AND kcu.constraint_catalog = tc.constraint_catalog"
-                . " AND kcu.constraint_name = tc.constraint_name"
-                . " LEFT JOIN information_schema.constraint_column_usage AS ccu"
-                . " ON ccu.constraint_schema = tc.constraint_schema"
-                . " AND ccu.constraint_catalog = tc.constraint_catalog"
-                . " AND ccu.constraint_name = tc.constraint_name"
-                . " AND ccu.column_name = kcu.column_name"
-                . " LEFT JOIN information_schema.referential_constraints rc"
-                . " ON rc.constraint_schema = tc.constraint_schema"
-                . " AND rc.constraint_catalog = tc.constraint_catalog"
-                . " AND rc.constraint_name = tc.constraint_name"
+        $sql = 'SELECT tc.constraint_type as type, tc.constraint_name as name,'
+                . 'kcu.column_name,'
+                . 'ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name,'
+                . 'rc.update_rule AS on_update, rc.delete_rule AS on_delete'
+                . ' FROM information_schema.table_constraints AS tc'
+                . ' LEFT JOIN information_schema.key_column_usage AS kcu'
+                . ' ON kcu.constraint_schema = tc.constraint_schema'
+                . ' AND kcu.constraint_catalog = tc.constraint_catalog'
+                . ' AND kcu.constraint_name = tc.constraint_name'
+                . ' LEFT JOIN information_schema.constraint_column_usage AS ccu'
+                . ' ON ccu.constraint_schema = tc.constraint_schema'
+                . ' AND ccu.constraint_catalog = tc.constraint_catalog'
+                . ' AND ccu.constraint_name = tc.constraint_name'
+                . ' AND ccu.column_name = kcu.column_name'
+                . ' LEFT JOIN information_schema.referential_constraints rc'
+                . ' ON rc.constraint_schema = tc.constraint_schema'
+                . ' AND rc.constraint_catalog = tc.constraint_catalog'
+                . ' AND rc.constraint_name = tc.constraint_name'
                 . " WHERE tc.table_name = '" . $tableName . "'"
                 . " AND tc.constraint_type IN ('PRIMARY KEY','FOREIGN KEY','UNIQUE')"
-                . " ORDER BY 1 DESC, 2 ASC;";
+                . ' ORDER BY 1 DESC, 2 ASC;';
 
         return $sql;
     }
@@ -387,6 +390,7 @@ class Postgresql implements DatabaseEngine {
      * Devuelve la sentencia SQL necesaria para crear una tabla con la estructura proporcionada.
      * @param string $tableName
      * @param array $columns
+     * @param array $constraints
      * @return string
      */
     public function sqlCreateTable($tableName, $columns, $constraints) {
@@ -399,11 +403,11 @@ class Postgresql implements DatabaseEngine {
                 $fields .= ' NOT NULL';
             }
 
-            if (in_array($col['tipo'], $serials)) {
+            if (in_array($col['tipo'], $serials, FALSE)) {
                 continue;
             }
 
-            if ($col['defecto'] !== NULL) {
+            if ($col['defecto'] !== '') {
                 $fields .= ' DEFAULT ' . $col['defecto'];
             }
         }
@@ -421,9 +425,9 @@ class Postgresql implements DatabaseEngine {
      */
     public function sqlAlterAddColumn($tableName, $colData) {
         $sql = 'ALTER TABLE ' . $tableName
-                . ' ADD COLUMN ' . $colData['nombre'] . " " . $colData['tipo'];
+                . ' ADD COLUMN ' . $colData['nombre'] . ' ' . $colData['tipo'];
 
-        if ($colData['defecto'] !== NULL) {
+        if ($colData['defecto'] !== '') {
             $sql .= ' DEFAULT ' . $colData['defecto'];
         }
 
@@ -443,7 +447,7 @@ class Postgresql implements DatabaseEngine {
     public function sqlAlterModifyColumn($tableName, $colData) {
         $sql = 'ALTER TABLE ' . $tableName
                 . ' ALTER COLUMN ' . $colData['nombre'] . ' TYPE ' . $colData['tipo'];
-        return $sql . ";";
+        return $sql . ';';
     }
 
     /**
@@ -453,9 +457,9 @@ class Postgresql implements DatabaseEngine {
      * @return string
      */
     public function sqlAlterConstraintDefault($tableName, $colData) {
-        $action = ($colData['defecto'] !== NULL) ? " SET DEFAULT " . $colData['defecto'] : " DROP DEFAULT";
+        $action = ($colData['defecto'] !== '') ? ' SET DEFAULT ' . $colData['defecto'] : ' DROP DEFAULT';
 
-        return "ALTER TABLE " . $tableName . " ALTER COLUMN " . $colData['nombre'] . $action;
+        return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['nombre'] . $action . ';';
     }
 
     /**
@@ -465,8 +469,8 @@ class Postgresql implements DatabaseEngine {
      * @return string
      */
     public function sqlAlterConstraintNull($tableName, $colData) {
-        $action = ($colData['nulo'] === 'YES') ? " DROP " : " SET ";
-        return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['nombre'] . $action . "NOT NULL;";
+        $action = ($colData['nulo'] === 'YES') ? ' DROP ' : ' SET ';
+        return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['nombre'] . $action . 'NOT NULL;';
     }
 
     /**
@@ -476,17 +480,18 @@ class Postgresql implements DatabaseEngine {
      * @return string
      */
     public function sqlDropConstraint($tableName, $colData) {
-        return "ALTER TABLE " . $tableName . " DROP CONSTRAINT " . $colData['name'] . ";";
+        return 'ALTER TABLE ' . $tableName . ' DROP CONSTRAINT ' . $colData['name'] . ';';
     }
 
     /**
      * Sentencia SQL para añadir una constraint a una tabla
      * @param string $tableName
      * @param string $constraintName
+     * @param string $sql
      * @return string
      */
     public function sqlAddConstraint($tableName, $constraintName, $sql) {
-        return "ALTER TABLE " . $tableName . " ADD CONSTRAINT " . $constraintName . " " . $sql . ";";
+        return 'ALTER TABLE ' . $tableName . ' ADD CONSTRAINT ' . $constraintName . ' ' . $sql . ';';
     }
 
     /**
@@ -497,5 +502,4 @@ class Postgresql implements DatabaseEngine {
     public function sqlSequenceExists($seqName) {
         return "SELECT * FROM pg_class where relname = '" . $seqName . "';";
     }
-
 }

--- a/Core/Base/DefaultItems.php
+++ b/Core/Base/DefaultItems.php
@@ -20,7 +20,14 @@
 
 namespace FacturaScripts\Core\Base;
 
-use FacturaScripts\Core\Model;
+use FacturaScripts\Core\Model\Almacen;
+use FacturaScripts\Core\Model\Divisa;
+use FacturaScripts\Core\Model\Ejercicio;
+use FacturaScripts\Core\Model\FormaPago;
+use FacturaScripts\Core\Model\Impuesto;
+use FacturaScripts\Core\Model\Page;
+use FacturaScripts\Core\Model\Pais;
+use FacturaScripts\Core\Model\Serie;
 
 /**
  * Esta clase sólo sirve para que los modelos sepan que elementos son los
@@ -33,61 +40,61 @@ class DefaultItems
 {
     /**
      * Página por defecto
-     * @var Model\Page
+     * @var Page
      */
     private static $defaultPage;
 
     /**
      * Página que se está mostrando
-     * @var Model\Page
+     * @var Page
      */
     private static $showingPage;
 
     /**
      * Código de ejercicio
-     * @var Model\Ejercicio
+     * @var Ejercicio
      */
     private static $codEjercicio;
 
     /**
      * Código de almacén
-     * @var Model\Almacen
+     * @var Almacen
      */
     private static $codAlmacen;
 
     /**
      * Código de divisa
-     * @var Model\Divisa
+     * @var Divisa
      */
     private static $codDivisa;
 
     /**
      * Código de forma de pago
-     * @var Model\FormaPago
+     * @var FormaPago
      */
     private static $codPago;
 
     /**
      * Código de impuesto
-     * @var Model\Impuesto
+     * @var Impuesto
      */
     private static $codImpuesto;
 
     /**
      * Código de país
-     * @var Model\Pais
+     * @var Pais
      */
     private static $codPais;
 
     /**
      * Código de serie
-     * @var Model\Serie
+     * @var Serie
      */
     private static $codSerie;
 
     /**
      * Devuelve el código de ejercicio por defecto
-     * @return Model\Ejercicio|null
+     * @return Ejercicio|null
      */
     public function codEjercicio()
     {
@@ -105,7 +112,7 @@ class DefaultItems
 
     /**
      * Devuelve el código de almacén por defecto
-     * @return Model\Almacen|null
+     * @return Almacen|null
      */
     public function codAlmacen()
     {
@@ -123,7 +130,7 @@ class DefaultItems
 
     /**
      * Devuelve el código de la divisa por defecto
-     * @return Model\Divisa|null
+     * @return Divisa|null
      */
     public function codDivisa()
     {
@@ -141,7 +148,7 @@ class DefaultItems
 
     /**
      * Devuelve el código de la forma de pago por defecto
-     * @return Model\FormaPago|null
+     * @return FormaPago|null
      */
     public function codPago()
     {
@@ -159,7 +166,7 @@ class DefaultItems
 
     /**
      * Devuelve el código del impuesto por defecto
-     * @return Model\Impuesto|null
+     * @return Impuesto|null
      */
     public function codImpuesto()
     {
@@ -177,7 +184,7 @@ class DefaultItems
 
     /**
      * Devuelve el código de país por defecto
-     * @return Model\Pais|null
+     * @return Pais|null
      */
     public function codPais()
     {
@@ -195,7 +202,7 @@ class DefaultItems
 
     /**
      * Devuelve el código de la serie por defecto
-     * @return Model\Serie|null
+     * @return Serie|null
      */
     public function codSerie()
     {
@@ -213,7 +220,7 @@ class DefaultItems
 
     /**
      * Devuelve la página por defecto
-     * @return Model\Page|null
+     * @return Page|null
      */
     public function defaultPage()
     {
@@ -231,7 +238,7 @@ class DefaultItems
 
     /**
      * Devuelve la página que se está mostrando
-     * @return Model\Page|null
+     * @return Page|null
      */
     public function showingPage()
     {

--- a/Core/Base/DefaultItems.php
+++ b/Core/Base/DefaultItems.php
@@ -36,8 +36,8 @@ use FacturaScripts\Core\Model\Serie;
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class DefaultItems {
-
+class DefaultItems
+{
     /**
      * Página por defecto
      * @var Page
@@ -87,17 +87,18 @@ class DefaultItems {
     /**
      * DefaultItems constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         if (self::$defaultPage === null) {
-            self::$defaultPage = NULL;
-            self::$showingPage = NULL;
-            self::$codEjercicio = NULL;
-            self::$codAlmacen = NULL;
-            self::$codDivisa = NULL;
-            self::$codPago = NULL;
-            self::$codImpuesto = NULL;
-            self::$codPais = NULL;
-            self::$codSerie = NULL;
+            self::$defaultPage = null;
+            self::$showingPage = null;
+            self::$codEjercicio = null;
+            self::$codAlmacen = null;
+            self::$codDivisa = null;
+            self::$codPago = null;
+            self::$codImpuesto = null;
+            self::$codPais = null;
+            self::$codSerie = null;
         }
     }
 
@@ -105,7 +106,8 @@ class DefaultItems {
      * Devuelve el código de ejercicio por defecto
      * @return Ejercicio|null
      */
-    public function codEjercicio() {
+    public function codEjercicio()
+    {
         return self::$codEjercicio;
     }
 
@@ -113,7 +115,8 @@ class DefaultItems {
      * Asigna el código de ejercicio por defecto
      * @param $cod
      */
-    public function setCodEjercicio($cod) {
+    public function setCodEjercicio($cod)
+    {
         self::$codEjercicio = $cod;
     }
 
@@ -121,7 +124,8 @@ class DefaultItems {
      * Devuelve el código de almacén por defecto
      * @return Almacen|null
      */
-    public function codAlmacen() {
+    public function codAlmacen()
+    {
         return self::$codAlmacen;
     }
 
@@ -129,7 +133,8 @@ class DefaultItems {
      * Asigna el código de almacén por defecto
      * @param $cod
      */
-    public function setCodAlmacen($cod) {
+    public function setCodAlmacen($cod)
+    {
         self::$codAlmacen = $cod;
     }
 
@@ -137,7 +142,8 @@ class DefaultItems {
      * Devuelve el código de la divisa por defecto
      * @return Divisa|null
      */
-    public function codDivisa() {
+    public function codDivisa()
+    {
         return self::$codDivisa;
     }
 
@@ -145,7 +151,8 @@ class DefaultItems {
      * Asigna el código de la divisa por defecto
      * @param $cod
      */
-    public function setCodDivisa($cod) {
+    public function setCodDivisa($cod)
+    {
         self::$codDivisa = $cod;
     }
 
@@ -153,7 +160,8 @@ class DefaultItems {
      * Devuelve el código de la forma de pago por defecto
      * @return FormaPago|null
      */
-    public function codPago() {
+    public function codPago()
+    {
         return self::$codPago;
     }
 
@@ -161,7 +169,8 @@ class DefaultItems {
      * Asigna el código de la forma de pago por defecto
      * @param $cod
      */
-    public function setCodPago($cod) {
+    public function setCodPago($cod)
+    {
         self::$codPago = $cod;
     }
 
@@ -169,7 +178,8 @@ class DefaultItems {
      * Devuelve el código del impuesto por defecto
      * @return Impuesto|null
      */
-    public function codImpuesto() {
+    public function codImpuesto()
+    {
         return self::$codImpuesto;
     }
 
@@ -177,7 +187,8 @@ class DefaultItems {
      * Asigna el código del impuesto por defecto
      * @param $cod
      */
-    public function setCodImpuesto($cod) {
+    public function setCodImpuesto($cod)
+    {
         self::$codImpuesto = $cod;
     }
 
@@ -185,7 +196,8 @@ class DefaultItems {
      * Devuelve el código de país por defecto
      * @return Pais|null
      */
-    public function codPais() {
+    public function codPais()
+    {
         return self::$codPais;
     }
 
@@ -193,7 +205,8 @@ class DefaultItems {
      * Asigna el código de país por defecto
      * @param $cod
      */
-    public function setCodPais($cod) {
+    public function setCodPais($cod)
+    {
         self::$codPais = $cod;
     }
 
@@ -201,7 +214,8 @@ class DefaultItems {
      * Devuelve el código de la serie por defecto
      * @return Serie|null
      */
-    public function codSerie() {
+    public function codSerie()
+    {
         return self::$codSerie;
     }
 
@@ -209,7 +223,8 @@ class DefaultItems {
      * Asigna el código de la serie por defecto
      * @param $cod
      */
-    public function setCodSerie($cod) {
+    public function setCodSerie($cod)
+    {
         self::$codSerie = $cod;
     }
 
@@ -217,7 +232,8 @@ class DefaultItems {
      * Devuelve la página por defecto
      * @return Page|null
      */
-    public function defaultPage() {
+    public function defaultPage()
+    {
         return self::$defaultPage;
     }
 
@@ -225,7 +241,8 @@ class DefaultItems {
      * Asigna la página por defecto
      * @param $name
      */
-    public function setDefaultPage($name) {
+    public function setDefaultPage($name)
+    {
         self::$defaultPage = $name;
     }
 
@@ -233,7 +250,8 @@ class DefaultItems {
      * Devuelve la página que se está mostrando
      * @return Page|null
      */
-    public function showingPage() {
+    public function showingPage()
+    {
         return self::$showingPage;
     }
 
@@ -241,7 +259,8 @@ class DefaultItems {
      * Asigna la página que se está mostrando
      * @param $name
      */
-    public function setShowingPage($name) {
+    public function setShowingPage($name)
+    {
         self::$showingPage = $name;
     }
 }

--- a/Core/Base/DefaultItems.php
+++ b/Core/Base/DefaultItems.php
@@ -43,41 +43,49 @@ class DefaultItems
      * @var Page
      */
     private static $defaultPage;
+
     /**
      * Página que se está mostrando
      * @var Page
      */
     private static $showingPage;
+
     /**
      * Código de ejercicio
      * @var Ejercicio
      */
     private static $codEjercicio;
+
     /**
      * Código de almacén
      * @var Almacen
      */
     private static $codAlmacen;
+
     /**
      * Código de divisa
      * @var Divisa
      */
     private static $codDivisa;
+
     /**
      * Código de forma de pago
      * @var FormaPago
      */
     private static $codPago;
+
     /**
      * Código de impuesto
      * @var Impuesto
      */
     private static $codImpuesto;
+
     /**
      * Código de país
      * @var Pais
      */
     private static $codPais;
+
     /**
      * Código de serie
      * @var Serie

--- a/Core/Base/DefaultItems.php
+++ b/Core/Base/DefaultItems.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2016  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/DefaultItems.php
+++ b/Core/Base/DefaultItems.php
@@ -13,34 +13,82 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace FacturaScripts\Core\Base;
 
+use FacturaScripts\Core\Model\Almacen;
+use FacturaScripts\Core\Model\Divisa;
+use FacturaScripts\Core\Model\Ejercicio;
+use FacturaScripts\Core\Model\FormaPago;
+use FacturaScripts\Core\Model\Impuesto;
+use FacturaScripts\Core\Model\Page;
+use FacturaScripts\Core\Model\Pais;
+use FacturaScripts\Core\Model\Serie;
+
 /**
  * Esta clase sólo sirve para que los modelos sepan que elementos son los
  * predeterminados para la sesión. Pero para guardar los valores hay que usar
  * las funciones fs_controller::save_lo_que_sea()
- * 
+ *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
 class DefaultItems {
 
+    /**
+     * Página por defecto
+     * @var Page
+     */
     private static $defaultPage;
+    /**
+     * Página que se está mostrando
+     * @var Page
+     */
     private static $showingPage;
+    /**
+     * Código de ejercicio
+     * @var Ejercicio
+     */
     private static $codEjercicio;
+    /**
+     * Código de almacén
+     * @var Almacen
+     */
     private static $codAlmacen;
+    /**
+     * Código de divisa
+     * @var Divisa
+     */
     private static $codDivisa;
+    /**
+     * Código de forma de pago
+     * @var FormaPago
+     */
     private static $codPago;
+    /**
+     * Código de impuesto
+     * @var Impuesto
+     */
     private static $codImpuesto;
+    /**
+     * Código de país
+     * @var Pais
+     */
     private static $codPais;
+    /**
+     * Código de serie
+     * @var Serie
+     */
     private static $codSerie;
 
+    /**
+     * DefaultItems constructor.
+     */
     public function __construct() {
-        if (!isset(self::$defaultPage)) {
+        if (self::$defaultPage === null) {
             self::$defaultPage = NULL;
             self::$showingPage = NULL;
             self::$codEjercicio = NULL;
@@ -53,76 +101,147 @@ class DefaultItems {
         }
     }
 
+    /**
+     * Devuelve el código de ejercicio por defecto
+     * @return Ejercicio|null
+     */
     public function codEjercicio() {
         return self::$codEjercicio;
     }
 
+    /**
+     * Asigna el código de ejercicio por defecto
+     * @param $cod
+     */
     public function setCodEjercicio($cod) {
         self::$codEjercicio = $cod;
     }
 
+    /**
+     * Devuelve el código de almacén por defecto
+     * @return Almacen|null
+     */
     public function codAlmacen() {
         return self::$codAlmacen;
     }
 
+    /**
+     * Asigna el código de almacén por defecto
+     * @param $cod
+     */
     public function setCodAlmacen($cod) {
         self::$codAlmacen = $cod;
     }
 
+    /**
+     * Devuelve el código de la divisa por defecto
+     * @return Divisa|null
+     */
     public function codDivisa() {
         return self::$codDivisa;
     }
 
+    /**
+     * Asigna el código de la divisa por defecto
+     * @param $cod
+     */
     public function setCodDivisa($cod) {
         self::$codDivisa = $cod;
     }
 
+    /**
+     * Devuelve el código de la forma de pago por defecto
+     * @return FormaPago|null
+     */
     public function codPago() {
         return self::$codPago;
     }
 
+    /**
+     * Asigna el código de la forma de pago por defecto
+     * @param $cod
+     */
     public function setCodPago($cod) {
         self::$codPago = $cod;
     }
 
+    /**
+     * Devuelve el código del impuesto por defecto
+     * @return Impuesto|null
+     */
     public function codImpuesto() {
         return self::$codImpuesto;
     }
 
+    /**
+     * Asigna el código del impuesto por defecto
+     * @param $cod
+     */
     public function setCodImpuesto($cod) {
         self::$codImpuesto = $cod;
     }
 
+    /**
+     * Devuelve el código de país por defecto
+     * @return Pais|null
+     */
     public function codPais() {
         return self::$codPais;
     }
 
+    /**
+     * Asigna el código de país por defecto
+     * @param $cod
+     */
     public function setCodPais($cod) {
         self::$codPais = $cod;
     }
 
+    /**
+     * Devuelve el código de la serie por defecto
+     * @return Serie|null
+     */
     public function codSerie() {
         return self::$codSerie;
     }
 
+    /**
+     * Asigna el código de la serie por defecto
+     * @param $cod
+     */
     public function setCodSerie($cod) {
         self::$codSerie = $cod;
     }
 
+    /**
+     * Devuelve la página por defecto
+     * @return Page|null
+     */
     public function defaultPage() {
         return self::$defaultPage;
     }
 
+    /**
+     * Asigna la página por defecto
+     * @param $name
+     */
     public function setDefaultPage($name) {
         self::$defaultPage = $name;
     }
 
+    /**
+     * Devuelve la página que se está mostrando
+     * @return Page|null
+     */
     public function showingPage() {
         return self::$showingPage;
     }
 
+    /**
+     * Asigna la página que se está mostrando
+     * @param $name
+     */
     public function setShowingPage($name) {
         self::$showingPage = $name;
     }
-
 }

--- a/Core/Base/IPFilter.php
+++ b/Core/Base/IPFilter.php
@@ -25,11 +25,19 @@ namespace FacturaScripts\Core\Base;
  *
  * @author Carlos García Gómez
  */
-class IPFilter {
-
+class IPFilter
+{
+    /**
+     * TODO
+     */
     const MAX_ATTEMPTS = 5;
+    /**
+     * TODO
+     */
     const BAN_SECONDS = 600;
-
+    /**
+     * TODO
+     */
     private $ipList;
 
     /**
@@ -37,7 +45,8 @@ class IPFilter {
      *
      * @param string $folder
      */
-    public function __construct($folder = '') {
+    public function __construct($folder = '')
+    {
         $this->ipList = [];
 
         if (file_exists($folder . '/Cache/ip.list')) {
@@ -57,16 +66,18 @@ class IPFilter {
     }
 
     /**
+     * TODO
      * @param $ip
      *
      * @return bool
      */
-    public function isBanned($ip) {
-        $banned = FALSE;
+    public function isBanned($ip)
+    {
+        $banned = false;
 
         foreach ($this->ipList as $line) {
             if ($line['ip'] === $ip && $line['count'] > self::MAX_ATTEMPTS) {
-                $banned = TRUE;
+                $banned = true;
                 break;
             }
         }
@@ -75,10 +86,12 @@ class IPFilter {
     }
 
     /**
+     * TODO
      * @param $ip
      */
-    public function setAttempt($ip) {
-        $found = FALSE;
+    public function setAttempt($ip)
+    {
+        $found = false;
         foreach ($this->ipList as $key => $line) {
             if ($line['ip'] === $ip) {
                 $this->ipList[$key]['count'] ++;

--- a/Core/Base/IPFilter.php
+++ b/Core/Base/IPFilter.php
@@ -32,12 +32,17 @@ class IPFilter {
 
     private $ipList;
 
+    /**
+     * IPFilter constructor.
+     *
+     * @param string $folder
+     */
     public function __construct($folder = '') {
         $this->ipList = [];
 
         if (file_exists($folder . '/Cache/ip.list')) {
             /// Read IP list file
-            $file = fopen($folder . '/Cache/ip.list', 'r');
+            $file = fopen($folder . '/Cache/ip.list', 'rb');
             if ($file) {
                 while (!feof($file)) {
                     $line = explode(';', trim(fgets($file)));
@@ -51,6 +56,11 @@ class IPFilter {
         }
     }
 
+    /**
+     * @param $ip
+     *
+     * @return bool
+     */
     public function isBanned($ip) {
         $banned = FALSE;
 
@@ -64,6 +74,9 @@ class IPFilter {
         return $banned;
     }
 
+    /**
+     * @param $ip
+     */
     public function setAttempt($ip) {
         $found = FALSE;
         foreach ($this->ipList as $key => $line) {
@@ -78,5 +91,4 @@ class IPFilter {
             $this->ipList[] = ['ip' => $ip, 'count' => 1, 'expire' => time() + self::BAN_SECONDS];
         }
     }
-
 }

--- a/Core/Base/IPFilter.php
+++ b/Core/Base/IPFilter.php
@@ -31,10 +31,12 @@ class IPFilter
      * TODO
      */
     const MAX_ATTEMPTS = 5;
+
     /**
      * TODO
      */
     const BAN_SECONDS = 600;
+
     /**
      * TODO
      */
@@ -42,7 +44,6 @@ class IPFilter
 
     /**
      * IPFilter constructor.
-     *
      * @param string $folder
      */
     public function __construct($folder = '')
@@ -68,7 +69,6 @@ class IPFilter
     /**
      * TODO
      * @param $ip
-     *
      * @return bool
      */
     public function isBanned($ip)

--- a/Core/Base/IPFilter.php
+++ b/Core/Base/IPFilter.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -27,10 +27,17 @@ namespace FacturaScripts\Core\Base;
  */
 class MiniLog {
 
+    /**
+     * TODO
+     * @var array
+     */
     private static $dataLog;
 
+    /**
+     * MiniLog constructor.
+     */
     public function __construct() {
-        if (!isset(self::$dataLog)) {
+        if (self::$dataLog === null) {
             self::$dataLog = [];
         }
     }
@@ -40,7 +47,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function emergency($message, array $context = array()) {
         $this->log('emergency', $message, $context);
@@ -54,7 +60,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function alert($message, array $context = array()) {
         $this->log('alert', $message, $context);
@@ -67,7 +72,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function critical($message, array $context = array()) {
         $this->log('critical', $message, $context);
@@ -79,7 +83,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function error($message, array $context = array()) {
         $this->log('error', $message, $context);
@@ -93,7 +96,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function warning($message, array $context = array()) {
         $this->log('warning', $message, $context);
@@ -104,7 +106,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function notice($message, array $context = array()) {
         $this->log('notice', $message, $context);
@@ -117,7 +118,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function info($message, array $context = array()) {
         $this->log('info', $message, $context);
@@ -128,7 +128,6 @@ class MiniLog {
      *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function debug($message, array $context = array()) {
         $this->log('debug', $message, $context);
@@ -136,10 +135,9 @@ class MiniLog {
 
     /**
      * SQL history.
-     * 
+     *
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function sql($message, array $context = array()) {
         $this->log('sql', $message, $context);
@@ -151,7 +149,6 @@ class MiniLog {
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return null
      */
     public function log($level, $message, array $context = array()) {
         self::$dataLog[] = [
@@ -164,7 +161,7 @@ class MiniLog {
 
     /**
      * Returns specified level messages or all.
-     * 
+     *
      * @param array $levels
      * @return array
      */
@@ -172,12 +169,11 @@ class MiniLog {
         $messages = [];
 
         foreach (self::$dataLog as $data) {
-            if (in_array($data['level'], $levels)) {
+            if (in_array($data['level'], $levels, FALSE)) {
                 $messages[] = $data;
             }
         }
 
         return $messages;
     }
-
 }

--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -25,8 +25,8 @@ namespace FacturaScripts\Core\Base;
  *
  * @author Carlos García Gómez
  */
-class MiniLog {
-
+class MiniLog
+{
     /**
      * TODO
      * @var array
@@ -36,7 +36,8 @@ class MiniLog {
     /**
      * MiniLog constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         if (self::$dataLog === null) {
             self::$dataLog = [];
         }
@@ -48,7 +49,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function emergency($message, array $context = array()) {
+    public function emergency($message, array $context = array())
+    {
         $this->log('emergency', $message, $context);
     }
 
@@ -61,7 +63,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function alert($message, array $context = array()) {
+    public function alert($message, array $context = array())
+    {
         $this->log('alert', $message, $context);
     }
 
@@ -73,7 +76,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function critical($message, array $context = array()) {
+    public function critical($message, array $context = array())
+    {
         $this->log('critical', $message, $context);
     }
 
@@ -84,7 +88,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function error($message, array $context = array()) {
+    public function error($message, array $context = array())
+    {
         $this->log('error', $message, $context);
     }
 
@@ -97,7 +102,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function warning($message, array $context = array()) {
+    public function warning($message, array $context = array())
+    {
         $this->log('warning', $message, $context);
     }
 
@@ -107,7 +113,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function notice($message, array $context = array()) {
+    public function notice($message, array $context = array())
+    {
         $this->log('notice', $message, $context);
     }
 
@@ -119,7 +126,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function info($message, array $context = array()) {
+    public function info($message, array $context = array())
+    {
         $this->log('info', $message, $context);
     }
 
@@ -129,7 +137,8 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function debug($message, array $context = array()) {
+    public function debug($message, array $context = array())
+    {
         $this->log('debug', $message, $context);
     }
 
@@ -139,18 +148,20 @@ class MiniLog {
      * @param string $message
      * @param array $context
      */
-    public function sql($message, array $context = array()) {
+    public function sql($message, array $context = array())
+    {
         $this->log('sql', $message, $context);
     }
 
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed $level
+     * @param string $level
      * @param string $message
      * @param array $context
      */
-    public function log($level, $message, array $context = array()) {
+    public function log($level, $message, array $context = array())
+    {
         self::$dataLog[] = [
             'time' => time(),
             'level' => $level,
@@ -165,12 +176,15 @@ class MiniLog {
      * @param array $levels
      * @return array
      */
-    public function read($levels = ['info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']) {
+    public function read(array $levels = ['info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'])
+    {
         $messages = [];
 
         foreach (self::$dataLog as $data) {
-            if (in_array($data['level'], $levels, FALSE)) {
-                $messages[] = $data;
+            if (in_array($data['level'], $levels, false)) {
+                if ($data['message'] !== '') {
+                    $messages[] = $data;
+                }
             }
         }
 

--- a/Core/Base/Model.php
+++ b/Core/Base/Model.php
@@ -94,11 +94,9 @@ trait Model
 
     /**
      * Constructor.
-     *
      * @param string $modelName
      * @param string $tableName nombre de la tabla de la base de datos.
      * @param string $primaryColumn
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Base/Model.php
+++ b/Core/Base/Model.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -20,13 +20,16 @@
 
 namespace FacturaScripts\Core\Base;
 
+use RuntimeException;
+
 /**
  * Gestor de plugins de FacturaScripts.
  *
  * @package FacturaScripts\Core\Base
  * @author Carlos García Gómez
  */
-class PluginManager {
+class PluginManager
+{
     /**
      * Lista de plugins activos.
      * @var array
@@ -44,7 +47,8 @@ class PluginManager {
      *
      * @param string $folder
      */
-    public function __construct($folder = '') {
+    public function __construct($folder = '')
+    {
         if (self::$folder === null) {
             self::$folder = $folder;
 
@@ -65,7 +69,8 @@ class PluginManager {
      *
      * @return string
      */
-    public function folder() {
+    public function folder()
+    {
         return self::$folder;
     }
 
@@ -74,7 +79,8 @@ class PluginManager {
      *
      * @return array
      */
-    public function enabledPlugins() {
+    public function enabledPlugins()
+    {
         return self::$enabledPlugins;
     }
 
@@ -83,7 +89,8 @@ class PluginManager {
      *
      * @param string $pluginName
      */
-    public function enable($pluginName) {
+    public function enable($pluginName)
+    {
         if (file_exists(self::$folder . '/plugins/' . $pluginName)) {
             self::$enabledPlugins[] = $pluginName;
             file_put_contents(self::$folder . '/plugin.list', implode(',', self::$enabledPlugins));
@@ -95,7 +102,8 @@ class PluginManager {
      *
      * @param string $pluginName
      */
-    public function disable($pluginName) {
+    public function disable($pluginName)
+    {
         foreach (self::$enabledPlugins as $i => $value) {
             if ($value === $pluginName) {
                 unset(self::$enabledPlugins[$i]);
@@ -112,9 +120,10 @@ class PluginManager {
      *
      * @param bool $clean
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
-    public function deploy($clean = true) {
+    public function deploy($clean = true)
+    {
         $folders = ['Controller', 'Model', 'Table'];
         if ($clean) {
             // Limpiamos Dinamic
@@ -123,7 +132,7 @@ class PluginManager {
                 $dir = self::$folder . '/Dinamic/' . $folder;
                 if (!file_exists($dir)) {
                     if (!@mkdir($dir, 0775, true) && !is_dir($dir)) {
-                        throw new \RuntimeException(sprintf('Unable to create the %s directory', $dir));
+                        throw new RuntimeException(sprintf('Unable to create the %s directory', $dir));
                     }
                 } else {
                     $this->cleanDinamic(self::$folder . '/Dinamic/');
@@ -151,7 +160,8 @@ class PluginManager {
      *
      * @param string $folder Carpeta a eliminar sus archivos
      */
-    private function cleanDinamic($folder) {
+    private function cleanDinamic($folder)
+    {
         // Añadimos los archivos que no son '.' ni '..'
         $items = array_diff(scandir($folder, SCANDIR_SORT_ASCENDING), ['.', '..']);
         // Ahora recorremos solo archivos o carpetas
@@ -171,7 +181,8 @@ class PluginManager {
      * @param string $place
      * @param string $pluginName
      */
-    private function linkFiles($folder, $place = 'Core', $pluginName = '') {
+    private function linkFiles($folder, $place = 'Core', $pluginName = '')
+    {
         if (empty($pluginName)) {
             $path = self::$folder . '/' . $place . '/' . $folder;
             $namespace = "\FacturaScripts\Core\\";
@@ -203,7 +214,8 @@ class PluginManager {
      * @param $folder
      * @param string $namespace
      */
-    private function linkClassFile($fileName, $folder, $namespace = "\FacturaScripts\Core\\") {
+    private function linkClassFile($fileName, $folder, $namespace = "\FacturaScripts\Core\\")
+    {
         if (!file_exists(self::$folder . '/Dinamic/' . $folder . '/' . $fileName)) {
             $className = substr($fileName, 0, -4);
             $txt = '<?php namespace FacturaScripts\Dinamic\\' . $folder . ";\n\n"
@@ -225,7 +237,8 @@ class PluginManager {
      * @param $folder
      * @param $filePath
      */
-    private function linkXmlFile($fileName, $folder, $filePath) {
+    private function linkXmlFile($fileName, $folder, $filePath)
+    {
         if (!file_exists(self::$folder . '/Dinamic/' . $folder . '/' . $fileName)) {
             copy($filePath, self::$folder . '/Dinamic/' . $folder . '/' . $fileName);
         }

--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -44,7 +44,6 @@ class PluginManager
 
     /**
      * PluginManager constructor.
-     *
      * @param string $folder
      */
     public function __construct($folder = '')
@@ -66,7 +65,6 @@ class PluginManager
 
     /**
      * Devuelve la carpeta
-     *
      * @return string
      */
     public function folder()
@@ -76,7 +74,6 @@ class PluginManager
 
     /**
      * Devuelve la lista de plugins activos.
-     *
      * @return array
      */
     public function enabledPlugins()
@@ -86,7 +83,6 @@ class PluginManager
 
     /**
      * Activa el plugin indicado.
-     *
      * @param string $pluginName
      */
     public function enable($pluginName)
@@ -99,7 +95,6 @@ class PluginManager
 
     /**
      * Desactiva el plugin indicado.
-     *
      * @param string $pluginName
      */
     public function disable($pluginName)
@@ -117,9 +112,7 @@ class PluginManager
      * Despliega todos los archivos necesarios en la carpeta Dinamic para poder
      * usar controladores y modelos de plugins con el autoloader, pero siguiendo
      * el sistema de prioridades de FacturaScripts.
-     *
      * @param bool $clean
-     *
      * @throws RuntimeException
      */
     public function deploy($clean = true)
@@ -157,7 +150,6 @@ class PluginManager
     /**
      * Eliminamos cada archivo de la carpeta Dinamic,
      * si es una carpeta, se llamará así misma
-     *
      * @param string $folder Carpeta a eliminar sus archivos
      */
     private function cleanDinamic($folder)
@@ -176,7 +168,6 @@ class PluginManager
 
     /**
      * Enlazamos los archivos
-     *
      * @param $folder
      * @param string $place
      * @param string $pluginName
@@ -209,7 +200,6 @@ class PluginManager
 
     /**
      * Enlaza las classes de forma dinamica
-     *
      * @param $fileName
      * @param $folder
      * @param string $namespace
@@ -232,7 +222,6 @@ class PluginManager
 
     /**
      * Enlaza los XML de forma dinamica
-     *
      * @param $fileName
      * @param $folder
      * @param $filePath

--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -122,7 +122,7 @@ class PluginManager {
                 /// ¿Existe la carpeta?
                 $dir = self::$folder . '/Dinamic/' . $folder;
                 if (!file_exists($dir)) {
-                    if (!@mkdir($dir, 0755, true) && !is_dir($dir)) {
+                    if (!@mkdir($dir, 0775, true) && !is_dir($dir)) {
                         throw new \RuntimeException(sprintf('Unable to create the %s directory', $dir));
                     }
                 } else {

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -20,6 +20,7 @@
 
 namespace FacturaScripts\Core\Base;
 
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
 use Symfony\Component\Translation\Translator as symfonyTranslator;
 use Symfony\Component\Translation\Loader\JsonFileLoader;
 
@@ -28,8 +29,8 @@ use Symfony\Component\Translation\Loader\JsonFileLoader;
  *
  * @author Carlos García Gómez
  */
-class Translator {
-
+class Translator
+{
     /**
      * Carpeta de trabajo de FacturaScripts.
      * @var string
@@ -54,9 +55,10 @@ class Translator {
      * @param string $folder
      * @param string $lang
      *
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($folder = '', $lang = 'es_ES') {
+    public function __construct($folder = '', $lang = 'es_ES')
+    {
         if (self::$folder === null) {
             self::$folder = $folder;
             self::$lang = $lang;
@@ -74,9 +76,10 @@ class Translator {
      * @param array $parameters
      *
      * @return string
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws TranslationInvalidArgumentException
      */
-    public function trans($txt, array $parameters = array()) {
+    public function trans($txt, array $parameters = [])
+    {
         return self::$translator->trans($txt, $parameters);
     }
 
@@ -84,9 +87,10 @@ class Translator {
      * Carga los archivos de traducción siguiendo el sistema de prioridades
      * de FacturaScripts. En esta caso hay que proporcionar al traductor las rutas
      * en orden inverso.
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws TranslationInvalidArgumentException
      */
-    private function locateFiles() {
+    private function locateFiles()
+    {
         $file = self::$folder . '/Core/Translation/' . self::$lang . '.json';
         self::$translator->addResource('json', $file, self::$lang);
 

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,24 +32,32 @@ class Translator {
 
     /**
      * Carpeta de trabajo de FacturaScripts.
-     * @var string 
+     * @var string
      */
     private static $folder;
-    
+
     /**
      * Idioma por defecto.
-     * @var string 
+     * @var string
      */
     private static $lang;
-    
+
     /**
      * El traductor de symfony.
-     * @var symfonyTranslator 
+     * @var symfonyTranslator
      */
     private static $translator;
 
+    /**
+     * Translator constructor.
+     *
+     * @param string $folder
+     * @param string $lang
+     *
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($folder = '', $lang = 'es_ES') {
-        if (!isset(self::$folder)) {
+        if (self::$folder === null) {
             self::$folder = $folder;
             self::$lang = $lang;
 
@@ -61,9 +69,12 @@ class Translator {
 
     /**
      * Traduce el texto al idioma predeterminado.
+     *
      * @param string $txt
      * @param array $parameters
+     *
      * @return string
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function trans($txt, array $parameters = array()) {
         return self::$translator->trans($txt, $parameters);
@@ -73,16 +84,18 @@ class Translator {
      * Carga los archivos de traducción siguiendo el sistema de prioridades
      * de FacturaScripts. En esta caso hay que proporcionar al traductor las rutas
      * en orden inverso.
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     private function locateFiles() {
-        self::$translator->addResource('json', self::$folder . '/Core/Translation/' . self::$lang . '.json', self::$lang);
-        
+        $file = self::$folder . '/Core/Translation/' . self::$lang . '.json';
+        self::$translator->addResource('json', $file, self::$lang);
+
         $pluginManager = new PluginManager(self::$folder);
         foreach ($pluginManager->enabledPlugins() as $pluginName) {
-            if (file_exists(self::$folder . '/Plugins/' . $pluginName . '/Translation/' . self::$lang . '.json')) {
-                self::$translator->addResource('json', self::$folder . '/Plugins/' . $pluginName . '/Translation/' . self::$lang . '.json', self::$lang);
+            $file = self::$folder . '/Plugins/' . $pluginName . '/Translation/' . self::$lang . '.json';
+            if (file_exists($file)) {
+                self::$translator->addResource('json', $file, self::$lang);
             }
         }
     }
-
 }

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -51,10 +51,8 @@ class Translator
 
     /**
      * Translator constructor.
-     *
      * @param string $folder
      * @param string $lang
-     *
      * @throws TranslationInvalidArgumentException
      */
     public function __construct($folder = '', $lang = 'es_ES')
@@ -71,10 +69,8 @@ class Translator
 
     /**
      * Traduce el texto al idioma predeterminado.
-     *
      * @param string $txt
      * @param array $parameters
-     *
      * @return string
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/Utils.php
+++ b/Core/Base/Utils.php
@@ -92,7 +92,7 @@ trait Utils {
      * @param string $last
      * @param string $step
      * @param string $format
-     * @return mixed
+     * @return array
      */
     public static function dateRange($first, $last, $step = '+1 day', $format = 'd-m-Y') {
         $dates = [];
@@ -113,7 +113,6 @@ trait Utils {
      * @return string
      */
     public static function randomString($length = 10) {
-        return mb_substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, $length);
+        return mb_substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, $length);
     }
-
 }

--- a/Core/Base/Utils.php
+++ b/Core/Base/Utils.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Base/Utils.php
+++ b/Core/Base/Utils.php
@@ -25,16 +25,17 @@ namespace FacturaScripts\Core\Base;
  *
  * @author Carlos García Gómez
  */
-trait Utils {
-
+trait Utils
+{
     /**
      * Convierte una variable con contenido binario a texto.
      * Lo hace en base64.
      * @param mixed $val
      * @return string
      */
-    public static function bin2str($val) {
-        if ($val === NULL) {
+    public static function bin2str($val)
+    {
+        if ($val === null) {
             return 'NULL';
         }
 
@@ -47,9 +48,10 @@ trait Utils {
      * @param string $val
      * @return null|string
      */
-    public static function str2bin($val) {
-        if ($val === NULL) {
-            return NULL;
+    public static function str2bin($val)
+    {
+        if ($val === null) {
+            return null;
         }
 
         return base64_decode($val);
@@ -61,9 +63,10 @@ trait Utils {
      * @param string $str
      * @return integer
      */
-    public static function intval($str) {
-        if ($str === NULL) {
-            return NULL;
+    public static function intval($str)
+    {
+        if ($str === null) {
+            return null;
         }
 
         return (int) $str;
@@ -74,11 +77,12 @@ trait Utils {
      * devuelve TRUE si son iguales, FALSE en caso contrario.
      * @param double $f1
      * @param double $f2
-     * @param integer $precision
-     * @param boolean $round
-     * @return boolean
+     * @param int $precision
+     * @param bool $round
+     * @return bool
      */
-    public static function floatcmp($f1, $f2, $precision = 10, $round = FALSE) {
+    public static function floatcmp($f1, $f2, $precision = 10, $round = false)
+    {
         if ($round || !function_exists('bccomp')) {
             return( abs($f1 - $f2) < 6 / pow(10, $precision + 1) );
         }
@@ -94,7 +98,8 @@ trait Utils {
      * @param string $format
      * @return array
      */
-    public static function dateRange($first, $last, $step = '+1 day', $format = 'd-m-Y') {
+    public static function dateRange($first, $last, $step = '+1 day', $format = 'd-m-Y')
+    {
         $dates = [];
         $current = strtotime($first);
         $last = strtotime($last);
@@ -112,7 +117,8 @@ trait Utils {
      * @param integer $length
      * @return string
      */
-    public static function randomString($length = 10) {
+    public static function randomString($length = 10)
+    {
         return mb_substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, $length);
     }
 }

--- a/Core/Controller/AdminHome.php
+++ b/Core/Controller/AdminHome.php
@@ -38,10 +38,20 @@ class AdminHome extends Base\Controller {
     public $formaPago;
     public $pais;
     public $serie;
-    
+
+    /**
+     * AdminHome constructor.
+     *
+     * @param Base\Cache $cache
+     * @param Base\Translator $i18n
+     * @param Base\MiniLog $miniLog
+     * @param string $className
+     *
+     * @throws \RuntimeException
+     */
     public function __construct(&$cache, &$i18n, &$miniLog, $className) {
         parent::__construct($cache, $i18n, $miniLog, $className);
-        
+
         /// por ahora desplegamos siempre el contenido de Dinamic, para las pruebas
         $pluginManager = new Base\PluginManager();
         $pluginManager->deploy();
@@ -56,6 +66,9 @@ class AdminHome extends Base\Controller {
         $this->serie = new Model\Serie();
     }
 
+    /**
+     * TODO
+     */
     public function run() {
         parent::run();
 
@@ -63,5 +76,4 @@ class AdminHome extends Base\Controller {
             $age->save();
         }
     }
-
 }

--- a/Core/Controller/AdminHome.php
+++ b/Core/Controller/AdminHome.php
@@ -22,21 +22,55 @@ namespace FacturaScripts\Core\Controller;
 
 use FacturaScripts\Core\Base;
 use FacturaScripts\Core\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
 
 /**
  * Description of admin_home
  *
  * @author Carlos García Gómez
  */
-class AdminHome extends Base\Controller {
-
+class AdminHome extends Base\Controller
+{
+    /**
+     * TODO
+     * @var Model\Agente
+     */
     public $agente;
+    /**
+     * TODO
+     * @var Model\Almacen
+     */
     public $almacen;
+    /**
+     * TODO
+     * @var Model\Divisa
+     */
     public $divisa;
+    /**
+     * TODO
+     * @var Model\Ejercicio
+     */
     public $ejercicio;
+    /**
+     * TODO
+     * @var Model\Empresa
+     */
     public $empresa;
+    /**
+     * TODO
+     * @var Model\FormaPago
+     */
     public $formaPago;
+    /**
+     * TODO
+     * @var Model\Pais
+     */
     public $pais;
+    /**
+     * TODO
+     * @var Model\Serie
+     */
     public $serie;
 
     /**
@@ -47,9 +81,11 @@ class AdminHome extends Base\Controller {
      * @param Base\MiniLog $miniLog
      * @param string $className
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className) {
+    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    {
         parent::__construct($cache, $i18n, $miniLog, $className);
 
         /// por ahora desplegamos siempre el contenido de Dinamic, para las pruebas
@@ -69,7 +105,8 @@ class AdminHome extends Base\Controller {
     /**
      * TODO
      */
-    public function run() {
+    public function run()
+    {
         parent::run();
 
         foreach ($this->agente->all() as $age) {

--- a/Core/Controller/AdminHome.php
+++ b/Core/Controller/AdminHome.php
@@ -75,12 +75,10 @@ class AdminHome extends Base\Controller
 
     /**
      * AdminHome constructor.
-     *
      * @param Base\Cache $cache
      * @param Base\Translator $i18n
      * @param Base\MiniLog $miniLog
      * @param string $className
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Controller/AdminHome.php
+++ b/Core/Controller/AdminHome.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -203,7 +203,7 @@ class Agente
     {
         $sql = 'SELECT MAX(' . $this->dataBase->sql2int('codagente') . ') as cod FROM ' . $this->tableName() . ';';
         $cod = $this->dataBase->select($sql);
-        if ($cod) {
+        if (!empty($cod)) {
             return 1 + (int)$cod[0]['cod'];
         }
 

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -20,6 +20,10 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * El agente/empleado es el que se asocia a un albarán, factura o caja.
  * Cada usuario puede estar asociado a un agente, y un agente puede
@@ -27,9 +31,9 @@ namespace FacturaScripts\Core\Model;
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Agente {
-
-    use \FacturaScripts\Core\Base\Model;
+class Agente
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar (10).
@@ -136,37 +140,39 @@ class Agente {
     /**
      * Agente constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'agentes', 'codagente');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
         }
     }
 
-    public function clear() {
-        $this->codagente = NULL;
+    public function clear()
+    {
+        $this->codagente = null;
         $this->nombre = '';
         $this->apellidos = '';
         $this->dnicif = '';
-        $this->email = NULL;
-        $this->telefono = NULL;
-        $this->codpostal = NULL;
-        $this->provincia = NULL;
-        $this->ciudad = NULL;
-        $this->direccion = NULL;
+        $this->email = null;
+        $this->telefono = null;
+        $this->codpostal = null;
+        $this->provincia = null;
+        $this->ciudad = null;
+        $this->direccion = null;
         $this->porcomision = 0.00;
-        $this->seg_social = NULL;
-        $this->banco = NULL;
-        $this->cargo = NULL;
+        $this->seg_social = null;
+        $this->banco = null;
+        $this->cargo = null;
         $this->f_alta = date('d-m-Y');
-        $this->f_baja = NULL;
+        $this->f_baja = null;
         $this->f_nacimiento = date('d-m-Y');
     }
 
@@ -174,7 +180,8 @@ class Agente {
      * Crea la consulta necesaria para crear un nuevo agente en la base de datos.
      * @return string
      */
-    protected function install() {
+    protected function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (codagente,nombre,apellidos,dnicif)'
                 . " VALUES ('1','Paco','Pepe','00000014Z');";
     }
@@ -183,7 +190,8 @@ class Agente {
      * Devuelve nombre + apellidos del agente.
      * @return string
      */
-    public function fullName() {
+    public function fullName()
+    {
         return $this->nombre . ' ' . $this->apellidos;
     }
 
@@ -191,7 +199,8 @@ class Agente {
      * Genera un nuevo código de agente
      * @return int
      */
-    public function newCodigo() {
+    public function newCodigo()
+    {
         $sql = 'SELECT MAX(' . $this->dataBase->sql2int('codagente') . ') as cod FROM ' . $this->tableName() . ';';
         $cod = $this->dataBase->select($sql);
         if ($cod) {
@@ -205,8 +214,9 @@ class Agente {
      * Devuelve la url donde se pueden ver/modificar estos datos
      * @return string
      */
-    public function url() {
-        if ($this->codagente === NULL) {
+    public function url()
+    {
+        if ($this->codagente === null) {
             return 'index.php?page=admin_agentes';
         }
 
@@ -215,10 +225,11 @@ class Agente {
 
     /**
      * Comprueba los datos del empleado/agente, devuelve TRUE si son correctos
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
+    public function test()
+    {
         $this->apellidos = static::noHtml($this->apellidos);
         $this->banco = static::noHtml($this->banco);
         $this->cargo = static::noHtml($this->cargo);
@@ -234,13 +245,13 @@ class Agente {
 
         if (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 50)) {
             $this->miniLog->alert($this->i18n->trans('agent-name-between-1-50'));
-            return FALSE;
+            return false;
         }
 
-        if ($this->codagente === NULL) {
+        if ($this->codagente === null) {
             $this->codagente = $this->newCodigo();
         }
 
-        return TRUE;
+        return true;
     }
 }

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,49 +45,49 @@ class Agente {
 
     /**
      * Nombre del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $nombre;
 
     /**
      * Apellidos del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $apellidos;
 
     /**
      * Email del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $email;
 
     /**
      * Teléfono del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $telefono;
 
     /**
      * Código postal del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $codpostal;
 
     /**
      * Provincia del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $provincia;
 
     /**
      * Ciudad del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $ciudad;
 
     /**
      * Dirección del agente o empleado.
-     * @var string 
+     * @var string
      */
     public $direccion;
 
@@ -133,6 +133,14 @@ class Agente {
      */
     public $porcomision;
 
+    /**
+     * Agente constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'agentes', 'codagente');
         if ($data) {
@@ -157,9 +165,9 @@ class Agente {
         $this->seg_social = NULL;
         $this->banco = NULL;
         $this->cargo = NULL;
-        $this->f_alta = Date('d-m-Y');
+        $this->f_alta = date('d-m-Y');
         $this->f_baja = NULL;
-        $this->f_nacimiento = Date('d-m-Y');
+        $this->f_nacimiento = date('d-m-Y');
     }
 
     /**
@@ -167,7 +175,7 @@ class Agente {
      * @return string
      */
     protected function install() {
-        return "INSERT INTO " . $this->tableName() . " (codagente,nombre,apellidos,dnicif)"
+        return 'INSERT INTO ' . $this->tableName() . ' (codagente,nombre,apellidos,dnicif)'
                 . " VALUES ('1','Paco','Pepe','00000014Z');";
     }
 
@@ -176,7 +184,7 @@ class Agente {
      * @return string
      */
     public function fullName() {
-        return $this->nombre . " " . $this->apellidos;
+        return $this->nombre . ' ' . $this->apellidos;
     }
 
     /**
@@ -184,7 +192,7 @@ class Agente {
      * @return int
      */
     public function newCodigo() {
-        $sql = "SELECT MAX(" . $this->dataBase->sql2int('codagente') . ") as cod FROM " . $this->tableName() . ";";
+        $sql = 'SELECT MAX(' . $this->dataBase->sql2int('codagente') . ') as cod FROM ' . $this->tableName() . ';';
         $cod = $this->dataBase->select($sql);
         if ($cod) {
             return 1 + (int)$cod[0]['cod'];
@@ -199,31 +207,32 @@ class Agente {
      */
     public function url() {
         if ($this->codagente === NULL) {
-            return "index.php?page=admin_agentes";
+            return 'index.php?page=admin_agentes';
         }
 
-        return "index.php?page=admin_agente&cod=" . $this->codagente;
+        return 'index.php?page=admin_agente&cod=' . $this->codagente;
     }
 
     /**
      * Comprueba los datos del empleado/agente, devuelve TRUE si son correctos
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
-        $this->apellidos = $this->noHtml($this->apellidos);
-        $this->banco = $this->noHtml($this->banco);
-        $this->cargo = $this->noHtml($this->cargo);
-        $this->ciudad = $this->noHtml($this->ciudad);
-        $this->codpostal = $this->noHtml($this->codpostal);
-        $this->direccion = $this->noHtml($this->direccion);
-        $this->dnicif = $this->noHtml($this->dnicif);
-        $this->email = $this->noHtml($this->email);
-        $this->nombre = $this->noHtml($this->nombre);
-        $this->provincia = $this->noHtml($this->provincia);
-        $this->seg_social = $this->noHtml($this->seg_social);
-        $this->telefono = $this->noHtml($this->telefono);
+        $this->apellidos = static::noHtml($this->apellidos);
+        $this->banco = static::noHtml($this->banco);
+        $this->cargo = static::noHtml($this->cargo);
+        $this->ciudad = static::noHtml($this->ciudad);
+        $this->codpostal = static::noHtml($this->codpostal);
+        $this->direccion = static::noHtml($this->direccion);
+        $this->dnicif = static::noHtml($this->dnicif);
+        $this->email = static::noHtml($this->email);
+        $this->nombre = static::noHtml($this->nombre);
+        $this->provincia = static::noHtml($this->provincia);
+        $this->seg_social = static::noHtml($this->seg_social);
+        $this->telefono = static::noHtml($this->telefono);
 
-        if (strlen($this->nombre) < 1 || strlen($this->nombre) > 50) {
+        if (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 50)) {
             $this->miniLog->alert($this->i18n->trans('agent-name-between-1-50'));
             return FALSE;
         }
@@ -234,5 +243,4 @@ class Agente {
 
         return TRUE;
     }
-
 }

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -139,9 +139,7 @@ class Agente
 
     /**
      * Agente constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */
@@ -155,6 +153,9 @@ class Agente
         }
     }
 
+    /**
+     * TODO
+     */
     public function clear()
     {
         $this->codagente = null;

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Almacen.php
+++ b/Core/Model/Almacen.php
@@ -20,14 +20,18 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * El almacén donde están físicamente los artículos.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Almacen {
-
-    use \FacturaScripts\Core\Base\Model;
+class Almacen
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar (4).
@@ -98,14 +102,15 @@ class Almacen {
     /**
      * Almacen constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'almacenes', 'codalmacen');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -116,7 +121,8 @@ class Almacen {
      * Crea la consulta necesaria para crear un nuevo almacen en la base de datos.
      * @return string
      */
-    public function install() {
+    public function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (codalmacen,nombre,poblacion,'
                 . "direccion,codpostal,telefono,fax,contacto) VALUES ('ALG','ALMACEN GENERAL','','','','','','');";
     }
@@ -125,7 +131,8 @@ class Almacen {
      * Devuelve la URL para ver/modificar los datos de este almacén
      * @return string
      */
-    public function url() {
+    public function url()
+    {
         if ($this->codalmacen === null) {
             return 'index.php?page=admin_almacenes';
         }
@@ -135,19 +142,21 @@ class Almacen {
 
     /**
      * Devuelve TRUE si este es almacén predeterminado de la empresa.
-     * @return boolean
+     * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ( $this->codalmacen === $this->defaultItems->codAlmacen() );
     }
 
     /**
      * Comprueba los datos del almacén, devuelve TRUE si son correctos
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
-        $status = FALSE;
+    public function test()
+    {
+        $status = false;
 
         $this->codalmacen = trim($this->codalmacen);
         $this->nombre = static::noHtml($this->nombre);
@@ -164,7 +173,7 @@ class Almacen {
         } elseif (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 100)) {
             $this->miniLog->alert($this->i18n->trans('store-name-invalid'));
         } else {
-            $status = TRUE;
+            $status = true;
         }
 
         return $status;

--- a/Core/Model/Almacen.php
+++ b/Core/Model/Almacen.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -37,64 +37,72 @@ class Almacen {
 
     /**
      * Nombre del almacen.
-     * @var string 
+     * @var string
      */
     public $nombre;
 
     /**
      * Código que representa al páis donde está ubicado el almacen.
-     * @var string 
+     * @var string
      */
     public $codpais;
 
     /**
      * Nombre de la provincia donde está ubicado el almacen.
-     * @var string 
+     * @var string
      */
     public $provincia;
 
     /**
      * Nombre de la población donde está ubicado el almacen.
-     * @var string 
+     * @var string
      */
     public $poblacion;
 
     /**
      * Código postal donde está ubicado el almacen.
-     * @var string 
+     * @var string
      */
     public $codpostal;
 
     /**
      * Dirección donde está ubicado el almacen.
-     * @var string 
+     * @var string
      */
     public $direccion;
 
     /**
      * Persona de contacto del almacen.
-     * @var string 
+     * @var string
      */
     public $contacto;
 
     /**
      * Número de fax del almacen.
-     * @var string 
+     * @var string
      */
     public $fax;
 
     /**
      * Número de teléfono del almacen.
-     * @var string 
+     * @var string
      */
     public $telefono;
 
     /**
      * Todavía sin uso.
-     * @var string 
+     * @var string
      */
     public $observaciones;
 
+    /**
+     * Almacen constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'almacenes', 'codalmacen');
         if ($data) {
@@ -109,7 +117,7 @@ class Almacen {
      * @return string
      */
     public function install() {
-        return "INSERT INTO " . $this->tableName() . " (codalmacen,nombre,poblacion,"
+        return 'INSERT INTO ' . $this->tableName() . ' (codalmacen,nombre,poblacion,'
                 . "direccion,codpostal,telefono,fax,contacto) VALUES ('ALG','ALMACEN GENERAL','','','','','','');";
     }
 
@@ -118,7 +126,7 @@ class Almacen {
      * @return string
      */
     public function url() {
-        if (is_null($this->codalmacen)) {
+        if ($this->codalmacen === null) {
             return 'index.php?page=admin_almacenes';
         }
 
@@ -136,23 +144,24 @@ class Almacen {
     /**
      * Comprueba los datos del almacén, devuelve TRUE si son correctos
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
         $status = FALSE;
 
         $this->codalmacen = trim($this->codalmacen);
-        $this->nombre = $this->noHtml($this->nombre);
-        $this->provincia = $this->noHtml($this->provincia);
-        $this->poblacion = $this->noHtml($this->poblacion);
-        $this->direccion = $this->noHtml($this->direccion);
-        $this->codpostal = $this->noHtml($this->codpostal);
-        $this->telefono = $this->noHtml($this->telefono);
-        $this->fax = $this->noHtml($this->fax);
-        $this->contacto = $this->noHtml($this->contacto);
+        $this->nombre = static::noHtml($this->nombre);
+        $this->provincia = static::noHtml($this->provincia);
+        $this->poblacion = static::noHtml($this->poblacion);
+        $this->direccion = static::noHtml($this->direccion);
+        $this->codpostal = static::noHtml($this->codpostal);
+        $this->telefono = static::noHtml($this->telefono);
+        $this->fax = static::noHtml($this->fax);
+        $this->contacto = static::noHtml($this->contacto);
 
-        if (!preg_match("/^[A-Z0-9]{1,4}$/i", $this->codalmacen)) {
+        if (!preg_match('/^[A-Z0-9]{1,4}$/i', $this->codalmacen)) {
             $this->miniLog->alert($this->i18n->trans('store-cod-invalid'));
-        } else if (strlen($this->nombre) < 1 || strlen($this->nombre) > 100) {
+        } elseif (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 100)) {
             $this->miniLog->alert($this->i18n->trans('store-name-invalid'));
         } else {
             $status = TRUE;
@@ -160,5 +169,4 @@ class Almacen {
 
         return $status;
     }
-
 }

--- a/Core/Model/Almacen.php
+++ b/Core/Model/Almacen.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2016  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Almacen.php
+++ b/Core/Model/Almacen.php
@@ -101,9 +101,7 @@ class Almacen
 
     /**
      * Almacen constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,18 +26,18 @@ namespace FacturaScripts\Core\Model;
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
 class Divisa {
-    
+
     use \FacturaScripts\Core\Base\Model;
 
     /**
      * Clave primaria. Varchar (3).
-     * @var string 
+     * @var string
      */
     public $coddivisa;
 
     /**
      * Descripción de la divisa
-     * @var string 
+     * @var string
      */
     public $descripcion;
 
@@ -61,10 +61,18 @@ class Divisa {
 
     /**
      * Símbolo que representa a la divisa
-     * @var string 
+     * @var string
      */
     public $simbolo;
 
+    /**
+     * Divisa constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'divisas', 'coddivisa');
         if ($data) {
@@ -74,6 +82,9 @@ class Divisa {
         }
     }
 
+    /**
+     * TODO
+     */
     public function clear() {
         $this->coddivisa = NULL;
         $this->descripcion = '';
@@ -88,7 +99,7 @@ class Divisa {
      * @return string
      */
     public function install() {
-        return "INSERT INTO " . $this->tableName() . " (coddivisa,descripcion,tasaconv,tasaconvcompra,codiso,simbolo)"
+        return 'INSERT INTO ' . $this->tableName() . ' (coddivisa,descripcion,tasaconv,tasaconvcompra,codiso,simbolo)'
                 . " VALUES ('EUR','EUROS','1','1','978','€')"
                 . ",('ARS','PESOS (ARG)','16.684','16.684','32','AR$')"
                 . ",('CLP','PESOS (CLP)','704.0227','704.0227','152','CLP$')"
@@ -122,19 +133,20 @@ class Divisa {
     /**
      * Comprueba los datos de la divisa, devuelve TRUE si son correctos
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
         $status = FALSE;
-        $this->descripcion = $this->noHtml($this->descripcion);
-        $this->simbolo = $this->noHtml($this->simbolo);
+        $this->descripcion = static::noHtml($this->descripcion);
+        $this->simbolo = static::noHtml($this->simbolo);
 
-        if (!preg_match("/^[A-Z0-9]{1,3}$/i", $this->coddivisa)) {
+        if (!preg_match('/^[A-Z0-9]{1,3}$/i', $this->coddivisa)) {
             $this->miniLog->alert($this->i18n->trans('bage-cod-invalid'));
-        } else if (isset($this->codiso) && !preg_match("/^[A-Z0-9]{1,3}$/i", $this->codiso)) {
+        } elseif ($this->codiso !== null && !preg_match('/^[A-Z0-9]{1,3}$/i', $this->codiso)) {
             $this->miniLog->alert($this->i18n->trans('iso-cod-invalid'));
-        } else if ($this->tasaconv === 0) {
+        } elseif ($this->tasaconv === 0) {
             $this->miniLog->alert($this->i18n->trans('conversion-rate-not-0'));
-        } else if ($this->tasaconvcompra === 0) {
+        } elseif ($this->tasaconvcompra === 0) {
             $this->miniLog->alert($this->i18n->trans('conversion-rate-pruchases-not-0'));
         } else {
             $this->cache->delete('m_divisa_all');
@@ -143,5 +155,4 @@ class Divisa {
 
         return $status;
     }
-
 }

--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -20,14 +20,18 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Una divisa (moneda) con su símbolo y su tasa de conversión respecto al euro.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Divisa {
-
-    use \FacturaScripts\Core\Base\Model;
+class Divisa
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar (3).
@@ -68,14 +72,15 @@ class Divisa {
     /**
      * Divisa constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'divisas', 'coddivisa');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -85,12 +90,13 @@ class Divisa {
     /**
      * TODO
      */
-    public function clear() {
-        $this->coddivisa = NULL;
+    public function clear()
+    {
+        $this->coddivisa = null;
         $this->descripcion = '';
         $this->tasaconv = 1.00;
         $this->tasaconvcompra = 1.00;
-        $this->codiso = NULL;
+        $this->codiso = null;
         $this->simbolo = '?';
     }
 
@@ -98,7 +104,8 @@ class Divisa {
      * Crea la consulta necesaria para crear una nueva divisa en la base de datos.
      * @return string
      */
-    public function install() {
+    public function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (coddivisa,descripcion,tasaconv,tasaconvcompra,codiso,simbolo)'
                 . " VALUES ('EUR','EUROS','1','1','978','€')"
                 . ",('ARS','PESOS (ARG)','16.684','16.684','32','AR$')"
@@ -118,25 +125,28 @@ class Divisa {
      * Devuelve la url donde ver/modificar estos datos
      * @return string
      */
-    public function url() {
+    public function url()
+    {
         return 'index.php?page=admin_divisas';
     }
 
     /**
      * Devuelve TRUE si esta es la divisa predeterminada de la empresa
-     * @return boolean
+     * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ( $this->coddivisa === $this->defaultItems->codDivisa() );
     }
 
     /**
      * Comprueba los datos de la divisa, devuelve TRUE si son correctos
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
-        $status = FALSE;
+    public function test()
+    {
+        $status = false;
         $this->descripcion = static::noHtml($this->descripcion);
         $this->simbolo = static::noHtml($this->simbolo);
 
@@ -150,7 +160,7 @@ class Divisa {
             $this->miniLog->alert($this->i18n->trans('conversion-rate-pruchases-not-0'));
         } else {
             $this->cache->delete('m_divisa_all');
-            $status = TRUE;
+            $status = true;
         }
 
         return $status;

--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -71,9 +71,7 @@ class Divisa
 
     /**
      * Divisa constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/Ejercicio.php
+++ b/Core/Model/Ejercicio.php
@@ -96,9 +96,7 @@ class Ejercicio
 
     /**
      * Ejercicio constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */
@@ -204,10 +202,8 @@ class Ejercicio
 
     /**
      * Devuelve la fecha más próxima a $fecha que esté dentro del intervalo de este ejercicio
-     *
      * @param string $fecha
      * @param bool $showError
-     *
      * @return string
      * @throws TranslationInvalidArgumentException
      */
@@ -235,11 +231,9 @@ class Ejercicio
     /**
      * Devuelve el ejercicio para la fecha indicada.
      * Si no existe, lo crea.
-     *
      * @param string $fecha
      * @param bool $soloAbierto
      * @param bool $crear
-     *
      * @return bool|ejercicio
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException

--- a/Core/Model/Ejercicio.php
+++ b/Core/Model/Ejercicio.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -31,13 +31,13 @@ class Ejercicio {
 
     /**
      * Clave primaria. Varchar(4).
-     * @var string 
+     * @var string
      */
     public $codejercicio;
 
     /**
      * Nombre del ejercicio
-     * @var string 
+     * @var string
      */
     public $nombre;
 
@@ -55,32 +55,32 @@ class Ejercicio {
 
     /**
      * Estado del ejercicio: ABIERTO|CERRADO
-     * @var string 
+     * @var string
      */
     public $estado;
 
     /**
      * ID del asiento de cierre del ejercicio.
-     * @var integer 
+     * @var integer
      */
     public $idasientocierre;
 
     /**
      * ID del asiento de pérdidas y ganancias.
-     * @var integer 
+     * @var integer
      */
     public $idasientopyg;
 
     /**
      * ID del asiento de apertura.
-     * @var integer 
+     * @var integer
      */
     public $idasientoapertura;
 
     /**
      * Identifica el plan contable utilizado. Esto solamente es necesario
      * para dar compatibilidad con Eneboo. En FacturaScripts no se utiliza.
-     * @var string 
+     * @var string
      */
     public $plancontable;
 
@@ -90,6 +90,14 @@ class Ejercicio {
      */
     public $longsubcuenta;
 
+    /**
+     * Ejercicio constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'ejercicios', 'codejercicio');
         if ($data) {
@@ -105,8 +113,8 @@ class Ejercicio {
     public function clear() {
         $this->codejercicio = NULL;
         $this->nombre = '';
-        $this->fechainicio = Date('01-01-Y');
-        $this->fechafin = Date('31-12-Y');
+        $this->fechainicio = date('01-01-Y');
+        $this->fechafin = date('31-12-Y');
         $this->estado = 'ABIERTO';
         $this->idasientocierre = NULL;
         $this->idasientopyg = NULL;
@@ -120,10 +128,10 @@ class Ejercicio {
      * @return string
      */
     protected function install() {
-        return "INSERT INTO " . $this->tableName() . " (codejercicio,nombre,fechainicio,fechafin,"
-                . "estado,longsubcuenta,plancontable,idasientoapertura,idasientopyg,idasientocierre) "
-                . "VALUES ('" . Date('Y') . "','" . Date('Y') . "'," . $this->var2str(Date('01-01-Y'))
-                . "," . $this->var2str(Date('31-12-Y')) . ",'ABIERTO',10,'08',NULL,NULL,NULL);";
+        return 'INSERT INTO ' . $this->tableName() . ' (codejercicio,nombre,fechainicio,fechafin,'
+                . 'estado,longsubcuenta,plancontable,idasientoapertura,idasientopyg,idasientocierre) '
+                . "VALUES ('" . date('Y') . "','" . date('Y') . "'," . $this->var2str(date('01-01-Y'))
+                . ',' . $this->var2str(date('31-12-Y')) . ",'ABIERTO',10,'08',NULL,NULL,NULL);";
     }
 
     /**
@@ -139,7 +147,7 @@ class Ejercicio {
      * @return string en formato año
      */
     public function year() {
-        return Date('Y', strtotime($this->fechainicio));
+        return date('Y', strtotime($this->fechainicio));
     }
 
     /**
@@ -148,13 +156,15 @@ class Ejercicio {
      * @return string
      */
     public function newCodigo($cod = '0001') {
-        if (!$this->dataBase->select("SELECT * FROM " . $this->tableName() . " WHERE codejercicio = " . $this->var2str($cod) . ";")) {
+        $sql = 'SELECT * FROM ' . $this->tableName() . ' WHERE codejercicio = ' . $this->var2str($cod) . ';';
+        if (!$this->dataBase->select($sql)) {
             return $cod;
         }
 
-        $cod = $this->dataBase->select("SELECT MAX(" . $this->dataBase->sql2int('codejercicio') . ") as cod FROM " . $this->tableName() . ";");
+        $sql = 'SELECT MAX(' . $this->dataBase->sql2int('codejercicio') . ') as cod FROM ' . $this->tableName() . ';';
+        $cod = $this->dataBase->select($sql);
         if ($cod) {
-            return sprintf('%04s', (1 + (int)$cod[0]['cod']));
+            return sprintf('%04s', 1 + (int)$cod[0]['cod']);
         }
 
         return '0001';
@@ -165,7 +175,7 @@ class Ejercicio {
      * @return string
      */
     public function url() {
-        if (is_null($this->codejercicio)) {
+        if ($this->codejercicio === null) {
             return 'index.php?page=contabilidad_ejercicios';
         }
 
@@ -182,9 +192,12 @@ class Ejercicio {
 
     /**
      * Devuelve la fecha más próxima a $fecha que esté dentro del intervalo de este ejercicio
+     *
      * @param string $fecha
      * @param boolean $showError
+     *
      * @return string
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function getBestFecha($fecha, $showError = FALSE) {
         $fecha2 = strtotime($fecha);
@@ -209,14 +222,18 @@ class Ejercicio {
     /**
      * Devuelve el ejercicio para la fecha indicada.
      * Si no existe, lo crea.
+     *
      * @param string $fecha
      * @param boolean $soloAbierto
      * @param boolean $crear
+     *
      * @return boolean|ejercicio
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function getByFecha($fecha, $soloAbierto = TRUE, $crear = TRUE) {
-        $sql = "SELECT * FROM " . $this->tableName() . " WHERE fechainicio <= "
-                . $this->var2str($fecha) . " AND fechafin >= " . $this->var2str($fecha) . ";";
+        $sql = 'SELECT * FROM ' . $this->tableName() . ' WHERE fechainicio <= '
+                . $this->var2str($fecha) . ' AND fechafin >= ' . $this->var2str($fecha) . ';';
 
         $data = $this->dataBase->select($sql);
         if ($data) {
@@ -224,16 +241,16 @@ class Ejercicio {
             if ($eje->abierto() || !$soloAbierto) {
                 return $eje;
             }
-        } else if ($crear) {
+        } elseif ($crear) {
             $eje = new Ejercicio();
-            $eje->codejercicio = $eje->newCodigo(Date('Y', strtotime($fecha)));
-            $eje->nombre = Date('Y', strtotime($fecha));
-            $eje->fechainicio = Date('1-1-Y', strtotime($fecha));
-            $eje->fechafin = Date('31-12-Y', strtotime($fecha));
+            $eje->codejercicio = $eje->newCodigo(date('Y', strtotime($fecha)));
+            $eje->nombre = date('Y', strtotime($fecha));
+            $eje->fechainicio = date('1-1-Y', strtotime($fecha));
+            $eje->fechafin = date('31-12-Y', strtotime($fecha));
 
             if (strtotime($fecha) < 1) {
                 $this->miniLog->alert($this->i18n->trans('date-invalid-date', [$fecha]));
-            } else if ($eje->save()) {
+            } elseif ($eje->save()) {
                 return $eje;
             }
         }
@@ -244,20 +261,22 @@ class Ejercicio {
     /**
      * Comprueba los datos del ejercicio, devuelve TRUE si son correctos
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
         $status = FALSE;
 
         $this->codejercicio = trim($this->codejercicio);
-        $this->nombre = $this->noHtml($this->nombre);
+        $this->nombre = static::noHtml($this->nombre);
 
-        if (!preg_match("/^[A-Z0-9_]{1,4}$/i", $this->codejercicio)) {
+        if (!preg_match('/^[A-Z0-9_]{1,4}$/i', $this->codejercicio)) {
             $this->miniLog->alert($this->i18n->trans('fiscal-year-code-invalid'));
-        } else if (strlen($this->nombre) < 1 || strlen($this->nombre) > 100) {
+        } elseif (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 100)) {
             $this->miniLog->alert($this->i18n->trans('fiscal-year-name-invalid'));
-        } else if (strtotime($this->fechainicio) > strtotime($this->fechafin)) {
-            $this->miniLog->alert($this->i18n->trans('start-date-later-end-date', [$this->fechainicio, $this->fechafin]));
-        } else if (strtotime($this->fechainicio) < 1) {
+        } elseif (strtotime($this->fechainicio) > strtotime($this->fechafin)) {
+            $params = [$this->fechainicio, $this->fechafin];
+            $this->miniLog->alert($this->i18n->trans('start-date-later-end-date', $params));
+        } elseif (strtotime($this->fechainicio) < 1) {
             $this->miniLog->alert($this->i18n->trans('date-invalid'));
         } else {
             $status = TRUE;
@@ -265,5 +284,4 @@ class Ejercicio {
 
         return $status;
     }
-
 }

--- a/Core/Model/Ejercicio.php
+++ b/Core/Model/Ejercicio.php
@@ -250,7 +250,7 @@ class Ejercicio
                 . $this->var2str($fecha) . ' AND fechafin >= ' . $this->var2str($fecha) . ';';
 
         $data = $this->dataBase->select($sql);
-        if ($data) {
+        if (!empty($data)) {
             $eje = new Ejercicio($data[0]);
             if ($eje->abierto() || !$soloAbierto) {
                 return $eje;

--- a/Core/Model/Ejercicio.php
+++ b/Core/Model/Ejercicio.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Ejercicio.php
+++ b/Core/Model/Ejercicio.php
@@ -20,14 +20,18 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Ejercicio contable. Es el periodo en el que se agrupan asientos, facturas, albaranes...
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Ejercicio {
-
-    use \FacturaScripts\Core\Base\Model;
+class Ejercicio
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar(4).
@@ -93,14 +97,15 @@ class Ejercicio {
     /**
      * Ejercicio constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'ejercicios', 'codejercicio');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -110,15 +115,16 @@ class Ejercicio {
     /**
      * Resetea los valores de las propiedades del modelo.
      */
-    public function clear() {
-        $this->codejercicio = NULL;
+    public function clear()
+    {
+        $this->codejercicio = null;
         $this->nombre = '';
         $this->fechainicio = date('01-01-Y');
         $this->fechafin = date('31-12-Y');
         $this->estado = 'ABIERTO';
-        $this->idasientocierre = NULL;
-        $this->idasientopyg = NULL;
-        $this->idasientoapertura = NULL;
+        $this->idasientocierre = null;
+        $this->idasientopyg = null;
+        $this->idasientoapertura = null;
         $this->plancontable = '08';
         $this->longsubcuenta = 10;
     }
@@ -127,7 +133,8 @@ class Ejercicio {
      * Crea la consulta necesaria para dotar de datos a un ejercicio en la base de datos.
      * @return string
      */
-    protected function install() {
+    protected function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (codejercicio,nombre,fechainicio,fechafin,'
                 . 'estado,longsubcuenta,plancontable,idasientoapertura,idasientopyg,idasientocierre) '
                 . "VALUES ('" . date('Y') . "','" . date('Y') . "'," . $this->var2str(date('01-01-Y'))
@@ -136,9 +143,10 @@ class Ejercicio {
 
     /**
      * Devuelve el estado del ejercicio ABIERTO->true | CERRADO->false
-     * @return boolean
+     * @return bool
      */
-    public function abierto() {
+    public function abierto()
+    {
         return ($this->estado === 'ABIERTO');
     }
 
@@ -146,7 +154,8 @@ class Ejercicio {
      * Devuelve el valos del año del ejercicio
      * @return string en formato año
      */
-    public function year() {
+    public function year()
+    {
         return date('Y', strtotime($this->fechainicio));
     }
 
@@ -155,7 +164,8 @@ class Ejercicio {
      * @param string $cod
      * @return string
      */
-    public function newCodigo($cod = '0001') {
+    public function newCodigo($cod = '0001')
+    {
         $sql = 'SELECT * FROM ' . $this->tableName() . ' WHERE codejercicio = ' . $this->var2str($cod) . ';';
         if (!$this->dataBase->select($sql)) {
             return $cod;
@@ -163,7 +173,7 @@ class Ejercicio {
 
         $sql = 'SELECT MAX(' . $this->dataBase->sql2int('codejercicio') . ') as cod FROM ' . $this->tableName() . ';';
         $cod = $this->dataBase->select($sql);
-        if ($cod) {
+        if (!empty($cod)) {
             return sprintf('%04s', 1 + (int)$cod[0]['cod']);
         }
 
@@ -174,7 +184,8 @@ class Ejercicio {
      * Devuelve la url donde ver/modificar estos datos
      * @return string
      */
-    public function url() {
+    public function url()
+    {
         if ($this->codejercicio === null) {
             return 'index.php?page=contabilidad_ejercicios';
         }
@@ -184,9 +195,10 @@ class Ejercicio {
 
     /**
      * Devuelve TRUE si este es el ejercicio predeterminado de la empresa
-     * @return boolean
+     * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ($this->codejercicio === $this->defaultItems->codEjercicio());
     }
 
@@ -194,12 +206,13 @@ class Ejercicio {
      * Devuelve la fecha más próxima a $fecha que esté dentro del intervalo de este ejercicio
      *
      * @param string $fecha
-     * @param boolean $showError
+     * @param bool $showError
      *
      * @return string
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws TranslationInvalidArgumentException
      */
-    public function getBestFecha($fecha, $showError = FALSE) {
+    public function getBestFecha($fecha, $showError = false)
+    {
         $fecha2 = strtotime($fecha);
 
         if ($fecha2 >= strtotime($this->fechainicio) && $fecha2 <= strtotime($this->fechafin)) {
@@ -224,14 +237,15 @@ class Ejercicio {
      * Si no existe, lo crea.
      *
      * @param string $fecha
-     * @param boolean $soloAbierto
-     * @param boolean $crear
+     * @param bool $soloAbierto
+     * @param bool $crear
      *
-     * @return boolean|ejercicio
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool|ejercicio
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function getByFecha($fecha, $soloAbierto = TRUE, $crear = TRUE) {
+    public function getByFecha($fecha, $soloAbierto = true, $crear = true)
+    {
         $sql = 'SELECT * FROM ' . $this->tableName() . ' WHERE fechainicio <= '
                 . $this->var2str($fecha) . ' AND fechafin >= ' . $this->var2str($fecha) . ';';
 
@@ -255,16 +269,17 @@ class Ejercicio {
             }
         }
 
-        return FALSE;
+        return false;
     }
 
     /**
      * Comprueba los datos del ejercicio, devuelve TRUE si son correctos
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
-        $status = FALSE;
+    public function test()
+    {
+        $status = false;
 
         $this->codejercicio = trim($this->codejercicio);
         $this->nombre = static::noHtml($this->nombre);
@@ -279,7 +294,7 @@ class Ejercicio {
         } elseif (strtotime($this->fechainicio) < 1) {
             $this->miniLog->alert($this->i18n->trans('date-invalid'));
         } else {
-            $status = TRUE;
+            $status = true;
         }
 
         return $status;

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *
@@ -40,6 +39,10 @@ class Empresa
      * @var integer
      */
     public $id;
+    /**
+     * TODO
+     * @var string
+     */
     public $xid;
 
     /**

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -51,13 +51,13 @@ class Empresa
     /**
      * TRUE -> activa la contabilidad integrada. Se genera el asiento correspondiente
      * cada vez que se crea/modifica una factura.
-     * @var boolean
+     * @var bool
      */
     public $contintegrada;
 
     /**
      * TRUE -> activa el uso de recargo de equivalencia en los albaranes y facturas de compra.
-     * @var boolean
+     * @var bool
      */
     public $recequivalencia;
 
@@ -279,7 +279,7 @@ class Empresa
 
     /**
      * Comprueba los datos de la empresa, devuelve TRUE si es correcto
-     * @return boolean
+     * @return bool
      * @throws TranslationInvalidArgumentException
      */
     public function test()

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -20,15 +20,20 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use FacturaScripts\Core\Base\Utils;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Esta clase almacena los principales datos de la empresa.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Empresa {
-
-    use \FacturaScripts\Core\Base\Model;
-    use \FacturaScripts\Core\Base\Utils;
+class Empresa
+{
+    use Model;
+    use Utils;
 
     /**
      * Clave primaria. Integer.
@@ -39,7 +44,7 @@ class Empresa {
 
     /**
      * Todavía sin uso.
-     * @var boolean
+     * @var bool
      */
     public $stockpedidos;
 
@@ -215,14 +220,15 @@ class Empresa {
     /**
      * Empresa constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'empresa', 'id');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
 
             /// cargamos las opciones de email por defecto
@@ -235,11 +241,11 @@ class Empresa {
                 'mail_port' => '465',
                 'mail_enc' => 'ssl',
                 'mail_user' => '',
-                'mail_low_security' => FALSE,
+                'mail_low_security' => false,
             );
 
-            if ($this->xid === NULL) {
-                $this->xid = statis::randomString(30);
+            if ($this->xid === null) {
+                $this->xid = static::randomString(30);
                 $this->save();
             }
         } else {
@@ -251,30 +257,34 @@ class Empresa {
      * Crea la consulta necesaria para dotar de datos a la empresa en la base de datos.
      * @return string
      */
-    protected function install() {
+    protected function install()
+    {
         $num = mt_rand(1, 9999);
-        return "INSERT INTO " . $this->tableName() . " (stockpedidos,contintegrada,recequivalencia,codserie,"
-                . "codalmacen,codpago,coddivisa,codejercicio,web,email,fax,telefono,codpais,apartado,provincia,"
-                . "ciudad,codpostal,direccion,administrador,codedi,cifnif,nombre,nombrecorto,lema,horario)"
+        return 'INSERT INTO ' . $this->tableName() . ' (stockpedidos,contintegrada,recequivalencia,codserie,'
+                . 'codalmacen,codpago,coddivisa,codejercicio,web,email,fax,telefono,codpais,apartado,provincia,'
+                . 'ciudad,codpostal,direccion,administrador,codedi,cifnif,nombre,nombrecorto,lema,horario)'
                 . "VALUES (NULL,FALSE,NULL,'A','ALG','CONT','EUR','0001','https://www.facturascripts.com',"
-                . "NULL,NULL,NULL,'ESP',NULL,NULL,NULL,NULL,'C/ Falsa, 123','',NULL,'00000014Z','Empresa " . $num . " S.L.',"
-                . "'E-" . $num . "','','');";
+                . "NULL,NULL,NULL,'ESP',NULL,NULL,NULL,NULL,'C/ Falsa, 123','',NULL,'00000014Z',"
+                . "'Empresa " . $num . " S.L.','E-" . $num . "','','');";
     }
 
     /**
      * Devuelve la url donde ver/modificar los datos
      * @return string
      */
-    public function url() {
+    public function url()
+    {
         return 'index.php?page=admin_empresa';
     }
 
     /**
-     * Comprueba los datos de la empresa, devuelve TRUE si está todo correcto
+     * Comprueba los datos de la empresa, devuelve TRUE si es correcto
      * @return boolean
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
-        $status = FALSE;
+    public function test()
+    {
+        $status = false;
 
         $this->nombre = static::noHtml($this->nombre);
         $this->nombrecorto = static::noHtml($this->nombrecorto);
@@ -298,10 +308,9 @@ class Empresa {
         } elseif (strlen($this->nombre) < strlen($this->nombrecorto)) {
             $this->miniLog->alert($this->i18n->trans('company-short-name-smaller-name'));
         } else {
-            $status = TRUE;
+            $status = true;
         }
 
         return $status;
     }
-
 }

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,7 +32,7 @@ class Empresa {
 
     /**
      * Clave primaria. Integer.
-     * @var integer 
+     * @var integer
      */
     public $id;
     public $xid;
@@ -88,25 +88,25 @@ class Empresa {
 
     /**
      * URL de la web de la empresa.
-     * @var string 
+     * @var string
      */
     public $web;
 
     /**
      * Dirección de email de la empresa.
-     * @var string 
+     * @var string
      */
     public $email;
 
     /**
      * Número de fax de la empresa.
-     * @var string 
+     * @var string
      */
     public $fax;
 
     /**
      * Número de teléfono de la empresa.
-     * @var string 
+     * @var string
      */
     public $telefono;
 
@@ -212,6 +212,14 @@ class Empresa {
       ] */
     public $email_config;
 
+    /**
+     * Empresa constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'empresa', 'id');
         if ($data) {
@@ -231,7 +239,7 @@ class Empresa {
             );
 
             if ($this->xid === NULL) {
-                $this->xid = $this->randomString(30);
+                $this->xid = statis::randomString(30);
                 $this->save();
             }
         } else {
@@ -268,26 +276,26 @@ class Empresa {
     public function test() {
         $status = FALSE;
 
-        $this->nombre = $this->noHtml($this->nombre);
-        $this->nombrecorto = $this->noHtml($this->nombrecorto);
-        $this->administrador = $this->noHtml($this->administrador);
-        $this->apartado = $this->noHtml($this->apartado);
-        $this->cifnif = $this->noHtml($this->cifnif);
-        $this->ciudad = $this->noHtml($this->ciudad);
-        $this->codpostal = $this->noHtml($this->codpostal);
-        $this->direccion = $this->noHtml($this->direccion);
-        $this->email = $this->noHtml($this->email);
-        $this->fax = $this->noHtml($this->fax);
-        $this->horario = $this->noHtml($this->horario);
-        $this->lema = $this->noHtml($this->lema);
-        $this->pie_factura = $this->noHtml($this->pie_factura);
-        $this->provincia = $this->noHtml($this->provincia);
-        $this->telefono = $this->noHtml($this->telefono);
-        $this->web = $this->noHtml($this->web);
+        $this->nombre = static::noHtml($this->nombre);
+        $this->nombrecorto = static::noHtml($this->nombrecorto);
+        $this->administrador = static::noHtml($this->administrador);
+        $this->apartado = static::noHtml($this->apartado);
+        $this->cifnif = static::noHtml($this->cifnif);
+        $this->ciudad = static::noHtml($this->ciudad);
+        $this->codpostal = static::noHtml($this->codpostal);
+        $this->direccion = static::noHtml($this->direccion);
+        $this->email = static::noHtml($this->email);
+        $this->fax = static::noHtml($this->fax);
+        $this->horario = static::noHtml($this->horario);
+        $this->lema = static::noHtml($this->lema);
+        $this->pie_factura = static::noHtml($this->pie_factura);
+        $this->provincia = static::noHtml($this->provincia);
+        $this->telefono = static::noHtml($this->telefono);
+        $this->web = static::noHtml($this->web);
 
-        if (strlen($this->nombre) < 1 || strlen($this->nombre) > 100) {
+        if (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 100)) {
             $this->miniLog->alert($this->i18n->trans('company-name-invalid'));
-        } else if (strlen($this->nombre) < strlen($this->nombrecorto)) {
+        } elseif (strlen($this->nombre) < strlen($this->nombrecorto)) {
             $this->miniLog->alert($this->i18n->trans('company-short-name-smaller-name'));
         } else {
             $status = TRUE;

--- a/Core/Model/FormaPago.php
+++ b/Core/Model/FormaPago.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -31,25 +31,25 @@ class FormaPago {
 
     /**
      * Clave primaria. Varchar (10).
-     * @var string 
+     * @var string
      */
     public $codpago;
 
     /**
      * Descripción de la forma de pago
-     * @var string 
+     * @var string
      */
     public $descripcion;
 
     /**
      * Pagados -> marca las facturas generadas como pagadas.
-     * @var string 
+     * @var string
      */
     public $genrecibos;
 
     /**
      * Código de la cuenta bancaria asociada.
-     * @var string 
+     * @var string
      */
     public $codcuenta;
 
@@ -72,6 +72,14 @@ class FormaPago {
      */
     public $vencimiento;
 
+    /**
+     * FormaPago constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'formaspago', 'codpago');
         if ($data) {
@@ -96,7 +104,7 @@ class FormaPago {
      * @return string
      */
     public function install() {
-        return "INSERT INTO " . $this->tableName() . " (codpago,descripcion,genrecibos,codcuenta,domiciliado,vencimiento)"
+        return 'INSERT INTO ' . $this->tableName() . ' (codpago,descripcion,genrecibos,codcuenta,domiciliado,vencimiento)'
                 . " VALUES ('CONT','Al contado','Pagados',NULL,FALSE,'+0day')"
                 . ",('TRANS','Transferencia bancaria','Emitidos',NULL,FALSE,'+1month')"
                 . ",('TARJETA','Tarjeta de crédito','Pagados',NULL,FALSE,'+0day')"
@@ -122,13 +130,14 @@ class FormaPago {
     /**
      * Comprueba la validez de los datos de la forma de pago.
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
-        $this->descripcion = $this->noHtml($this->descripcion);
+        $this->descripcion = static::noHtml($this->descripcion);
 
         /// comprobamos la validez del vencimiento
-        $fecha1 = Date('d-m-Y');
-        $fecha2 = Date('d-m-Y', strtotime($this->vencimiento));
+        $fecha1 = date('d-m-Y');
+        $fecha2 = date('d-m-Y', strtotime($this->vencimiento));
         if (strtotime($fecha1) > strtotime($fecha2)) {
             $this->miniLog->alert($this->i18n->trans('expiration-invalid'));
             return FALSE;
@@ -201,5 +210,4 @@ class FormaPago {
         /// y por último generamos la fecha
         return date('d-m-Y', strtotime($tmp_dia . '-' . $tmp_mes . '-' . $tmp_anyo));
     }
-
 }

--- a/Core/Model/FormaPago.php
+++ b/Core/Model/FormaPago.php
@@ -20,14 +20,18 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Forma de pago de una factura, albarán, pedido o presupuesto.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class FormaPago {
-
-    use \FacturaScripts\Core\Base\Model;
+class FormaPago
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar (10).
@@ -55,14 +59,14 @@ class FormaPago {
 
     /**
      * Para indicar si hay que mostrar la cuenta bancaria del cliente.
-     * @var boolean
+     * @var bool
      */
     public $domiciliado;
 
     /**
      * TRUE (por defecto) -> mostrar los datos en documentos de venta,
      * incluida la cuenta bancaria asociada.
-     * @var boolean
+     * @var bool
      */
     public $imprimir;
 
@@ -75,27 +79,29 @@ class FormaPago {
     /**
      * FormaPago constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'formaspago', 'codpago');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
         }
     }
 
-    public function clear() {
-        $this->codpago = NULL;
+    public function clear()
+    {
+        $this->codpago = null;
         $this->descripcion = '';
         $this->genrecibos = 'Emitidos';
         $this->codcuenta = '';
-        $this->domiciliado = FALSE;
-        $this->imprimir = TRUE;
+        $this->domiciliado = false;
+        $this->imprimir = true;
         $this->vencimiento = '+1day';
     }
 
@@ -103,36 +109,41 @@ class FormaPago {
      * Crea la consulta necesaria para crear una nueva forma de pago en la base de datos.
      * @return string
      */
-    public function install() {
-        return 'INSERT INTO ' . $this->tableName() . ' (codpago,descripcion,genrecibos,codcuenta,domiciliado,vencimiento)'
-                . " VALUES ('CONT','Al contado','Pagados',NULL,FALSE,'+0day')"
-                . ",('TRANS','Transferencia bancaria','Emitidos',NULL,FALSE,'+1month')"
-                . ",('TARJETA','Tarjeta de crédito','Pagados',NULL,FALSE,'+0day')"
-                . ",('PAYPAL','PayPal','Pagados',NULL,FALSE,'+0day');";
+    public function install()
+    {
+        return 'INSERT INTO ' . $this->tableName()
+            . ' (codpago,descripcion,genrecibos,codcuenta,domiciliado,vencimiento)'
+            . " VALUES ('CONT','Al contado','Pagados',NULL,FALSE,'+0day')"
+            . ",('TRANS','Transferencia bancaria','Emitidos',NULL,FALSE,'+1month')"
+            . ",('TARJETA','Tarjeta de crédito','Pagados',NULL,FALSE,'+0day')"
+            . ",('PAYPAL','PayPal','Pagados',NULL,FALSE,'+0day');";
     }
 
     /**
      * Devuelve la URL donde ver/modificar los datos
      * @return string
      */
-    public function url() {
+    public function url()
+    {
         return 'index.php?page=contabilidad_formas_pago';
     }
 
     /**
      * Devuelve TRUE si esta es la forma de pago predeterminada de la empresa
-     * @return boolean
+     * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ( $this->codpago === $this->defaultItems->codPago() );
     }
 
     /**
      * Comprueba la validez de los datos de la forma de pago.
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
+    public function test()
+    {
         $this->descripcion = static::noHtml($this->descripcion);
 
         /// comprobamos la validez del vencimiento
@@ -140,10 +151,10 @@ class FormaPago {
         $fecha2 = date('d-m-Y', strtotime($this->vencimiento));
         if (strtotime($fecha1) > strtotime($fecha2)) {
             $this->miniLog->alert($this->i18n->trans('expiration-invalid'));
-            return FALSE;
+            return false;
         }
 
-        return TRUE;
+        return true;
     }
 
     /**
@@ -153,7 +164,8 @@ class FormaPago {
      * @param string $dias_de_pago dias de pago específicos para el cliente (separados por comas).
      * @return string
      */
-    public function calcularVencimiento($fecha_inicio, $dias_de_pago = '') {
+    public function calcularVencimiento($fecha_inicio, $dias_de_pago = '')
+    {
         $fecha = $this->calcularVencimiento2($fecha_inicio);
 
         /// validamos los días de pago
@@ -164,7 +176,7 @@ class FormaPago {
             }
         }
 
-        if ($array_dias !== NULL) {
+        if ($array_dias !== null) {
             foreach ($array_dias as $i => $dia_de_pago) {
                 if ($i === 0) {
                     $fecha = $this->calcularVencimiento2($fecha_inicio, $dia_de_pago);
@@ -187,7 +199,8 @@ class FormaPago {
      * @param string|integer $dia_de_pago
      * @return string
      */
-    private function calcularVencimiento2($fecha_inicio, $dia_de_pago = 0) {
+    private function calcularVencimiento2($fecha_inicio, $dia_de_pago = 0)
+    {
         if ($dia_de_pago === 0) {
             return date('d-m-Y', strtotime($fecha_inicio . ' ' . $this->vencimiento));
         }

--- a/Core/Model/FormaPago.php
+++ b/Core/Model/FormaPago.php
@@ -78,9 +78,7 @@ class FormaPago
 
     /**
      * FormaPago constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */
@@ -94,6 +92,9 @@ class FormaPago
         }
     }
 
+    /**
+     * TODO
+     */
     public function clear()
     {
         $this->codpago = null;

--- a/Core/Model/FormaPago.php
+++ b/Core/Model/FormaPago.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Page.php
+++ b/Core/Model/Page.php
@@ -69,9 +69,7 @@ class Page
 
     /**
      * Page constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/Page.php
+++ b/Core/Model/Page.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Page.php
+++ b/Core/Model/Page.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,13 +32,13 @@ class Page {
     /**
      * Clave primaria. Varchar (30).
      * Nombre de la página (controlador).
-     * @var string 
+     * @var string
      */
     public $name;
 
     /**
      * Título de la página.
-     * @var string 
+     * @var string
      */
     public $title;
     public $menu;
@@ -51,6 +51,14 @@ class Page {
     public $showonmenu;
     public $orden;
 
+    /**
+     * Page constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'fs_pages', 'name');
         if ($data) {
@@ -60,6 +68,9 @@ class Page {
         }
     }
 
+    /**
+     * TODO
+     */
     public function clear() {
         $this->name = NULL;
         $this->title = NULL;
@@ -69,25 +80,36 @@ class Page {
         $this->orden = 100;
     }
 
+    /**
+     * @return string
+     */
     protected function install() {
-        return "INSERT INTO " . $this->tableName() . " (name,title,menu,submenu,showonmenu)"
+        return 'INSERT INTO ' . $this->tableName() . ' (name,title,menu,submenu,showonmenu)'
                 . " VALUES ('AdminHome','Panel de control','admin',NULL,TRUE);";
     }
 
+    /**
+     * @return string
+     */
     public function url() {
-        if (is_null($this->name)) {
+        if ($this->name === NULL) {
             return 'index.php?page=AdminHome';
         }
 
         return 'index.php?page=' . $this->name;
     }
 
+    /**
+     * @return bool
+     */
     public function isDefault() {
         return ( $this->name === $this->defaultItems->defaultPage() );
     }
 
+    /**
+     * @return bool
+     */
     public function showing() {
         return ( $this->name === $this->defaultItems->showingPage() );
     }
-
 }

--- a/Core/Model/Page.php
+++ b/Core/Model/Page.php
@@ -20,14 +20,18 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Elemento del menú de FacturaScripts, cada uno se corresponde con un controlador.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Page {
-
-    use \FacturaScripts\Core\Base\Model;
+class Page
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar (30).
@@ -41,27 +45,40 @@ class Page {
      * @var string
      */
     public $title;
+    /**
+     * TODO
+     * @var
+     */
     public $menu;
+    /**
+     * TODO
+     * @var
+     */
     public $submenu;
 
     /**
      * FALSE -> ocultar en el menú.
-     * @var boolean
+     * @var bool
      */
     public $showonmenu;
+    /**
+     * TODO
+     * @var
+     */
     public $orden;
 
     /**
      * Page constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'fs_pages', 'name');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -71,28 +88,33 @@ class Page {
     /**
      * TODO
      */
-    public function clear() {
-        $this->name = NULL;
-        $this->title = NULL;
-        $this->menu = NULL;
-        $this->submenu = NULL;
-        $this->showonmenu = TRUE;
+    public function clear()
+    {
+        $this->name = null;
+        $this->title = null;
+        $this->menu = null;
+        $this->submenu = null;
+        $this->showonmenu = true;
         $this->orden = 100;
     }
 
     /**
+     * TODO
      * @return string
      */
-    protected function install() {
+    protected function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (name,title,menu,submenu,showonmenu)'
                 . " VALUES ('AdminHome','Panel de control','admin',NULL,TRUE);";
     }
 
     /**
+     * TODO
      * @return string
      */
-    public function url() {
-        if ($this->name === NULL) {
+    public function url()
+    {
+        if ($this->name === null) {
             return 'index.php?page=AdminHome';
         }
 
@@ -100,16 +122,20 @@ class Page {
     }
 
     /**
+     * TODO
      * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ( $this->name === $this->defaultItems->defaultPage() );
     }
 
     /**
+     * TODO
      * @return bool
      */
-    public function showing() {
+    public function showing()
+    {
         return ( $this->name === $this->defaultItems->showingPage() );
     }
 }

--- a/Core/Model/PageRule.php
+++ b/Core/Model/PageRule.php
@@ -54,7 +54,7 @@ class PageRule
 
     /**
      * Otorga permisos al usuario a eliminar elementos en la página.
-     * @var boolean
+     * @var bool
      */
     public $allowdelete;
 
@@ -66,9 +66,7 @@ class PageRule
 
     /**
      * PageRule constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/PageRule.php
+++ b/Core/Model/PageRule.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/PageRule.php
+++ b/Core/Model/PageRule.php
@@ -20,16 +20,24 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Define que un usuario tiene acceso a una página concreta
  * y si tiene permisos de eliminación en esa página.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class PageRule {
+class PageRule
+{
+    use Model;
 
-    use \FacturaScripts\Core\Base\Model;
-
+    /**
+     * TODO
+     * @var
+     */
     public $id;
 
     /**
@@ -49,19 +57,25 @@ class PageRule {
      * @var boolean
      */
     public $allowdelete;
+
+    /**
+     * TODO
+     * @var
+     */
     public $allowupdate;
 
     /**
      * PageRule constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'fs_access', 'id');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();

--- a/Core/Model/PageRule.php
+++ b/Core/Model/PageRule.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,7 +34,7 @@ class PageRule {
 
     /**
      * Nick del usuario.
-     * @var string 
+     * @var string
      */
     public $nick;
 
@@ -46,11 +46,19 @@ class PageRule {
 
     /**
      * Otorga permisos al usuario a eliminar elementos en la página.
-     * @var boolean 
+     * @var boolean
      */
     public $allowdelete;
     public $allowupdate;
 
+    /**
+     * PageRule constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'fs_access', 'id');
         if ($data) {
@@ -59,5 +67,4 @@ class PageRule {
             $this->clear();
         }
     }
-
 }

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -20,14 +20,18 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Un país, por ejemplo España.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Pais {
-
-    use \FacturaScripts\Core\Base\Model;
+class Pais
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar(3).
@@ -52,14 +56,15 @@ class Pais {
     /**
      * Pais constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'paises', 'codpais');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -70,7 +75,8 @@ class Pais {
      * Crea la consulta necesaria para crear los paises en la base de datos.
      * @return string
      */
-    public function install() {
+    public function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (codpais,codiso,nombre)'
                 . " VALUES ('ESP','ES','España'),"
                 . " ('AFG','AF','Afganistán'),"
@@ -319,8 +325,9 @@ class Pais {
      * Devuelve la URL donde ver/modificar los datos
      * @return string
      */
-    public function url() {
-        if ($this->codpais === NULL) {
+    public function url()
+    {
+        if ($this->codpais === null) {
             return 'index.php?page=admin_paises';
         }
 
@@ -329,33 +336,41 @@ class Pais {
 
     /**
      * Devuelve TRUE si el pais es el predeterminado de la empresa
-     * @return boolean
+     * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ( $this->codpais === $this->defaultItems->codPais() );
     }
 
     /**
      * Devuelve el pais con codido = $cod
+     *
      * @param string $cod
-     * @return pais|boolean
+     *
+     * @return pais|bool
+     * @throws TranslationInvalidArgumentException
+     * @throws RuntimeException
      */
-    public function getByIso($cod) {
-        $data = $this->dataBase->select('SELECT * FROM ' . $this->tableName() . ' WHERE codiso = ' . $this->var2str($cod) . ';');
+    public function getByIso($cod)
+    {
+        $sql = 'SELECT * FROM ' . $this->tableName() . ' WHERE codiso = ' . $this->var2str($cod) . ';';
+        $data = $this->dataBase->select($sql);
         if ($data) {
             return new Pais($data[0]);
         }
 
-        return FALSE;
+        return false;
     }
 
     /**
      * Comprueba los datos del pais, devuelve TRUE si son correctos
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
-        $status = FALSE;
+    public function test()
+    {
+        $status = false;
 
         $this->codpais = trim($this->codpais);
         $this->nombre = static::noHtml($this->nombre);
@@ -365,7 +380,7 @@ class Pais {
         } elseif (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 100)) {
             $this->miniLog->alert($this->i18n->trans('country-name-invalid'));
         } else {
-            $status = TRUE;
+            $status = true;
         }
 
         return $status;

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,7 +26,7 @@ namespace FacturaScripts\Core\Model;
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
 class Pais {
-    
+
     use \FacturaScripts\Core\Base\Model;
 
     /**
@@ -39,16 +39,24 @@ class Pais {
     /**
      * Código alfa-2 del país.
      * http://es.wikipedia.org/wiki/ISO_3166-1
-     * @var string 
+     * @var string
      */
     public $codiso;
 
     /**
      * Nombre del pais.
-     * @var string 
+     * @var string
      */
     public $nombre;
 
+    /**
+     * Pais constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'paises', 'codpais');
         if ($data) {
@@ -63,7 +71,7 @@ class Pais {
      * @return string
      */
     public function install() {
-        return "INSERT INTO " . $this->tableName() . " (codpais,codiso,nombre)"
+        return 'INSERT INTO ' . $this->tableName() . ' (codpais,codiso,nombre)'
                 . " VALUES ('ESP','ES','España'),"
                 . " ('AFG','AF','Afganistán'),"
                 . " ('ALB','AL','Albania'),"
@@ -312,7 +320,7 @@ class Pais {
      * @return string
      */
     public function url() {
-        if (is_null($this->codpais)) {
+        if ($this->codpais === NULL) {
             return 'index.php?page=admin_paises';
         }
 
@@ -333,7 +341,7 @@ class Pais {
      * @return pais|boolean
      */
     public function getByIso($cod) {
-        $data = $this->dataBase->select("SELECT * FROM " . $this->tableName() . " WHERE codiso = " . $this->var2str($cod) . ";");
+        $data = $this->dataBase->select('SELECT * FROM ' . $this->tableName() . ' WHERE codiso = ' . $this->var2str($cod) . ';');
         if ($data) {
             return new Pais($data[0]);
         }
@@ -344,16 +352,17 @@ class Pais {
     /**
      * Comprueba los datos del pais, devuelve TRUE si son correctos
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
         $status = FALSE;
 
         $this->codpais = trim($this->codpais);
-        $this->nombre = $this->noHtml($this->nombre);
+        $this->nombre = static::noHtml($this->nombre);
 
-        if (!preg_match("/^[A-Z0-9]{1,20}$/i", $this->codpais)) {
+        if (!preg_match('/^[A-Z0-9]{1,20}$/i', $this->codpais)) {
             $this->miniLog->alert($this->i18n->trans('country-cod-invalid', [$this->codpais]));
-        } else if (strlen($this->nombre) < 1 || strlen($this->nombre) > 100) {
+        } elseif (!(strlen($this->nombre) > 1) && !(strlen($this->nombre) < 100)) {
             $this->miniLog->alert($this->i18n->trans('country-name-invalid'));
         } else {
             $status = TRUE;
@@ -361,5 +370,4 @@ class Pais {
 
         return $status;
     }
-
 }

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -356,7 +356,7 @@ class Pais
     {
         $sql = 'SELECT * FROM ' . $this->tableName() . ' WHERE codiso = ' . $this->var2str($cod) . ';';
         $data = $this->dataBase->select($sql);
-        if ($data) {
+        if (!empty($data)) {
             return new Pais($data[0]);
         }
 

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -55,9 +55,7 @@ class Pais
 
     /**
      * Pais constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */
@@ -345,9 +343,7 @@ class Pais
 
     /**
      * Devuelve el pais con codido = $cod
-     *
      * @param string $cod
-     *
      * @return pais|bool
      * @throws TranslationInvalidArgumentException
      * @throws RuntimeException

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Rol.php
+++ b/Core/Model/Rol.php
@@ -49,9 +49,7 @@ class Rol
 
     /**
      * Rol constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/Rol.php
+++ b/Core/Model/Rol.php
@@ -21,30 +21,44 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Define un paquete de permisos para asignar rápidamente a usuarios.
  *
  * @author Joe Nilson            <joenilson at gmail.com>
  * @author Carlos García Gómez   <neorazorx at gmail.com>
  */
-class Rol {
+class Rol
+{
+    use Model;
 
-    use \FacturaScripts\Core\Base\Model;
-
+    /**
+     * TODO
+     * @var mixed
+     */
     public $codrol;
+
+    /**
+     * TODO
+     * @var mixed
+     */
     public $descripcion;
 
     /**
      * Rol constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'fs_roles', 'codrol');
-        if ($data) {
+        if (!empty($data)) {
             $this->codrol = $data['codrol'];
             $this->descripcion = $data['descripcion'];
         } else {
@@ -55,16 +69,19 @@ class Rol {
     /**
      * TODO
      */
-    public function clear() {
-        $this->codrol = NULL;
-        $this->descripcion = NULL;
+    public function clear()
+    {
+        $this->codrol = null;
+        $this->descripcion = null;
     }
 
     /**
+     * TODO
      * @return string
      */
-    public function url() {
-        if ($this->codrol === NULL) {
+    public function url()
+    {
+        if ($this->codrol === null) {
             return 'index.php?page=AdminRol';
         }
 
@@ -72,10 +89,12 @@ class Rol {
     }
 
     /**
+     * TODO
      * @return bool
      */
-    public function test() {
+    public function test()
+    {
         $this->descripcion = static::noHtml($this->descripcion);
-        return TRUE;
+        return true;
     }
 }

--- a/Core/Model/Rol.php
+++ b/Core/Model/Rol.php
@@ -34,6 +34,14 @@ class Rol {
     public $codrol;
     public $descripcion;
 
+    /**
+     * Rol constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'fs_roles', 'codrol');
         if ($data) {
@@ -44,22 +52,30 @@ class Rol {
         }
     }
 
+    /**
+     * TODO
+     */
     public function clear() {
         $this->codrol = NULL;
         $this->descripcion = NULL;
     }
 
+    /**
+     * @return string
+     */
     public function url() {
-        if (is_null($this->codrol)) {
+        if ($this->codrol === NULL) {
             return 'index.php?page=AdminRol';
         }
 
         return 'index.php?page=AdminRol&codrol=' . $this->codrol;
     }
-    
+
+    /**
+     * @return bool
+     */
     public function test() {
-        $this->descripcion = $this->noHtml($this->descripcion);
+        $this->descripcion = static::noHtml($this->descripcion);
         return TRUE;
     }
-
 }

--- a/Core/Model/Rol.php
+++ b/Core/Model/Rol.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2016 Joe Nilson             <joenilson at gmail.com>
  * Copyright (C) 2017 Carlos García Gómez    <neorazorx at gmail.com>

--- a/Core/Model/RolAccess.php
+++ b/Core/Model/RolAccess.php
@@ -67,9 +67,7 @@ class RolAccess
 
     /**
      * RolAccess constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/RolAccess.php
+++ b/Core/Model/RolAccess.php
@@ -37,6 +37,14 @@ class RolAccess {
     public $allowdelete;
     public $allowupdate;
 
+    /**
+     * RolAccess constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'fs_roles_access', 'id');
         if ($data) {
@@ -45,5 +53,4 @@ class RolAccess {
             $this->clear();
         }
     }
-
 }

--- a/Core/Model/RolAccess.php
+++ b/Core/Model/RolAccess.php
@@ -21,33 +21,62 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Define los permisos individuales para cada página dentro de un rol de usuarios.
  *
  * @author Joe Nilson            <joenilson at gmail.com>
  * @author Carlos García Gómez   <neorazorx at gmail.com>
  */
-class RolAccess {
+class RolAccess
+{
+    use Model;
 
-    use \FacturaScripts\Core\Base\Model;
-
+    /**
+     * TODO
+     * @var
+     */
     public $id;
+
+    /**
+     * TODO
+     * @var
+     */
     public $codrol;
+
+    /**
+     * TODO
+     * @var
+     */
     public $pagename;
+
+    /**
+     * TODO
+     * @var
+     */
     public $allowdelete;
+
+    /**
+     * TODO
+     * @var
+     */
     public $allowupdate;
 
     /**
      * RolAccess constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'fs_roles_access', 'id');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();

--- a/Core/Model/RolAccess.php
+++ b/Core/Model/RolAccess.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2016 Joe Nilson             <joenilson at gmail.com>
  * Copyright (C) 2017 Carlos García Gómez    <neorazorx at gmail.com>

--- a/Core/Model/RolUser.php
+++ b/Core/Model/RolUser.php
@@ -35,6 +35,14 @@ class RolUser {
     public $codrol;
     public $nick;
 
+    /**
+     * RolUser constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'fs_roles_users', 'id');
         if ($data) {
@@ -43,5 +51,4 @@ class RolUser {
             $this->clear();
         }
     }
-
 }

--- a/Core/Model/RolUser.php
+++ b/Core/Model/RolUser.php
@@ -55,9 +55,7 @@ class RolUser
 
     /**
      * RolUser constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/RolUser.php
+++ b/Core/Model/RolUser.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2016 Joe Nilson             <joenilson at gmail.com>
  * Copyright (C) 2017 Carlos García Gómez    <neorazorx at gmail.com>

--- a/Core/Model/RolUser.php
+++ b/Core/Model/RolUser.php
@@ -21,31 +21,50 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Define la relación entre un usuario y un rol.
  *
  * @author Joe Nilson            <joenilson at gmail.com>
  * @author Carlos García Gómez   <neorazorx at gmail.com>
  */
-class RolUser {
+class RolUser
+{
+    use Model;
 
-    use \FacturaScripts\Core\Base\Model;
-
+    /**
+     * TODO
+     * @var
+     */
     public $id;
+
+    /**
+     * TODO
+     * @var
+     */
     public $codrol;
+
+    /**
+     * TODO
+     * @var
+     */
     public $nick;
 
     /**
      * RolUser constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'fs_roles_users', 'id');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();

--- a/Core/Model/Serie.php
+++ b/Core/Model/Serie.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -27,18 +27,18 @@ namespace FacturaScripts\Core\Model;
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
 class Serie {
-    
+
     use \FacturaScripts\Core\Base\Model;
 
     /**
      * Clave primaria. Varchar (2).
-     * @var string 
+     * @var string
      */
     public $codserie;
 
     /**
      * Descripción de la serie de facturación
-     * @var string 
+     * @var string
      */
     public $descripcion;
 
@@ -66,6 +66,14 @@ class Serie {
      */
     public $numfactura;
 
+    /**
+     * Serie constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'series', 'codserie');
         if ($data) {
@@ -75,6 +83,9 @@ class Serie {
         }
     }
 
+    /**
+     * TODO
+     */
     public function clear() {
         $this->codserie = '';
         $this->descripcion = '';
@@ -89,7 +100,7 @@ class Serie {
      * @return string
      */
     public function install() {
-        return "INSERT INTO " . $this->tableName() . " (codserie,descripcion,siniva,irpf) VALUES "
+        return 'INSERT INTO ' . $this->tableName() . ' (codserie,descripcion,siniva,irpf) VALUES '
                 . "('A','SERIE A',FALSE,'0'),('R','RECTIFICATIVAS',FALSE,'0');";
     }
 
@@ -98,7 +109,7 @@ class Serie {
      * @return string
      */
     public function url() {
-        if (is_null($this->codserie)) {
+        if ($this->codserie === NULL) {
             return 'index.php?page=contabilidad_series';
         }
 
@@ -116,20 +127,21 @@ class Serie {
     /**
      * Comprueba los datos de la serie, devuelve TRUE si son correctos
      * @return boolean
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     public function test() {
         $status = FALSE;
 
         $this->codserie = trim($this->codserie);
-        $this->descripcion = $this->noHtml($this->descripcion);
+        $this->descripcion = static::noHtml($this->descripcion);
 
         if ($this->numfactura < 1) {
             $this->numfactura = 1;
         }
 
-        if (!preg_match("/^[A-Z0-9]{1,2}$/i", $this->codserie)) {
+        if (!preg_match('/^[A-Z0-9]{1,2}$/i', $this->codserie)) {
             $this->miniLog->alert($this->i18n->trans('serie-cod-invalid'));
-        } else if (strlen($this->descripcion) < 1 || strlen($this->descripcion) > 100) {
+        } elseif (!(strlen($this->descripcion) > 1) && !(strlen($this->descripcion) < 100)) {
             $this->miniLog->alert($this->i18n->trans('serie-desc-invalid'));
         } else {
             $status = TRUE;
@@ -137,5 +149,4 @@ class Serie {
 
         return $status;
     }
-
 }

--- a/Core/Model/Serie.php
+++ b/Core/Model/Serie.php
@@ -72,9 +72,7 @@ class Serie
 
     /**
      * Serie constructor.
-     *
      * @param array $data
-     *
      * @throws RuntimeException
      * @throws TranslationInvalidArgumentException
      */

--- a/Core/Model/Serie.php
+++ b/Core/Model/Serie.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Model/Serie.php
+++ b/Core/Model/Serie.php
@@ -20,15 +20,19 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Una serie de facturación o contabilidad, para tener distinta numeración
  * en cada serie.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class Serie {
-
-    use \FacturaScripts\Core\Base\Model;
+class Serie
+{
+    use Model;
 
     /**
      * Clave primaria. Varchar (2).
@@ -44,7 +48,7 @@ class Serie {
 
     /**
      * TRUE -> las facturas asociadas no encluyen IVA.
-     * @var boolean
+     * @var bool
      */
     public $siniva;
 
@@ -69,14 +73,15 @@ class Serie {
     /**
      * Serie constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'series', 'codserie');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -86,12 +91,13 @@ class Serie {
     /**
      * TODO
      */
-    public function clear() {
+    public function clear()
+    {
         $this->codserie = '';
         $this->descripcion = '';
-        $this->siniva = FALSE;
+        $this->siniva = false;
         $this->irpf = 0.00;
-        $this->codejercicio = NULL;
+        $this->codejercicio = null;
         $this->numfactura = 1;
     }
 
@@ -99,7 +105,8 @@ class Serie {
      * Crea la consulta necesaria para crear una nueva serie en la base de datos.
      * @return string
      */
-    public function install() {
+    public function install()
+    {
         return 'INSERT INTO ' . $this->tableName() . ' (codserie,descripcion,siniva,irpf) VALUES '
                 . "('A','SERIE A',FALSE,'0'),('R','RECTIFICATIVAS',FALSE,'0');";
     }
@@ -108,8 +115,9 @@ class Serie {
      * Devuelve la url donde ver/modificar la serie
      * @return string
      */
-    public function url() {
-        if ($this->codserie === NULL) {
+    public function url()
+    {
+        if ($this->codserie === null) {
             return 'index.php?page=contabilidad_series';
         }
 
@@ -118,19 +126,21 @@ class Serie {
 
     /**
      * Devuelve TRUE si la serie es la predeterminada de la empresa
-     * @return boolean
+     * @return bool
      */
-    public function isDefault() {
+    public function isDefault()
+    {
         return ( $this->codserie === $this->defaultItems->codSerie() );
     }
 
     /**
      * Comprueba los datos de la serie, devuelve TRUE si son correctos
-     * @return boolean
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @return bool
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
-        $status = FALSE;
+    public function test()
+    {
+        $status = false;
 
         $this->codserie = trim($this->codserie);
         $this->descripcion = static::noHtml($this->descripcion);
@@ -144,7 +154,7 @@ class Serie {
         } elseif (!(strlen($this->descripcion) > 1) && !(strlen($this->descripcion) < 100)) {
             $this->miniLog->alert($this->i18n->trans('serie-desc-invalid'));
         } else {
-            $status = TRUE;
+            $status = true;
         }
 
         return $status;

--- a/Core/Model/User.php
+++ b/Core/Model/User.php
@@ -20,15 +20,20 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\Model;
+use FacturaScripts\Core\Base\Utils;
+use RuntimeException;
+use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
+
 /**
  * Usuario de FacturaScripts.
  *
  * @author Carlos García Gómez <neorazorx@gmail.com>
  */
-class User {
-
-    use \FacturaScripts\Core\Base\Model;
-    use \FacturaScripts\Core\Base\Utils;
+class User
+{
+    use Model;
+    use Utils;
 
     /**
      * Clave primaria. Varchar (50).
@@ -59,13 +64,13 @@ class User {
 
     /**
      * TRUE -> el usuario es un administrador.
-     * @var boolean
+     * @var bool
      */
     public $admin;
 
     /**
      * TRUE -> el usuario esta activo.
-     * @var boolean
+     * @var bool
      */
     public $enabled;
 
@@ -96,14 +101,15 @@ class User {
     /**
      * User constructor.
      *
-     * @param bool $data
+     * @param array $data
      *
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws TranslationInvalidArgumentException
      */
-    public function __construct($data = FALSE) {
+    public function __construct(array $data = [])
+    {
         $this->init(__CLASS__, 'fs_users', 'nick');
-        if ($data) {
+        if (!empty($data)) {
             $this->loadFromData($data);
         } else {
             $this->clear();
@@ -113,25 +119,27 @@ class User {
     /**
      * Reseta los valores de este objeto.
      */
-    public function clear() {
-        $this->nick = NULL;
-        $this->password = NULL;
-        $this->email = NULL;
-        $this->logkey = NULL;
-        $this->admin = FALSE;
-        $this->enabled = TRUE;
+    public function clear()
+    {
+        $this->nick = null;
+        $this->password = null;
+        $this->email = null;
+        $this->logkey = null;
+        $this->admin = false;
+        $this->enabled = true;
         $this->langcode = FS_LANG;
-        $this->homepage = NULL;
-        $this->lastactivity = NULL;
-        $this->lastip = NULL;
+        $this->homepage = null;
+        $this->lastactivity = null;
+        $this->lastip = null;
     }
 
     /**
      * Inserta valores por defecto a la tabla, en el proceso de creación de la misma.
      * @return string
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws TranslationInvalidArgumentException
      */
-    protected function install() {
+    protected function install()
+    {
         $this->miniLog->info($this->i18n->trans('created-default-admin-account'));
         return 'INSERT INTO ' . $this->tableName() . " (nick,password,admin,enabled) VALUES ('admin','"
                 . password_hash('admin', PASSWORD_DEFAULT) . "',TRUE,TRUE);";
@@ -141,8 +149,9 @@ class User {
      * Devuelve la url desde donde editar este usuario.
      * @return string
      */
-    public function url() {
-        if ($this->nick === NULL) {
+    public function url()
+    {
+        if ($this->nick === null) {
             return 'index.php?page=AdminUsers';
         }
 
@@ -150,50 +159,60 @@ class User {
     }
 
     /**
+     * TODO
      * @param $value
      */
-    public function setPassword($value) {
+    public function setPassword($value)
+    {
         $this->password = password_hash($value, PASSWORD_DEFAULT);
     }
 
     /**
+     * TODO
      * @param $value
      *
      * @return bool
      */
-    public function verifyPassword($value) {
+    public function verifyPassword($value)
+    {
         return password_verify($value, $this->password);
     }
 
     /**
+     * TODO
      * @return string
      */
-    public function newLogkey() {
+    public function newLogkey()
+    {
         $this->logkey = static::randomString(99);
         return $this->logkey;
     }
 
     /**
+     * TODO
      * @param $value
      *
      * @return bool
      */
-    public function verifyLogkey($value) {
+    public function verifyLogkey($value)
+    {
         return ($this->logkey === $value);
     }
 
     /**
+     * TODO
      * @return bool
-     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @throws TranslationInvalidArgumentException
      */
-    public function test() {
+    public function test()
+    {
         $this->nick = trim($this->nick);
 
         if (!preg_match("/^[A-Z0-9_\+\.\-]{3,50}$/i", $this->nick)) {
             $this->miniLog->alert($this->i18n->trans('invalid-user-nick', [$this->nick]));
-            return FALSE;
+            return false;
         }
 
-        return TRUE;
+        return true;
     }
 }

--- a/Core/Model/User.php
+++ b/Core/Model/User.php
@@ -154,7 +154,7 @@ class User
     /**
      * Devuelve el usuario con el nick solicitado
      * @param string $nick
-     * @return User
+     * @return User|bool
      */
     public function get($nick)
     {

--- a/Core/Model/User.php
+++ b/Core/Model/User.php
@@ -13,7 +13,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,19 +32,19 @@ class User {
 
     /**
      * Clave primaria. Varchar (50).
-     * @var string 
+     * @var string
      */
     public $nick;
 
     /**
      * Contraseña, cifrada con password_hash()
-     * @var string 
+     * @var string
      */
     private $password;
 
     /**
      * Email del usuario.
-     * @var string 
+     * @var string
      */
     public $email;
 
@@ -53,13 +53,13 @@ class User {
      * sirve para no tener que guardar la contraseña.
      * Se regenera cada vez que el cliente inicia sesión. Así se
      * impide que dos personas accedan con el mismo usuario.
-     * @var string 
+     * @var string
      */
     private $logkey;
 
     /**
      * TRUE -> el usuario es un administrador.
-     * @var boolean 
+     * @var boolean
      */
     public $admin;
 
@@ -93,6 +93,14 @@ class User {
      */
     public $lastip;
 
+    /**
+     * User constructor.
+     *
+     * @param bool $data
+     *
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function __construct($data = FALSE) {
         $this->init(__CLASS__, 'fs_users', 'nick');
         if ($data) {
@@ -121,10 +129,11 @@ class User {
     /**
      * Inserta valores por defecto a la tabla, en el proceso de creación de la misma.
      * @return string
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      */
     protected function install() {
         $this->miniLog->info($this->i18n->trans('created-default-admin-account'));
-        return "INSERT INTO " . $this->tableName() . " (nick,password,admin,enabled) VALUES ('admin','"
+        return 'INSERT INTO ' . $this->tableName() . " (nick,password,admin,enabled) VALUES ('admin','"
                 . password_hash('admin', PASSWORD_DEFAULT) . "',TRUE,TRUE);";
     }
 
@@ -133,30 +142,50 @@ class User {
      * @return string
      */
     public function url() {
-        if (is_null($this->nick)) {
+        if ($this->nick === NULL) {
             return 'index.php?page=AdminUsers';
         }
 
         return 'index.php?page=AdminUser&id=' . $this->nick;
     }
 
+    /**
+     * @param $value
+     */
     public function setPassword($value) {
         $this->password = password_hash($value, PASSWORD_DEFAULT);
     }
 
+    /**
+     * @param $value
+     *
+     * @return bool
+     */
     public function verifyPassword($value) {
         return password_verify($value, $this->password);
     }
 
+    /**
+     * @return string
+     */
     public function newLogkey() {
-        $this->logkey = $this->randomString(99);
+        $this->logkey = static::randomString(99);
         return $this->logkey;
     }
 
+    /**
+     * @param $value
+     *
+     * @return bool
+     */
     public function verifyLogkey($value) {
         return ($this->logkey === $value);
     }
 
+    /**
+     * @return bool
+     * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
+     */
     public function test() {
         $this->nick = trim($this->nick);
 
@@ -167,5 +196,4 @@ class User {
 
         return TRUE;
     }
-
 }

--- a/Core/Model/User.php
+++ b/Core/Model/User.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  carlos@facturascripts.com
  *

--- a/Core/Table/fs_pages.xml
+++ b/Core/Table/fs_pages.xml
@@ -38,7 +38,7 @@
         <tipo>integer</tipo>
         <nulo>NO</nulo>
         <defecto>100</defecto>
-    </columna>   
+    </columna>
     <restriccion>
         <nombre>fs_pages_pkey</nombre>
         <consulta>PRIMARY KEY (name)</consulta>

--- a/generateDoc.sh
+++ b/generateDoc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+command_exists () {
+    type "$1" &> /dev/null ;
+}
+
+if command_exists phpdoc ; then
+    # More info: https://www.phpdoc.org/docs/latest/guides/running-phpdocumentor.html
+    phpdoc -d Core -t doc
+else
+    echo 'Instala phpdoc para ejecutar este comando.'
+fi


### PR DESCRIPTION
En cada commit separado se pueden ir viendo el detalle en el mensaje de commit.

Ahora scrutinizer detecta con mayor facilidad bloques o porciones de código repetidos.

Como consejo general para todos, las cosas no documentadas mejor dejarlas con TODO que así los IDEs resaltan que eso está pendiente de hacer.