### PR TITLE
Added support for add plugins manually

### DIFF
--- a/Core/Controller/Plugins.php
+++ b/Core/Controller/Plugins.php
@@ -204,13 +204,13 @@ class Plugins extends Base\Controller
      *
      * @param string $pluginUnziped
      *
-     * @return bool|string
+     * @return string
      */
     private function getVerifiedPluginName($pluginUnziped)
     {
         /// If contains any '-', assume that is like 'pluginname-branch-commitid'
         /// Better verify it from facturascripts.ini field name
-        $pluginFolder = substr($pluginUnziped, 0, strpos($pluginUnziped, '-'));
+        $pluginFolder = substr($pluginUnziped, 0, strpos($pluginUnziped, '-')) ?: '';
         $pluginFolder = empty($pluginFolder) ? $pluginUnziped : $pluginFolder;
         if ($pluginUnziped !== $pluginFolder) {
             $folder = $this->pm->getPluginPath() . $pluginFolder;
@@ -276,11 +276,11 @@ class Plugins extends Base\Controller
      *
      * @param string $val
      *
-     * @return int|string
+     * @return int
      */
     private function returnKBytes($val)
     {
-        $value = substr(trim($val), 0, -1);
+        $value = (int) substr(trim($val), 0, -1);
         $last = strtolower(substr($val, -1));
         switch ($last) {
             case 'g':

--- a/Core/Controller/Plugins.php
+++ b/Core/Controller/Plugins.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017  Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Base;
+use FacturaScripts\Core\Model;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Manage list of available plugins and main actions with they.
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+class Plugins extends Base\Controller
+{
+    /**
+     * List of enabled plugins.
+     * @var array
+     */
+    public $enabledPlugins;
+
+    /**
+     * PHP Upload Max File Size.
+     * @var int
+     */
+    public $uploadMaxFileSize;
+
+    /**
+     * PHP Post Max Size.
+     * @var int
+     */
+    public $postMaxSize;
+
+    /**
+     * User language.
+     * @var string
+     */
+    public $lang;
+
+    /**
+     * Plugin Manager.
+     * @var Base\PluginManager
+     */
+    public $pm;
+
+    /**
+     * Runs the controller's private logic.
+     *
+     * @param Response $response
+     * @param Model\User|null $user
+     */
+    public function privateCore(&$response, $user)
+    {
+        parent::privateCore($response, $user);
+        $this->lang = $this->request->cookies->get('fsLang');
+        $this->pm = new Base\PluginManager();
+        $this->enabledPlugins = $this->pm->enabledPlugins();
+
+        $this->disablePlugin($this->request->get('disable', ''));
+        $this->removePlugin($this->request->get('remove', ''));
+        $this->enablePlugin($this->request->get('enable', ''));
+        $this->uploadPlugin($this->request->files->get('plugin'));
+
+        $this->enabledPlugins = $this->pm->enabledPlugins();
+        $this->postMaxSize = $this->returnKBytes(ini_get('post_max_size'));
+        $this->uploadMaxFileSize = $this->returnKBytes(ini_get('upload_max_filesize'));
+    }
+
+    /**
+     * Returns basic page attributes.
+     *
+     * @return array
+     */
+    public function getPageData()
+    {
+        $pagedata = parent::getPageData();
+        $pagedata['title'] = 'plugins';
+        $pagedata['icon'] = 'fa-puzzle-piece';
+        $pagedata['menu'] = 'admin';
+
+        return $pagedata;
+    }
+
+    /**
+     * Returns if file exists.
+     *
+     * @param string $file
+     *
+     * @return bool
+     */
+    public function fileExists($file)
+    {
+        return file_exists($file);
+    }
+
+    /**
+     * Disable the plugin name received.
+     *
+     * @param string $disablePlugin
+     */
+    private function disablePlugin($disablePlugin)
+    {
+        if (!empty($disablePlugin)) {
+            if (in_array($disablePlugin, $this->enabledPlugins)) {
+                $this->pm->disable($disablePlugin);
+                $this->miniLog->error($this->i18n->trans('plugin-disabled'));
+                $this->pm->deploy();
+            } else {
+                $this->miniLog->error($this->i18n->trans('plugin-is-not-yet-enabled'));
+            }
+        }
+    }
+
+    /**
+     * Remove and disable the plugin name received.
+     *
+     * @param string $removePlugin
+     */
+    private function removePlugin($removePlugin)
+    {
+        if (!empty($removePlugin)) {
+            if (is_dir($this->pm->getPluginPath() . $removePlugin)) {
+                $this->pm->disable($removePlugin);
+                $this->pm->deploy();
+                $this->miniLog->error($this->i18n->trans('plugin-deleted', [$removePlugin]));
+                $this->delTree($this->pm->getPluginPath() . $removePlugin);
+            } else {
+                $this->miniLog->error($this->i18n->trans('plugin-yet-deleted', [$removePlugin]));
+            }
+        }
+    }
+
+    /**
+     * Enable the plugin name received.
+     *
+     * @param string $enablePlugin
+     */
+    private function enablePlugin($enablePlugin)
+    {
+        if (!empty($enablePlugin)) {
+            if (!in_array($enablePlugin, $this->enabledPlugins)) {
+                $this->pm->enable($enablePlugin);
+                $this->miniLog->info($this->i18n->trans('plugin-enabled'));
+            } else {
+                $this->miniLog->info($this->i18n->trans('plugin-yet-enabled'));
+            }
+            $this->pm->deploy();
+        }
+    }
+
+    /**
+     * Upload and enable a plugin.
+     *
+     * @param \Symfony\Component\HttpFoundation\File\UploadedFile[] $uploadFiles
+     */
+    private function uploadPlugin($uploadFiles)
+    {
+        if ($uploadFiles === null) {
+            //$this->miniLog->error($this->i18n->trans('file-not-uploaded'));
+        } else {
+            foreach ($uploadFiles as $uploadFile) {
+                if ($uploadFile->getMimeType() === 'application/zip') {
+                    $listFilesBefore = array_diff(scandir($this->pm->getPluginPath(), SCANDIR_SORT_ASCENDING), ['.', '..']);
+                    $result = $this->unzipFile($uploadFile->getPathname(), $this->pm->getPluginPath(), $listFilesBefore);
+                    if ($result === true) {
+                        $listFilesAfter = array_diff(scandir($this->pm->getPluginPath(), SCANDIR_SORT_ASCENDING), ['.', '..']);
+                        /// Contains added files on a list
+                        $diffFolders = array_diff($listFilesAfter, $listFilesBefore);
+                        foreach ($diffFolders as $folder) {
+                            $pluginName = $this->getVerifiedPluginName($folder);
+                            $this->miniLog->info($this->i18n->trans('plugin-installed', [$pluginName]));
+                            $this->enablePlugin($pluginName);
+                        }
+                    } else {
+                        $this->miniLog->error($this->i18n->trans('can-not-open-zip-file', [$result]));
+                    }
+                    unlink($uploadFile->getPathname());
+                } else {
+                    $this->miniLog->error($this->i18n->trans('file-not-supported'));
+                }
+            }
+        }
+    }
+
+    /**
+     * Return the verified name, if its different than extracted folder, also rename it.
+     *
+     * @param string $pluginUnziped
+     *
+     * @return bool|string
+     */
+    private function getVerifiedPluginName($pluginUnziped)
+    {
+        /// If contains any '-', assume that is like 'pluginname-branch-commitid'
+        /// Better verify it from facturascripts.ini field name
+        $pluginFolder = substr($pluginUnziped, 0, strpos($pluginUnziped, '-'));
+        $pluginFolder = empty($pluginFolder) ? $pluginUnziped : $pluginFolder;
+        if ($pluginUnziped !== $pluginFolder) {
+            $folder = $this->pm->getPluginPath() . $pluginFolder;
+            if (file_exists($folder) && is_dir($folder)) {
+                $this->miniLog->info($this->i18n->trans('removing-previous-version', [$pluginFolder]));
+                $this->delTree($folder);
+            }
+            if (!@rename($this->pm->getPluginPath() . $pluginUnziped, $folder)) {
+                $this->miniLog->error($this->i18n->trans('plugin-can-not-renamed', [$pluginUnziped, $pluginFolder]));
+            } else {
+                $this->miniLog->info($this->i18n->trans('plugin-renamed', [$pluginUnziped, $pluginFolder]));
+            }
+        }
+        return $pluginFolder;
+    }
+
+    /**
+     * Unzip the file path to destiny folder.
+     *
+     * @param string $filePath
+     * @param string $destinyFolder
+     * @param array $listFilesBefore
+     *
+     * @return mixed
+     */
+    private function unzipFile($filePath, $destinyFolder, &$listFilesBefore)
+    {
+        $zipFile = new \ZipArchive();
+        $result = $zipFile->open($filePath);
+        $folder = str_replace('/', '', $zipFile->getNameIndex(0));
+        $pluginName = $this->getVerifiedPluginName($folder);
+        if (is_dir($destinyFolder . $pluginName)) {
+            $this->miniLog->info($this->i18n->trans('removing-previous-version', [$pluginName]));
+            $this->delTree($destinyFolder . $pluginName);
+            /// Update the list before, if we delete an existing folder
+            $listFilesBefore = array_diff(scandir($this->pm->getPluginPath(), SCANDIR_SORT_ASCENDING), ['.', '..']);
+        }
+        if ($result === true) {
+            $zipFile->extractTo($destinyFolder);
+            $zipFile->close();
+        }
+        return $result;
+    }
+
+    /**
+     * Recursive delete directory.
+     *
+     * @param string $dir
+     *
+     * @return bool
+     */
+    private function delTree($dir)
+    {
+        $files = array_diff(scandir($dir, SCANDIR_SORT_ASCENDING), ['.', '..']);
+        foreach ($files as $file) {
+            is_dir($dir . '/' . $file) ? $this->delTree("$dir/$file") : unlink("$dir/$file");
+        }
+        return rmdir($dir);
+    }
+
+    /**
+     * Return the unit of $val in KBytes.
+     *
+     * @param string $val
+     *
+     * @return int|string
+     */
+    private function returnKBytes($val)
+    {
+        $value = substr(trim($val), 0, -1);
+        $last = strtolower(substr($val, -1));
+        switch ($last) {
+            case 'g':
+                $value *= 1024;
+            case 'm':
+                $value *= 1024;
+        }
+        return $value;
+    }
+}

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -983,5 +983,16 @@
     "epigraph-group": "Epigraph group",
     "id-account-special": "Id. Account special",
     "sub-account": "Sub-account",
-    "idaccount": "Id. Account"
+    "idaccount": "Id. Account",
+    "add-new-plugin": "Add new plugin",
+    "select-plugin-zip-file": "Select plugin zip file:",
+    "plugin-is-not-yet-enabled": "Plugin is not yet enabled",
+    "plugin-yet-deleted": "Plugin yet deleted",
+    "plugin-yet-enabled": "Plugin yet enabled",
+    "plugin-installed": "Plugin installed",
+    "can-not-open-zip-file": "Can't open zip file '0'",
+    "file-not-supported": "File not supported",
+    "plugin-renamed": "Plugin renamed from '0' to '1'",
+    "removing-previous-version": "Removing previous version '0'",
+    "plugin-can-not-renamed": "Plugin '0' can't be renamed to '1'"
 }

--- a/Core/View/Plugins.html
+++ b/Core/View/Plugins.html
@@ -1,0 +1,172 @@
+{% extends "Master/MenuTemplate.html" %}
+
+{% set langCode = fsc.lang|slice(0, 2)|lower %}
+
+{% block css %}
+    {{ parent() }}
+    <link href="node_modules/bootstrap-fileinput/css/fileinput.min.css" media="all" rel="stylesheet" type="text/css" />
+{% endblock %}
+
+{% block javascript %}
+    {{ parent() }}
+    <script src="node_modules/bootstrap-fileinput/js/fileinput.min.js"></script>
+    {% set absFileInputLocale = [constant('FS_FOLDER'), '/', 'node_modules/bootstrap-fileinput/js/locales/', langCode, '.js']|join %}
+    {% set relFileInputLocale = ['node_modules/bootstrap-fileinput/js/locales/', langCode, '.js']|join %}
+    {% if fsc.fileExists(absFileInputLocale) == true %}
+    <script src="{{ relFileInputLocale }}"></script>
+    {% endif %}
+    <script src="node_modules/bootstrap-fileinput/themes/fa/theme.min.js"></script>
+{% endblock %}
+
+{% block body %}
+
+<!-- Calculate texts according to language -->
+{% set refresh = i18n.trans('refresh-page') %}
+{% set defaultT, defaultF = i18n.trans('mark-as-homepage'), i18n.trans('marked-as-homepage') %}
+{% set add = i18n.trans('add') %}
+{% set disable, enable, delete = i18n.trans('disable'), i18n.trans('enable'), i18n.trans('delete') %}
+
+<!-- Macros Template Imports -->
+{% from 'Macro/Utils.html' import popoverTitle as popoverTitle %}
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-6">
+            <span class="btn-group d-xs-none">
+                <a class="btn btn-sm btn-outline-secondary" href="{{ fsc.url() }}" {{ popoverTitle(refresh, 'bottom') }}>
+                    <i class="fa fa-refresh" aria-hidden="true"></i>
+                </a>
+                {% if fsc.getPageData()['name'] == fsc.user.homepage %}
+                <a class="btn btn-sm btn-outline-secondary active" href="{{ fsc.url() }}&amp;defaultPage=FALSE" {{ popoverTitle(defaultF, 'bottom') }}>
+                    <i class="fa fa-bookmark" aria-hidden="true"></i>
+                </a>
+                {% else %}
+                <a class="btn btn-sm btn-outline-secondary" href="{{ fsc.url() }}&amp;defaultPage=TRUE" {{ popoverTitle(defaultT, 'bottom') }}>
+                    <i class="fa fa-bookmark-o" aria-hidden="true"></i>
+                </a>
+                {% endif %}
+            </span>
+            <span class="btn-group d-xs-none">
+                <button type="button" class="btn btn-sm btn-success" data-toggle="modal" data-target="#addPlugin">
+                    <i class="fa fa-plus" aria-hidden="true"></i>
+                    <span class="d-none d-sm-inline-block">&nbsp;{{ add }}</span>
+                </button>
+            </span>
+        </div>
+        <div class="col-6 text-right">
+            <h2>
+                <i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i>
+                {{ i18n.trans(fsc.getPageData()['name']) }}
+
+            </h2>
+        </div>
+    </div>
+</div>
+
+<!--
+    List of plugins available for download and row colored for enabled or unstable
+-->
+<div class="table-responsive">
+    <table class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th scope="col">{{ i18n.trans('name') }}</th>
+                <th scope="col">{{ i18n.trans('description') }}</th>
+                <th class="text-right" scope="col">{{ i18n.trans('actions') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% if fsc.pm.installedPlugins is empty %}
+            <tr class="table-warning">
+                <td colspan="3"><b>{{ i18n.trans('no-data') }}</b></td>
+            </tr>
+        {% else %}
+            {% for plugin in fsc.pm.installedPlugins %}
+                {% if plugin in fsc.enabledPlugins %}
+                    <tr class="table-primary">
+                {% else %}
+                    <tr>
+                {% endif %}
+                    <td><b>{{ plugin }}</b></td>
+                    <td></td>
+                    <td class="text-right">
+                        <span class="btn-group d-xs-none">
+                            {% if plugin in fsc.enabledPlugins %}
+                            <a class="btn btn-sm btn-secondary" href="{{ fsc.url() }}&amp;disable={{ plugin }}" {{ popoverTitle(disable, 'bottom') }}>
+                                <i class="fa fa-close" aria-hidden="true"></i>
+                                <span class="d-none d-sm-inline-block">&nbsp;{{ disable }}</span>
+                            </a>
+                            {% else %}
+                            <a class="btn btn-sm btn-primary" href="{{ fsc.url() }}&amp;enable={{ plugin }}" {{ popoverTitle(enable, 'bottom') }}>
+                                <i class="fa fa-check" aria-hidden="true"></i>
+                                <span class="d-none d-sm-inline-block">&nbsp;{{ enable }}</span>
+                            </a>
+                            {% endif %}
+                            <a class="btn btn-sm btn-danger" href="{{ fsc.url() }}&amp;remove={{ plugin }}" {{ popoverTitle(delete, 'bottom') }}>
+                                <i class="fa fa-trash" aria-hidden="true"></i>
+                                <span class="d-none d-sm-inline-block">&nbsp;{{ delete }}</span>
+                            </a>
+                        </span>
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endif %}
+        </tbody>
+    </table>
+</div>
+
+<!--
+    Modal for add new plugins
+-->
+<form action="{{ fsc.url() }}" name="upload-plugins" method="post" class="form" enctype="multipart/form-data">
+    <div class="modal fade" id="addPlugin" tabindex="-1" role="dialog" aria-labelledby="addPluginLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="addPluginLabel">{{ i18n.trans('add-new-plugin') }}</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{{ i18n.trans('close') }}">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label class="control-label" for="plugin">{{ i18n.trans('select-plugin-zip-file') }}</label>
+                        <div class="file-loading">
+                            <input id="plugin" name="plugin[]" type="file" multiple>
+                        </div>
+                        <div id="file-upload-errors" class="help-block"></div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ i18n.trans('cancel') }}</button>
+                    <button type="submit" class="btn btn-primary">{{ i18n.trans('continue') }}</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>
+
+<script type="text/javascript">
+    var input = $("#plugin");
+    input.fileinput({
+        theme: "fa",
+        uploadUrl: "{{ fsc.url() }}",
+        uploadAsync: false,
+        showUpload: false,
+        showRemove: false,
+        dropZoneEnabled: true,
+        browseOnZoneClick: false,
+        fileActionSettings: {showDrag: false, showUpload: false, showZoom: false},
+        language: "{{ langCode }}",
+        allowedFileExtensions: ["zip"],
+        overwriteInitial: false,
+        previewFileIcon: '<i class="fa fa-file-archive-o"></i>',
+        browseClass: "btn btn-success",
+        allowedPreviewTypes: false,
+        elErrorContainer: '#file-upload-errors',
+        minFileCount: 1,
+        maxFileCount: 10,
+        maxFileSize: {{ fsc.uploadMaxFileSize }}
+    });
+</script>
+{% endblock %}

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   "dependencies": {
     "bootbox": "^4.x",
     "bootstrap": "4.0.0-beta.2",
+    "bootstrap-fileinput": "^4.4.6",
     "font-awesome": "^4.x",
+    "handsontable": "^0.34.x",
     "jquery": "^3.x",
     "jscolor-picker": "^2.0.4",
-    "popper.js": "^1.12.6",
-    "handsontable": "^0.34.x"
+    "popper.js": "^1.12.6"
   }
 }


### PR DESCRIPTION
- Core/Base/PluginManager.php:
   - Added support to return plugin path folder.
   - Method loadFromFile now don't return [0 => ''].
   - Added method to return all installed plugins from folder.
- Plugins.(php/html): Added innitial support for install plugins manually.
   - Only allows to add zip files.
   - Can use drag&drop for install.
   - Have native support for internationalization (load default language file if exists, else use english).
   - Auto-verify max file size per file, not per post.
- Added new translation strings.
- Added bootstrap-fileinput dependency to npm.