### PR TITLE
correccion readonly

### DIFF
--- a/Core/Base/ExtendedController/WidgetItem.php
+++ b/Core/Base/ExtendedController/WidgetItem.php
@@ -310,8 +310,8 @@ class WidgetItem
     protected function specialAttributes()
     {
         $hint = $this->getHintHTML($this->hint);
-        $readOnly = empty($this->readOnly) ? '' : ' readonly="readonly"';
-        $required = empty($this->required) ? '' : ' required="required"';
+        $readOnly = empty($this->readOnly) ? '' : ' disabled';
+        $required = empty($this->required) ? '' : ' required';
 
         return $hint . $readOnly . $required;
     }


### PR DESCRIPTION
se cambia readonly por disabled porque hay controles como checkbox y radiobutton que no admiten el readnonly, pero todos los objetos admiten el disabled.