### PR TITLE
En el controlador EditProveedor, la vista de artículos debe ser

### DIFF
--- a/Core/Controller/EditProveedor.php
+++ b/Core/Controller/EditProveedor.php
@@ -26,6 +26,7 @@ use FacturaScripts\Core\Base\ExtendedController;
  * Controller to edit a single item from the Proveedor model
  *
  * @author Nazca Networks <comercial@nazcanetworks.com>
+ * @author Fco. Antonio Moreno Pérez <famphuelva@gmail.com>
  */
 class EditProveedor extends ExtendedController\PanelController
 {
@@ -38,7 +39,7 @@ class EditProveedor extends ExtendedController\PanelController
         $this->addEditView('\FacturaScripts\Dinamic\Model\Proveedor', 'EditProveedor', 'supplier');
         $this->addEditListView('\FacturaScripts\Dinamic\Model\DireccionProveedor', 'EditDireccionProveedor', 'addresses', 'fa-road');
         $this->addEditListView('\FacturaScripts\Dinamic\Model\CuentaBancoProveedor', 'EditCuentaBancoProveedor', 'bank-accounts', 'fa-university');
-        $this->addEditListView('\FacturaScripts\Dinamic\Model\ArticuloProveedor', 'EditProveedorArticulo', 'products', 'fa-cubes');
+        $this->addListView('\FacturaScripts\Dinamic\Model\ArticuloProveedor', 'ListArticuloProveedor', 'products', 'fa-cubes');
         $this->addListView('\FacturaScripts\Dinamic\Model\FacturaProveedor', 'ListFacturaProveedor', 'invoices', 'fa-files-o');
         $this->addListView('\FacturaScripts\Dinamic\Model\AlbaranProveedor', 'ListAlbaranProveedor', 'delivery-notes', 'fa-files-o');
         $this->addListView('\FacturaScripts\Dinamic\Model\PedidoProveedor', 'ListPedidoProveedor', 'orders', 'fa-files-o');
@@ -61,7 +62,7 @@ class EditProveedor extends ExtendedController\PanelController
 
             case 'EditDireccionProveedor':
             case 'EditCuentaBancoProveedor':
-            case 'EditProveedorArticulo':
+            case 'ListArticuloProveedor':
             case 'ListFacturaProveedor':
             case 'ListAlbaranProveedor':
             case 'ListPedidoProveedor':

--- a/Core/XMLView/EditAlbaranCliente.xml
+++ b/Core/XMLView/EditAlbaranCliente.xml
@@ -20,6 +20,7 @@
  * Initial description for the controller EditAlbaranCliente
  *
  * @author Carlos García Gómez <carlos@facturascripts.com>
+ * @author Fco. Antonio Moreno Pérez <famphuelva@gmail.com>
 -->
 
 <view>

--- a/Core/XMLView/EditAlbaranProveedor.xml
+++ b/Core/XMLView/EditAlbaranProveedor.xml
@@ -21,6 +21,7 @@
  *
  * @author Carlos García Gómez <carlos@facturascripts.com>
  * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+  * @author Fco. Antonio Moreno Pérez <famphuelva@gmail.com>
 -->
 
 <view>
@@ -29,22 +30,47 @@
             <column name="code" display="none" order="100">
                 <widget type="text" fieldname="idalbaran" required="true" />
             </column>
-            <column name="supplier" title="supplier" numcolumns="3" order="100">
+            <column name="numproveedor" numcolumns="3" order="140">
+                <widget type="text" fieldname="numproveedor" />
+            </column>
+            <column name="date" title="date" numcolumns="2" order="110">
+                <widget type="datepicker" fieldname="fecha" required="true" />
+            </column>
+            <column name="hour" title="hour" numcolumns="2" order="120">
+                <widget type="text" fieldname="hora" required="true" />
+            </column>
+        </group>
+         <group name="supplier" title="supplier" numcolumns="12">
+            <column name="cifnif" title="cifnif" numcolumns="4" order="120">
+                <widget type="text" fieldname="cifnif" />
+            </column>
+            <column name="supplier" title="name-or-business-name" numcolumns="3" order="110">
                 <widget type="text" fieldname="nombre" required="true" />
+            </column>
+        </group>
+        <group name="codattributes" title="attributes" numcolumns="12">
+            <column name="warehouse" numcolumns="3">
+                <widget type="select" fieldname="codalmacen">
+                    <values source="almacenes" fieldcode="codalmacen" fieldtitle="nombre"></values>
+                </widget>
             </column>
             <column name="serie" numcolumns="2" order="100">
                 <widget type="select" fieldname="codserie">
                     <values source="series" fieldcode="codserie" fieldtitle="descripcion"></values>
                 </widget>
             </column>
-            <column name="numproveedor" numcolumns="3" order="100">
-                <widget type="text" fieldname="numproveedor" />
+            <column name="payment" title="method-payment" numcolumns="3" titleurl="?page=ListFormaPago" order="120">
+                <widget type="select" fieldname="codpago">
+                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"></values>
+                </widget>
             </column>
-            <column name="date" title="date" numcolumns="2" order="100">
-                <widget type="datepicker" fieldname="fecha" required="true" />
+            <column name="currency" title="currency" numcolumns="2" titleurl="?page=ListDivisa" order="120">
+                <widget type="select" fieldname="coddivisa">
+                    <values source="divisas" fieldcode="coddivisa" fieldtitle="descripcion"></values>
+                </widget>
             </column>
-            <column name="hour" title="hour" numcolumns="2" order="100">
-                <widget type="text" fieldname="hora" required="true" />
+            <column name="tasaconv" numcolumns="2" order="150">
+                <widget type="number" fieldname="tasaconv" />
             </column>
         </group>
         <group name="notes" numcolumns="12">

--- a/Core/XMLView/EditFacturaProveedor.xml
+++ b/Core/XMLView/EditFacturaProveedor.xml
@@ -21,6 +21,7 @@
  *
  * @author Carlos García Gómez <carlos@facturascripts.com>
  * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+  * @author Fco. Antonio Moreno Pérez <famphuelva@gmail.com>
 -->
 
 <view>
@@ -29,22 +30,47 @@
             <column name="code" display="none" order="100">
                 <widget type="text" fieldname="idfactura" required="true" />
             </column>
-            <column name="supplier" title="supplier" numcolumns="3" order="100">
+            <column name="numproveedor" numcolumns="3" order="140">
+                <widget type="text" fieldname="numproveedor" />
+            </column>
+            <column name="date" title="date" numcolumns="2" order="110">
+                <widget type="datepicker" fieldname="fecha" required="true" />
+            </column>
+            <column name="hour" title="hour" numcolumns="2" order="120">
+                <widget type="text" fieldname="hora" required="true" />
+            </column>
+        </group>
+         <group name="supplier" title="supplier" numcolumns="12">
+            <column name="cifnif" title="cifnif" numcolumns="4" order="120">
+                <widget type="text" fieldname="cifnif" />
+            </column>
+            <column name="supplier" title="name-or-business-name" numcolumns="4" order="110">
                 <widget type="text" fieldname="nombre" required="true" />
+            </column>
+        </group>
+        <group name="codattributes" title="attributes" numcolumns="12">
+            <column name="warehouse" numcolumns="3">
+                <widget type="select" fieldname="codalmacen">
+                    <values source="almacenes" fieldcode="codalmacen" fieldtitle="nombre"></values>
+                </widget>
             </column>
             <column name="serie" numcolumns="2" order="100">
                 <widget type="select" fieldname="codserie">
                     <values source="series" fieldcode="codserie" fieldtitle="descripcion"></values>
                 </widget>
             </column>
-            <column name="numproveedor" numcolumns="3" order="100">
-                <widget type="text" fieldname="numproveedor" />
+            <column name="payment" title="method-payment" numcolumns="3" titleurl="?page=ListFormaPago" order="120">
+                <widget type="select" fieldname="codpago">
+                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"></values>
+                </widget>
             </column>
-            <column name="date" title="date" numcolumns="2" order="100">
-                <widget type="datepicker" fieldname="fecha" required="true" />
+            <column name="currency" title="currency" numcolumns="2" titleurl="?page=ListDivisa" order="130">
+                <widget type="select" fieldname="coddivisa">
+                    <values source="divisas" fieldcode="coddivisa" fieldtitle="descripcion"></values>
+                </widget>
             </column>
-            <column name="hour" title="hour" numcolumns="2" order="100">
-                <widget type="text" fieldname="hora" required="true" />
+            <column name="tasaconv" numcolumns="2" order="150">
+                <widget type="number" fieldname="tasaconv" />
             </column>
         </group>
         <group name="notes" numcolumns="12">

--- a/Core/XMLView/EditProveedorArticulo.xml
+++ b/Core/XMLView/EditProveedorArticulo.xml
@@ -20,11 +20,11 @@
  * Initial description for the controller EditProveedorArticulo
  *
  * @author Nazca Networks <comercial@nazcanetworks.com>
+ * @Fco. Antonio Moreno Pérez <famphuelva@gmail.com>
 -->
 
 <view>
     <columns>
-        <group name="data" numcolumns="12">   
             <column name="id" display="none" order="100">
                 <widget type="number" decimal="0" fieldname="id" readonly="true" required="true" />
             </column>
@@ -45,8 +45,6 @@
             <column name="partnumber" order="140" numcolumns="2">
                 <widget type="text" fieldname="partnumber"   />
             </column>
-        </group>
-        <group name="price" numcolumns="12">   
             <column name="precio" numcolumns="2" display="left" order="110">
                 <widget type="number" fieldname="precio" />
             </column>
@@ -64,6 +62,5 @@
             <column name="stock" order="140" numcolumns="2">
                 <widget type="text" fieldname="stock"   />
             </column>
-        </group>
     </columns>
 </view>


### PR DESCRIPTION
listView, no EditListView. Y se debe modificar editProveedorArticulo.xml 
para mostrar los resultados como en un listado, es decir, sin grupos.

Añadir todas las columnas faltantes a editFacturaProveedor.xml, 
como está en editAlbaranCliente.xml 
(a excepción de las direcciones de envío y facturación

Añadir todas las columnas faltantes a editAlbaranProveedor.xml, 
como está en editAlbaranCliente.xml 
(a excepción de las direcciones de envío y facturación)