### PR TITLE
PHPBlocks translations for Core/Base/Cache.

### DIFF
--- a/Core/Base/Cache/APCAdapter.php
+++ b/Core/Base/Cache/APCAdapter.php
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace FacturaScripts\Core\Base\Cache;
 
 use FacturaScripts\Core\Base\MiniLog;
@@ -66,22 +67,29 @@ class APCAdapter implements AdaptorInterface
     public function get($key)
     {
         $this->minilog->debug($this->i18n->trans('apc-get-key-item', [$key]));
-        return apc_fetch($key);
+        if (apc_exists($key)) {
+            $result = apc_fetch($key);
+            return ($result === false) ? null : $result;
+        }
+        return null;
     }
 
     /**
      * Put content into the cache.
      *
      * @param string $key
-     * @param mixed  $content   the the content you want to store
-     * @param int    $expire    time to expire
+     * @param mixed $content the the content you want to store
+     * @param int $expire time to expire
      *
      * @return bool whether if the operation was successful or not
      */
     public function set($key, $content, $expire = 5400)
     {
         $this->minilog->debug($this->i18n->trans('apc-set-key-item', [$key]));
-        return apc_store($key, $content, $expire);
+        if (apc_fetch($key) !== false) {
+            return apc_store($key, $content, $expire);
+        }
+        return apc_add($key, $content, $expire);
     }
 
     /**
@@ -105,6 +113,12 @@ class APCAdapter implements AdaptorInterface
     public function clear()
     {
         $this->minilog->debug($this->i18n->trans('apc-clear'));
-        return apc_clear_cache();
+        /**
+         * If cache_type is "user", the user cache will be cleared;
+         * otherwise, the system cache (cached files) will be cleared.
+         * On shared hostings, users only have perms to his own apache user.
+         * @source: http://php.net/manual/function.apc-clear-cache.php
+         */
+        return apc_clear_cache('user');
     }
 }

--- a/Core/Base/Cache/AdaptorInterface.php
+++ b/Core/Base/Cache/AdaptorInterface.php
@@ -20,7 +20,7 @@
 namespace FacturaScripts\Core\Base\Cache;
 
 /**
- * Description of AdaptorInterface
+ * Adaptor Interface.
  *
  * @author Carlos García Gómez <carlos@facturascripts.com>
  */

--- a/Core/Base/Cache/FileCache.php
+++ b/Core/Base/Cache/FileCache.php
@@ -94,8 +94,8 @@ class FileCache implements AdaptorInterface
      * Get the data associated with a key.
      *
      * @param string $key
-     * @param bool   $raw
-     * @param null   $custom_time
+     * @param bool $raw
+     * @param int|null $custom_time
      *
      * @return mixed the content you put in, or null if expired or not found
      */
@@ -119,8 +119,8 @@ class FileCache implements AdaptorInterface
      * Put content into the cache.
      *
      * @param string $key
-     * @param mixed  $content the the content you want to store
-     * @param bool   $raw     whether if you want to store raw data or not. If it is true, $content *must* be a string
+     * @param mixed $content the the content you want to store
+     * @param bool $raw whether if you want to store raw data or not. If it is true, $content *must* be a string
      *
      * @return bool whether if the operation was successful or not
      */
@@ -178,7 +178,7 @@ class FileCache implements AdaptorInterface
      * Check if a file has expired or not.
      *
      * @param string $file the rout to the file
-     * @param int    $time the number of minutes it was set to expire
+     * @param int $time the number of minutes it was set to expire
      *
      * @return bool if the file has expired or not
      */

--- a/Core/Base/Cache/MemcacheAdapter.php
+++ b/Core/Base/Cache/MemcacheAdapter.php
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace FacturaScripts\Core\Base\Cache;
 
 use FacturaScripts\Core\Base\MiniLog;
@@ -79,7 +80,7 @@ class MemcacheAdapter implements AdaptorInterface
             }
         }
     }
-    
+
     /**
      * Return if is connected or not.
      *
@@ -111,8 +112,8 @@ class MemcacheAdapter implements AdaptorInterface
      * Put content into the cache.
      *
      * @param string $key
-     * @param mixed  $content the the content you want to store
-     * @param int    $expire  time to expire
+     * @param mixed $content the the content you want to store
+     * @param int $expire time to expire
      *
      * @return bool whether if the operation was successful or not
      */
@@ -157,7 +158,7 @@ class MemcacheAdapter implements AdaptorInterface
         if (self::$connected) {
             return self::$memcache->flush();
         }
-        
+
         return false;
     }
 }


### PR DESCRIPTION
- APCAdapter: better code for get/set/clear (now works)