### PR TITLE
Update Form macros to have simpleSelect receive associative arrays and remove i18n var from inputs and selects

### DIFF
--- a/Core/Controller/DocumentReports.php
+++ b/Core/Controller/DocumentReports.php
@@ -515,13 +515,13 @@ class DocumentReports extends Controller
     public function getDocumentTypes()
     {
         return [
-            'customer-estimations',
-            'customer-orders',
-            'customer-delivery-notes',
-            'customer-invoices',
-            'supplier-orders',
-            'supplier-delivery-notes',
-            'supplier-invoices'
+            'customer-estimations'    => $this->i18n->trans('customer-estimations'),
+            'customer-orders'         => $this->i18n->trans('customer-orders'),
+            'customer-delivery-notes' => $this->i18n->trans('customer-delivery-notes'),
+            'customer-invoices'       => $this->i18n->trans('customer-invoices'),
+            'supplier-orders'         => $this->i18n->trans('supplier-orders'),
+            'supplier-delivery-notes' => $this->i18n->trans('supplier-delivery-notes'),
+            'supplier-invoices'       => $this->i18n->trans('supplier-invoices')
         ];
     }
 }

--- a/Core/View/DocumentReports.html
+++ b/Core/View/DocumentReports.html
@@ -34,34 +34,34 @@
         <div class="row">
             <div class="col-md-4">
                 <div class="form-group">
-                    {{ forms.simpleSelect('source1', 'source1', fsc.source1, fsc.getDocumentTypes(), 'choose-source-1', i18n, 'fa-files-o', {onchange: 'this.form.submit()'}) }}
+                    {{ forms.simpleSelect('source1', 'source1', fsc.source1, fsc.getDocumentTypes(), i18n.trans('choose-source-1'), 'fa-files-o', {onchange: 'this.form.submit()'}) }}
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="form-group">
-                    {{ forms.simpleInput('date1-from', 'date1-form', fsc.date1From.format('d-m-Y'), 'text', i18n.trans('start-date'), 'fa-calendar', {class: 'datepicker'}) }}
+                    {{ forms.simpleInput('date1-from', 'date1-form', fsc.date1From.format('d-m-Y'), 'text', i18n.trans('start-date'), 'fa-calendar', {class: 'form-control datepicker'}) }}
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="form-group">
-                    {{ forms.simpleInput('date1-to', 'date1-to', fsc.date1To.format('d-m-Y'), 'text', i18n.trans('end-date'), 'fa-calendar', {class: 'datepicker'}) }}
+                    {{ forms.simpleInput('date1-to', 'date1-to', fsc.date1To.format('d-m-Y'), 'text', i18n.trans('end-date'), 'fa-calendar', {class: 'form-control datepicker'}) }}
                 </div>
             </div>
         </div>
         <div class="row">
             <div class="col-md-4">
                 <div class="form-group">
-                    {{ forms.simpleSelect('source2', 'source2', fsc.source2, fsc.getDocumentTypes(), 'choose-source-2', i18n, 'fa-files-o',{'onchange': 'this.form.submit()'}) }}
+                    {{ forms.simpleSelect('source2', 'source2', fsc.source2, fsc.getDocumentTypes(), i18n.trans('choose-source-2'), 'fa-files-o',{'onchange': 'this.form.submit()'}) }}
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="form-group">
-                    {{ forms.simpleInput('date2-from', 'date2-form', fsc.date2From.format('d-m-Y'), 'text', i18n.trans('start-date'), 'fa-calendar', {class: 'datepicker'}) }}
+                    {{ forms.simpleInput('date2-from', 'date2-form', fsc.date2From.format('d-m-Y'), 'text', i18n.trans('start-date'), 'fa-calendar', {class: 'form-control datepicker'}) }}
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="form-group">
-                    {{ forms.simpleInput('date2-to', 'date2-to', fsc.date2To.format('d-m-Y'), 'text', i18n.trans('end-date'), 'fa-calendar', {class: 'datepicker'}) }}
+                    {{ forms.simpleInput('date2-to', 'date2-to', fsc.date2To.format('d-m-Y'), 'text', i18n.trans('end-date'), 'fa-calendar', {class: 'form-control datepicker'}) }}
                 </div>
             </div>
         </div>

--- a/Core/View/Macro/Forms.html
+++ b/Core/View/Macro/Forms.html
@@ -53,16 +53,13 @@
         {% endif %}
 
                 <input type="{{ type }}" id="{{ id }}" name="{{ name }}" value="{{ value }}"
-                        {% if attributes.class is defined %}
-                            {% set attributes = attributes|merge({'class': 'form-control ' ~ attributes.class}) %}
-                        {% else %}
+                        {% if attributes.class is not defined %}
                             class="form-control"
                         {% endif %}
 
                         {% for attribute,attrValue in attributes %}
                             {{ attribute }}="{{ attrValue }}"
-                        {% endfor %}
-                /> {# end input #}
+                        {% endfor %} /> {# end input #}
 
         {% if icon %}
             </div>
@@ -75,23 +72,19 @@
      * @param string $id element id attribute
      * @param string $name element name attribute
      * @param string $value the default value that will be selected (must be contained in the allValues select)
-     * @param array  $allValues an indexed array with all the select options. The key will be discarded.
+     * @param array  $allValues an associative array with the select options (where the key is the option value and the
+     *               array value is the option text.
      * @param string $label NULL if no label is set. This will add a <label> element with the string as its contents.
-     * @param object $i18n NULL if no translation is needed, or the i18n object otherwise.
      * @param string $icon string identifying a FontAwesome icon (http://fontawesome.io/icons/).
      * @param array  $attributes an associative array of strings, extra attributes with their values
      *               (https://www.w3.org/TR/2017/REC-html52-20171214/sec-forms.html#the-input-element)
-     *               it shouldn't be 'id' or 'name', as those are already given, if the class attribute is given, it will
-     *               be merged with the default ones.
+     *               it shouldn't be 'id' or 'name', as those are already given, beware that if the class attribute is
+     *               given, it will override the default ones (remember to add the "form-control" class for consistency.
      */
 #}
-{% macro simpleSelect(id, name, value, allValues = {}, label = NULL, i18n = NULL, icon = NULL, attributes = NULL) %}
+{% macro simpleSelect(id, name, value, allValues = {}, label = NULL, icon = NULL, attributes = NULL) %}
     {% if label %}
-        {% if i18n %}
-        <label for="{{ name }}">{{ i18n.trans(label) }}</label>
-        {% else %}
         <label for="{{ name }}">{{ label }}</label>
-        {% endif %}
     {% endif %}
 
     {% if icon %}
@@ -102,24 +95,17 @@
     {% endif %}
 
         <select id="{{ id }}" name="{{ name }}"
-                {% if attributes.class is defined %}
-                    {% set attributes = attributes|merge({'class': 'form-control ' ~ attributes.class}) %}
-                {% else %}
-                    class="form-control"
+                {% if attributes.class is not defined %}
+                class="form-control"
                 {% endif %}
 
                 {% for attribute,attrValue in attributes %}
                     {{ attribute }}="{{ attrValue }}"
-                {% endfor %}
-        > {# end select #}
+                {% endfor %}> {# end select #}
 
-            {% for option in allValues %}
-                <option value="{{ option }}"{% if value == option %} selected="selected"{% endif %}>
-                    {% if i18n %}
-                        {{ i18n.trans(option) }}
-                    {% else %}
-                        {{ option }}
-                    {% endif %}
+            {% for key,option in allValues %}
+                <option value="{{ key }}"{% if value == key %} selected="selected"{% endif %}>
+                    {{ option }}
                 </option>
             {% endfor %}
         </select>


### PR DESCRIPTION
Change the Form Macros so that i18n is not a parameter (strings should
be translated before), simpleSelect now works with associative arrays
instead of indexed ones and the class attribute can be fully overriden (
no form-control class is added when overriding with the attributes 
parameter).
Updated DocumentReports.php and DocumentReports.html to work with the
new changes.