### PR TITLE
FS2018: Cambiar diseño de dashboard de col-3 a card-columns

### DIFF
--- a/Core/View/Dashboard.html
+++ b/Core/View/Dashboard.html
@@ -25,8 +25,8 @@
         </div>
     </div>
     <div class="row">
+        <div class="card-columns" style="padding-left: 10px; padding-right: 10px;">
         {% for card in fsc.cursor %}
-        <div class="col-3">
             <div class="card {{ card.cardClass() }}">
                 <div class="card-body">
                     <p class="card-text">{{ card.descripcion }}</p>
@@ -47,9 +47,8 @@
                     <small>{{ card.fecha }}</small>
                 </div>
             </div>
-            <br/>
-        </div>
         {% endfor %}
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Se realizó el cambio de diseño del dashboard de col-3 a card-columns agregando 10px de padding lateral para despegar las tarjetas de los margenes left y right