### PR TITLE
Added information panels in the view header

### DIFF
--- a/Core/Base/ExtendedController/EditController.php
+++ b/Core/Base/ExtendedController/EditController.php
@@ -217,6 +217,17 @@ abstract class EditController extends Base\Controller
     }
 
     /**
+     * Descriptive identifier for humans of the main data editing record
+     *
+     * @return string
+     */
+    public function getPrimaryDescription()
+    {
+        $model = $this->view->getModel();
+        return $model->primaryDescription();
+    }
+
+    /**
      * Returns the url for a specified type
      *
      * @param string $type

--- a/Core/Base/ExtendedController/PanelController.php
+++ b/Core/Base/ExtendedController/PanelController.php
@@ -199,6 +199,18 @@ abstract class PanelController extends Base\Controller
     }
 
     /**
+     * Descriptive identifier for humans of the main data editing record
+     *
+     * @return string
+     */
+    public function getPrimaryDescription()
+    {
+        $viewName = array_keys($this->views)[0];
+        $model = $this->views[$viewName]->getModel();
+        return $model->primaryDescription();
+    }
+
+    /**
      * Run the actions that alter data before reading it
      *
      * @param BaseView $view
@@ -257,12 +269,12 @@ abstract class PanelController extends Base\Controller
             $this->miniLog->alert($this->i18n->trans('not-allowed-modify'));
             return false;
         }
-        
+
         if ($view->save()) {
             $this->miniLog->notice($this->i18n->trans('record-updated-correctly'));
             return true;
         }
-        
+
         return false;
     }
 
@@ -279,13 +291,13 @@ abstract class PanelController extends Base\Controller
             $this->miniLog->alert($this->i18n->trans('not-allowed-delete'));
             return false;
         }
-        
+
         $fieldKey = $view->getModel()->primaryColumn();
         if ($view->delete($this->request->get($fieldKey))) {
             $this->miniLog->notice($this->i18n->trans('record-deleted-correctly'));
             return true;
         }
-        
+
         return false;
     }
 

--- a/Core/Base/ExtendedController/RowItem.php
+++ b/Core/Base/ExtendedController/RowItem.php
@@ -47,11 +47,12 @@ abstract class RowItem implements VisualItemInterface
                 return new RowItemStatus();
 
             case 'actions':
-            case 'header':
+            case 'statistics':
                 return new RowItemButtons($type);
 
+            case 'header':
             case 'footer':
-                return new RowItemFooter();
+                return new RowItemCards($type);
 
             default:
                 return null;

--- a/Core/Base/ExtendedController/RowItemCards.php
+++ b/Core/Base/ExtendedController/RowItemCards.php
@@ -20,11 +20,11 @@
 namespace FacturaScripts\Core\Base\ExtendedController;
 
 /**
- * Description of RowItemFooter
+ * Description of RowItemCards
  *
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-class RowItemFooter extends RowItem
+class RowItemCards extends RowItem
 {
     /**
      * Panels lists.
@@ -41,9 +41,9 @@ class RowItemFooter extends RowItem
     /**
      * Class constructor
      */
-    public function __construct()
+    public function __construct($type)
     {
-        parent::__construct('footer');
+        parent::__construct($type);
         $this->panels = [];
         $this->buttons = [];
     }

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -32,7 +32,9 @@ use FacturaScripts\Core\Lib\Import\CSVImport;
 class Agente
 {
 
-    use Base\ModelTrait;
+    use Base\ModelTrait {
+        primaryDescription as traitPrimaryDescription;
+    }
     use Base\ContactInformation;
 
     /**
@@ -133,6 +135,16 @@ class Agente
     }
 
     /**
+     * Returns name + agent's last name.
+     *
+     * @return string
+     */
+    public function primaryDescription()
+    {
+        return $this->nombre . ' ' . $this->apellidos;
+    }
+
+    /**
      * Reset values of all model properties.
      */
     public function clear()
@@ -150,16 +162,6 @@ class Agente
         $this->f_alta = date('d-m-Y');
         $this->f_baja = null;
         $this->f_nacimiento = date('d-m-Y');
-    }
-
-    /**
-     * Returns name + agent's last name.
-     *
-     * @return string
-     */
-    public function fullName()
-    {
-        return $this->nombre . ' ' . $this->apellidos;
     }
 
     /**

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -32,9 +32,7 @@ use FacturaScripts\Core\Lib\Import\CSVImport;
 class Agente
 {
 
-    use Base\ModelTrait {
-        primaryDescription as traitPrimaryDescription;
-    }
+    use Base\ModelTrait;
     use Base\ContactInformation;
 
     /**

--- a/Core/Model/Base/ModelTrait.php
+++ b/Core/Model/Base/ModelTrait.php
@@ -187,6 +187,16 @@ trait ModelTrait
     }
 
     /**
+     * Descriptive identifier for humans of the data record
+     *
+     * @return string
+     */
+    public function primaryDescription()
+    {
+        return strval($this->primaryColumnValue());
+    }
+
+    /**
      * Returns the name of the table that uses this model.
      *
      * @return string

--- a/Core/View/DocumentReports.html
+++ b/Core/View/DocumentReports.html
@@ -77,9 +77,9 @@
                         <option value="">{{ i18n.trans('choose-employee') }}</option>
                         {% for emp in fsc.employeeList %}
                         {% if emp.codagente == fsc.employee %}
-                        <option value="{{ emp.codagente }}" selected="selected">{{ emp.fullName() }}</option>
+                        <option value="{{ emp.codagente }}" selected="selected">{{ emp.primaryDescription() }}</option>
                         {% else %}
-                        <option value="{{ emp.codagente }}" >{{ emp.fullName() }}</option>
+                        <option value="{{ emp.codagente }}" >{{ emp.primaryDescription() }}</option>
                         {% endif %}
                         {% endfor %}
                     </select>

--- a/Core/View/Macro/BaseController.html
+++ b/Core/View/Macro/BaseController.html
@@ -57,17 +57,17 @@
 
 {#
    /**
-     * Generate the code for the row of footers views (information cards)
+     * Generate the code for the row of cards views (information cards)
      */
 #}
-{% macro rowFooterForEditView(context, view) %}
-{% set footer = view.getRow('footer') %}
-{% if footer is not empty %}
+{% macro rowCardsForEditView(context, view, type) %}
+{% set cards = view.getRow(type) %}
+{% if cards is not empty %}
 {% from 'Macro/Utils.html' import popoverTitle as popoverTitle %}
 
     <br />
-    <div id="footer" class="row">
-        {% for panel in footer.panels %}
+    <div id="{{ type }}" class="row">
+        {% for panel in cards.panels %}
         <div class="col">
             <div class="card {% if panel.color %}border-{{ panel.color }}{% endif %}">
                 {% if panel.title is not empty %}
@@ -79,7 +79,7 @@
                     {% if panel.label is not empty %}
                     <p><i>{{ context.i18n.trans(panel.label) }}</i></p>
                     {% endif %}
-                    {% set buttons = footer.getButtons(panel.name) %}
+                    {% set buttons = cards.getButtons(panel.name) %}
                     {% if buttons|length > 0 %}
                     {% set formName = panel.name ~ '_form' %}
                     <form action="{{ context.edit_url }}" method="post" name="{{ formName }}">
@@ -114,14 +114,14 @@
      * Generate the code for the row of statistical buttons
      */
 #}
-{% macro rowHeaderForEditView(context, view) %}
+{% macro rowStatisticsForEditView(context, view) %}
 {% from 'Macro/Utils.html' import popoverTitle as popoverTitle %}
 
 <div class="row" style="margin-top: -.5rem">
     <div class="col-12">
         <div class="btn-toolbar pull-right" role="toolbar" style="margin-bottom: 1rem">
             <div class="btn-group btn-group-lg" role="group">
-                {% set header = view.getRow('header') %}
+                {% set header = view.getRow('statistics') %}
                 {% if header is not empty %}
                     {% for button in header.buttons %}
                         {% set value = attribute(context.fsc, button.action, [view]) %}

--- a/Core/View/Macro/BaseController.html
+++ b/Core/View/Macro/BaseController.html
@@ -66,7 +66,7 @@
 {% from 'Macro/Utils.html' import popoverTitle as popoverTitle %}
 
     <br />
-    <div id="{{ type }}" class="row">
+    <div id="{{ type }}" class="row mb-2">
         {% for panel in cards.panels %}
         <div class="col">
             <div class="card {% if panel.color %}border-{{ panel.color }}{% endif %}">
@@ -77,7 +77,7 @@
                 {% endif %}
                 <div class="card-body">
                     {% if panel.label is not empty %}
-                    <p><i>{{ context.i18n.trans(panel.label) }}</i></p>
+                    <p><i>{{ context.i18n.trans(panel.label)|raw }}</i></p>
                     {% endif %}
                     {% set buttons = cards.getButtons(panel.name) %}
                     {% if buttons|length > 0 %}

--- a/Core/View/Master/DocumentController.html
+++ b/Core/View/Master/DocumentController.html
@@ -52,8 +52,8 @@
 {% from 'Macro/BaseController.html' import columnsForListView as columnsForListView %}
 {% from 'Macro/BaseController.html' import columnsForEditListView as columnsForEditListView %}
 {% from 'Macro/BaseController.html' import columnsForEditView as columnsForEditView %}
-{% from 'Macro/BaseController.html' import rowHeaderForEditView as rowHeaderForEditView %}
-{% from 'Macro/BaseController.html' import rowFooterForEditView as rowFooterForEditView %}
+{% from 'Macro/BaseController.html' import rowStatisticsForEditView as rowStatisticsForEditView %}
+{% from 'Macro/BaseController.html' import rowCardsForEditView as rowCardsForEditView %}
 {% from 'Macro/BaseController.html' import modalFormFromColumns as modalFormFromColumns %}
 
 <div class="container-fluid">
@@ -181,7 +181,7 @@
 
                         {% if viewType == 'EditView' %}
                             <!-- Statistical buttons bar -->
-                            {{ rowHeaderForEditView(_context, view) }}
+                            {{ rowStatisticsForEditView(_context, view) }}
                             <!-- Main Form -->
                             {% set model = view.getModel() %}
                             {{ columnsForEditView(_context, view, model, TRUE) }}
@@ -194,7 +194,7 @@
                         {% if viewType == 'HtmlView' %}
                             <div>{% include view.fileName ignore missing %}</div>
                         {% else %}
-                            {{ rowFooterForEditView(_context, view) }}
+                            {{ rowCardsForEditView(_context, view, 'footer') }}
                             {{ modalFormFromColumns(_context, view) }}
                         {% endif %}
                     </div>

--- a/Core/View/Master/EditController.html
+++ b/Core/View/Master/EditController.html
@@ -137,9 +137,8 @@
         </div>
 
         <div class="col-6 text-center">
-            <h2>
-                <i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}
-            </h2>
+            <h2><i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}</h2>
+            <h5 class="text-info">{{ fsc.getPrimaryDescription() }}</h5>
         </div>
 
         <div class="col-3 text-right d-print-none">
@@ -164,11 +163,11 @@
     </div>
 
     {# Data Row #}
-    <div id="data" class="row">
+    <div id="data" class="row mt-2">
         <div class="col-12">
             {# Header Row #}
             {{ rowCardsForEditView(_context, fsc.view, 'header') }}
-            
+
             <form action="#" method="post" class="form" role="form" name="main_form">
                 <input type="hidden" name="action" value="save">
                 <div class="card">

--- a/Core/View/Master/EditController.html
+++ b/Core/View/Master/EditController.html
@@ -1,3 +1,28 @@
+{#
+   /**
+     * Edit Controller Template.
+     *
+     * Show the model data in format for editing.
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2013-2017  Carlos Garcia Gomez  <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
 {% extends "Master/MenuTemplate.html" %}
 
 {% block css %}
@@ -60,7 +85,7 @@
 {% endblock %}
 
 {% block body %}
-<!-- Calculate texts according to language -->
+{# Calculate texts according to language #}
 {% set go_back = i18n.trans('back') %}
 {% set save, save_title = i18n.trans('save'), i18n.trans('save-data') %}
 {% set undo, undo_title = i18n.trans('undo'), i18n.trans('restore-data') %}
@@ -74,22 +99,22 @@
 
 {% set title = i18n.trans(fsc.getPageData()['title']) | capitalize %}
 
-<!-- Visual macros -->
+{# Visual macros #}
 {% from 'Macro/Utils.html' import popoverTitle as popoverTitle %}
 {% from 'Macro/Utils.html' import exportData as exportData %}
 {% from 'Macro/BaseController.html' import columnsForEditView as columnsForEditView %}
-{% from 'Macro/BaseController.html' import rowHeaderForEditView as rowHeaderForEditView %}
-{% from 'Macro/BaseController.html' import rowFooterForEditView as rowFooterForEditView %}
+{% from 'Macro/BaseController.html' import rowStatisticsForEditView as rowStatisticsForEditView %}
+{% from 'Macro/BaseController.html' import rowCardsForEditView as rowCardsForEditView %}
 {% from 'Macro/BaseController.html' import modalFormFromColumns as modalFormFromColumns %}
 
-<!-- Aux Objects -->
+{# Aux Objects #}
 {% set model = fsc.view.getModel() %}
 
-<!-- Main Body -->
+{# Main Body #}
 <div class="container-fluid">
     {{ parent() }}
 
-    <!-- Header Row -->
+    {# Header Row #}
     <div id="header" class="row">
         <div class="col-3 d-print-none">
             <div class="btn-group">
@@ -106,7 +131,7 @@
                    <i class="fa fa-wrench" aria-hidden="true"></i>
                     <span class="d-none d-sm-inline-block">&nbsp;{{ options }}</span>
                 </a>
-                <!-- Adds print and export options -->
+                {# Adds print and export options #}
                 {{ exportData(fsc, i18n, 'edit') }}
             </div>
         </div>
@@ -138,7 +163,7 @@
         </div>
     </div>
 
-    <!-- Data Row -->
+    {# Data Row #}
     <div id="data" class="row">
         <div class="col-12">
             <form action="#" method="post" class="form" role="form" name="main_form">
@@ -149,10 +174,10 @@
                     </div>
 
                     <div class="card-body">
-                        <!-- Statistical buttons bar -->
-                        {{ rowHeaderForEditView(_context, fsc.view) }}
+                        {# Statistical buttons bar #}
+                        {{ rowStatisticsForEditView(_context, fsc.view) }}
 
-                        <!-- Main Form -->
+                        {# Main Form #}
                         <div id="main_row" class="row">
                             {{ columnsForEditView(_context, fsc.view, model, FALSE) }}
                         </div>
@@ -172,10 +197,10 @@
         </div>
     </div>
 
-    <!-- Footer Row -->
-    {{ rowFooterForEditView(_context, fsc.view) }}
+    {# Footer Row #}
+    {{ rowCardsForEditView(_context, fsc.view, 'footer') }}
 
-    <!-- Modals Forms -->
+    {# Modals Forms #}
     {{ modalFormFromColumns(_context, fsc.view) }}
 </div>
 {% endblock %}

--- a/Core/View/Master/EditController.html
+++ b/Core/View/Master/EditController.html
@@ -166,6 +166,9 @@
     {# Data Row #}
     <div id="data" class="row">
         <div class="col-12">
+            {# Header Row #}
+            {{ rowCardsForEditView(_context, fsc.view, 'header') }}
+            
             <form action="#" method="post" class="form" role="form" name="main_form">
                 <input type="hidden" name="action" value="save">
                 <div class="card">

--- a/Core/View/Master/ListController.html
+++ b/Core/View/Master/ListController.html
@@ -1,3 +1,29 @@
+{#
+   /**
+     * List Controller Template.
+     *
+     * Displays the data of one or several models, by tabs,
+     * in rows and columns format.
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2013-2017  Carlos Garcia Gomez  <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
 {% extends "Master/MenuTemplate.html" %}
 
 {% block javascript %}
@@ -48,7 +74,7 @@
                 }
             });
         }
-        
+
         return false;
     }
     function setOperator(buttonID, operator) {
@@ -82,7 +108,7 @@
 {% endblock %}
 
 {% block body %}
-<!-- Calculate texts according to language -->
+{# Calculate texts according to language #}
 {% set refresh = i18n.trans('refresh-page') %}
 {% set defaultT, defaultF = i18n.trans('mark-as-homepage'), i18n.trans('marked-as-homepage') %}
 {% set options, options_title = i18n.trans('options'), i18n.trans('setup-options') %}
@@ -92,10 +118,10 @@
 {% set panel_header = i18n.trans('common-data') %}
 {% set title = i18n.trans(fsc.getPageData()['title']) | capitalize %}
 
-<!-- Calculate common values -->
+{# Calculate common values #}
 {% set list_url = fsc.views[fsc.active].getURL('list') %}
 
-<!-- Macros Template Imports -->
+{# Macros Template Imports #}
 {% from 'Macro/Utils.html' import popoverTitle as popoverTitle %}
 {% from 'Macro/Utils.html' import message as show_message %}
 {% from 'Macro/Utils.html' import exportData as exportData %}
@@ -104,10 +130,10 @@
 {% from 'Macro/BaseController.html' import filterForSelectInput as filterForSelectInput %}
 {% from 'Macro/BaseController.html' import filterForCheckBoxInput as filterForCheckBoxInput %}
 {% from 'Macro/BaseController.html' import filterForTextInput as filterForTextInput %}
-{% from 'Macro/BaseController.html' import rowFooterForEditView as rowFooterForEditView %}
+{% from 'Macro/BaseController.html' import rowCardsForEditView as rowCardsForEditView %}
 {% from 'Macro/BaseController.html' import modalFormFromColumns as modalFormFromColumns %}
 
-<!-- Page Header -->
+{# Page Header #}
 <div class="container-fluid d-print-none">
     {{ parent() }}
     <div class="d-none">
@@ -115,7 +141,7 @@
             <input type="hidden" name="action" value="insert"/>
         </form>
     </div>
-    <!-- Header Row -->
+    {# Header Row #}
     <div class="row">
         <div class="col-sm-7 col-6">
             <div class="btn-group d-xs-none">
@@ -141,7 +167,7 @@
                    <i class="fa fa-wrench" aria-hidden="true"></i>
                     <span class="d-none d-sm-inline-block">&nbsp;{{ options }}</span>
                 </a>
-                <!-- Adds print and export options -->
+                {# Adds print and export options #}
                 {{ exportData(fsc, i18n) }}
             </div>
         </div>
@@ -153,9 +179,9 @@
     </div>
 </div>
 
-<!-- Main Data -->
+{# Main Data #}
 <div>
-    <!-- Tabs declaration -->
+    {# Tabs declaration #}
     <ul class="nav nav-tabs d-print-none" id="mainTabs" role="tablist">
         {% for indexView, view in fsc.views %}
         <li class="nav-item" {{ popoverTitle(view.title, 'bottom') }}>
@@ -170,16 +196,16 @@
         {% endfor %}
     </ul>
 
-    <!-- Main Tab -->
+    {# Main Tab #}
     <div class="tab-content" id="mainTabContent">
         {% for indexView, view in fsc.views %}
         {% set active = (indexView == fsc.active) ? 'active' : '' %}
         <div class="tab-pane {{ active }}" id="{{ view.getModelID() }}" role="tabpanel">
-            <!-- Filters Row -->
+            {# Filters Row #}
             <form name="f_search{{ indexView }}" id="formSearch{{ indexView }}" action="{{ fsc.url() }}" method="post" class="form">
                 <div class="container-fluid d-print-none" style="margin-top: 15px; margin-bottom: 10px;">
                     <div class="row align-items-center">
-                        <!-- Main filter -->
+                        {# Main filter #}
                         <div class="col-md-2">
                             <div class="input-group">
                                 <input type="hidden" name="active" value="{{ indexView }}"/>
@@ -193,17 +219,17 @@
                             </div>
                         </div>
 
-                        <!-- Aditionals filters -->
+                        {# Aditionals filters #}
                         {% set columnsUsed = 2 %}
                         {% for key1, filter in view.getFilters() %}
-                        <!-- check if there is space available for columns -->
+                        {# check if there is space available for columns #}
                         {% if (columnsUsed % 12) == 0 %}
                     </div>
                     <div class="row align-items-center" style="margin-top:5px; margin-bottom: 10px;">
                         {% set columnsUsed = 0 %}
                         {% endif %}
 
-                        <!-- Add new column filter -->
+                        {# Add new column filter #}
                         {% if filter.type == 'select' %}
                         {{ filterForSelectInput(_context, key1, filter) }}
                         {% elseif filter.type == 'checkbox' %}
@@ -213,23 +239,23 @@
                         {% set columnsUsed = columnsUsed + 2 %}
                         {% endif %}
 
-                        <!-- subtract the available space -->
+                        {# subtract the available space #}
                         {% set columnsUsed = columnsUsed + 2 %}
                         {% endfor %}
 
-                        <!-- Order by selector -->
+                        {# Order by selector #}
                         {{ buttonOrderBy(_context, view) }}
                     </div>
                 </div>
             </form>
 
-            <!-- Data Row -->
+            {# Data Row #}
             <div class="table-responsive">
-                <!-- Data Table -->
+                {# Data Table #}
                 {{ columnsForListView(_context, view) }}
             </div>
 
-            <!-- Footer Navigation -->
+            {# Footer Navigation #}
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-10 text-center">
@@ -261,7 +287,7 @@
                 </div>
                 <div class="row">
                     <div class="col-12">
-                        {{ rowFooterForEditView(_context, view) }}
+                        {{ rowCardsForEditView(_context, view, 'footer') }}
                         {{ modalFormFromColumns(_context, view) }}
                     </div>
                 </div>

--- a/Core/View/Master/PanelController.html
+++ b/Core/View/Master/PanelController.html
@@ -125,9 +125,8 @@
             {{ exportData(fsc, i18n, 'edit') }}
         </div>
         <div class="col-6 text-right">
-            <h2>
-                <i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}
-            </h2>
+            <h2><i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}</h2>
+            <h5 class="text-info">{{ fsc.getPrimaryDescription() }}</h5>
         </div>
     </div>
 

--- a/Core/View/Master/PanelController.html
+++ b/Core/View/Master/PanelController.html
@@ -1,3 +1,29 @@
+{#
+   /**
+     * Panel Controller Template. (Left Panel)
+     *
+     * It shows the data of one or several models, through a navigation panel,
+     * in different formats.
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2013-2017  Carlos Garcia Gomez  <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
 {% extends "Master/MenuTemplate.html" %}
 
 {% block css %}
@@ -74,8 +100,8 @@
 {% from 'Macro/BaseController.html' import columnsForListView as columnsForListView %}
 {% from 'Macro/BaseController.html' import columnsForEditListView as columnsForEditListView %}
 {% from 'Macro/BaseController.html' import columnsForEditView as columnsForEditView %}
-{% from 'Macro/BaseController.html' import rowHeaderForEditView as rowHeaderForEditView %}
-{% from 'Macro/BaseController.html' import rowFooterForEditView as rowFooterForEditView %}
+{% from 'Macro/BaseController.html' import rowStatisticsForEditView as rowStatisticsForEditView %}
+{% from 'Macro/BaseController.html' import rowCardsForEditView as rowCardsForEditView %}
 {% from 'Macro/BaseController.html' import modalFormFromColumns as modalFormFromColumns %}
 
 {# -- Main Body -- #}
@@ -132,10 +158,10 @@
                             {% if viewType == 'ListView' %}
                                 {{ columnsForListView(_context, view) }}
                             {% elseif viewType == 'EditView' %}
-                                <!-- Statistical buttons bar -->
-                                {{ rowHeaderForEditView(_context, view) }}
+                                {# Statistical buttons bar #}
+                                {{ rowStatisticsForEditView(_context, view) }}
 
-                                <!-- Main Form -->
+                                {# Main Form #}
                                 {% set model = view.getModel() %}
                                 {{ columnsForEditView(_context, view, model, TRUE) }}
                             {% elseif viewType == 'EditListView' %}
@@ -146,7 +172,7 @@
                         </div>
                     </div>
                     {% if viewType in ['ListView','EditView','EditListView'] %}
-                        {{ rowFooterForEditView(_context, view) }}
+                        {{ rowCardsForEditView(_context, view, 'footer') }}
                         {{ modalFormFromColumns(_context, view) }}
                     {% endif %}
                 </div>

--- a/Core/View/Master/PanelController.html
+++ b/Core/View/Master/PanelController.html
@@ -152,6 +152,10 @@
                 {% for indexView, view in fsc.views %}
                     {% set active = (indexView == fsc.active) ? ' show active' : '' %}
                     <div class="tab-pane fade{{ active }}" id="{{ indexView }}" role="tabpanel" aria-labelledby="{{ indexView }}-tab">
+                        {% if viewType in ['EditView','EditListView'] %}
+                            {{ rowCardsForEditView(_context, view, 'header') }}
+                        {% endif %}
+
                         <div class="card">
                             <div class="card-body">
                             {% set viewType = fsc.viewClass(view) %}

--- a/Core/View/Master/PanelControllerBottom.html
+++ b/Core/View/Master/PanelControllerBottom.html
@@ -121,9 +121,8 @@
             {{ exportData(fsc, i18n, 'edit') }}
         </div>
         <div class="col-6 text-right">
-            <h2>
-                <i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}
-            </h2>
+            <h2><i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}</h2>
+            <h5 class="text-info">{{ fsc.getPrimaryDescription() }}</h5>
         </div>
     </div>
 

--- a/Core/View/Master/PanelControllerBottom.html
+++ b/Core/View/Master/PanelControllerBottom.html
@@ -135,6 +135,10 @@
         <div class="col-12">
             {% for indexView, view in fsc.views %}
                 {% if loop.index == 1 %}
+                    {% if viewType in ['EditView','EditListView'] %}
+                        {{ rowCardsForEditView(_context, view, 'header') }}
+                    {% endif %}
+
                     <div class="card">
                         <div class="card-body">
                             {% set viewType = fsc.viewClass(view) %}
@@ -184,14 +188,22 @@
                         {% endif %}
 
                         {% if viewType == 'EditView' %}
+                        {# Information Cards Header #}
+                        {{ rowCardsForEditView(_context, view, 'header') }}
+
                         {# Statistical buttons bar #}
                         {{ rowStatisticsForEditView(_context, view) }}
+
                         {# Main Form #}
                         {% set model = view.getModel() %}
                         {{ columnsForEditView(_context, view, model, TRUE) }}
                         {% endif %}
 
                         {% if viewType == 'EditListView' %}
+                        {# Information Cards Header #}
+                        {{ rowCardsForEditView(_context, view, 'header') }}
+
+                        {# Main Form #}
                         {{ columnsForEditListView(_context, view) }}
                         {% endif %}
 

--- a/Core/View/Master/PanelControllerBottom.html
+++ b/Core/View/Master/PanelControllerBottom.html
@@ -1,3 +1,29 @@
+{#
+   /**
+     * Panel Controller Template. (Bottom Panel)
+     *
+     * It shows the data of one or several models, through a navigation panel,
+     * in different formats.
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2013-2017  Carlos Garcia Gomez  <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
 {% extends "Master/MenuTemplate.html" %}
 
 {% block css %}
@@ -70,8 +96,8 @@
 {% from 'Macro/BaseController.html' import columnsForListView as columnsForListView %}
 {% from 'Macro/BaseController.html' import columnsForEditListView as columnsForEditListView %}
 {% from 'Macro/BaseController.html' import columnsForEditView as columnsForEditView %}
-{% from 'Macro/BaseController.html' import rowHeaderForEditView as rowHeaderForEditView %}
-{% from 'Macro/BaseController.html' import rowFooterForEditView as rowFooterForEditView %}
+{% from 'Macro/BaseController.html' import rowStatisticsForEditView as rowStatisticsForEditView %}
+{% from 'Macro/BaseController.html' import rowCardsForEditView as rowCardsForEditView %}
 {% from 'Macro/BaseController.html' import modalFormFromColumns as modalFormFromColumns %}
 
 {# -- Main Body -- #}
@@ -115,10 +141,10 @@
                             {% if viewType == 'ListView' %}
                                 {{ columnsForListView(_context, view) }}
                             {% elseif viewType == 'EditView' %}
-                                <!-- Statistical buttons bar -->
-                                {{ rowHeaderForEditView(_context, view) }}
+                                {# Statistical buttons bar #}
+                                {{ rowStatisticsForEditView(_context, view) }}
 
-                                <!-- Main Form -->
+                                {# Main Form #}
                                 {% set model = view.getModel() %}
                                 {{ columnsForEditView(_context, view, model, TRUE) }}
                             {% elseif viewType == 'EditListView' %}
@@ -129,7 +155,7 @@
                         </div>
                     </div>
                     {% if viewType in ['ListView','EditView','EditListView'] %}
-                        {{ rowFooterForEditView(_context, view) }}
+                        {{ rowCardsForEditView(_context, view, 'footer') }}
                         {{ modalFormFromColumns(_context, view) }}
                     {% endif %}
                 {% endif %}
@@ -158,9 +184,9 @@
                         {% endif %}
 
                         {% if viewType == 'EditView' %}
-                        <!-- Statistical buttons bar -->
-                        {{ rowHeaderForEditView(_context, view) }}
-                        <!-- Main Form -->
+                        {# Statistical buttons bar #}
+                        {{ rowStatisticsForEditView(_context, view) }}
+                        {# Main Form #}
                         {% set model = view.getModel() %}
                         {{ columnsForEditView(_context, view, model, TRUE) }}
                         {% endif %}
@@ -172,7 +198,7 @@
                         {% if viewType == 'HtmlView' %}
                         <div>{% include view.fileName ignore missing %}</div>
                         {% elseif viewType in ['EditView','EditListView'] %}
-                        {{ rowFooterForEditView(_context, view) }}
+                        {{ rowCardsForEditView(_context, view, 'footer') }}
                         {% endif %}
                     </div>
                 {% endfor %}

--- a/Core/View/Master/PanelControllerTop.html
+++ b/Core/View/Master/PanelControllerTop.html
@@ -1,3 +1,29 @@
+{#
+   /**
+     * Panel Controller Template. (Top Panel)
+     *
+     * It shows the data of one or several models, through a navigation panel,
+     * in different formats.
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2013-2017  Carlos Garcia Gomez  <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
 {% extends "Master/MenuTemplate.html" %}
 
 {% block css %}
@@ -70,8 +96,8 @@
 {% from 'Macro/BaseController.html' import columnsForListView as columnsForListView %}
 {% from 'Macro/BaseController.html' import columnsForEditListView as columnsForEditListView %}
 {% from 'Macro/BaseController.html' import columnsForEditView as columnsForEditView %}
-{% from 'Macro/BaseController.html' import rowHeaderForEditView as rowHeaderForEditView %}
-{% from 'Macro/BaseController.html' import rowFooterForEditView as rowFooterForEditView %}
+{% from 'Macro/BaseController.html' import rowStatisticsForEditView as rowStatisticsForEditView %}
+{% from 'Macro/BaseController.html' import rowCardsForEditView as rowCardsForEditView %}
 {% from 'Macro/BaseController.html' import modalFormFromColumns as modalFormFromColumns %}
 
 {# -- Main Body -- #}
@@ -127,9 +153,9 @@
                         {% endif %}
 
                         {% if viewType == 'EditView' %}
-                            <!-- Statistical buttons bar -->
-                            {{ rowHeaderForEditView(_context, view) }}
-                            <!-- Main Form -->
+                            {# Statistical buttons bar #}
+                            {{ rowStatisticsForEditView(_context, view) }}
+                            {# Main Form #}
                             {% set model = view.getModel() %}
                             {{ columnsForEditView(_context, view, model, TRUE) }}
                         {% endif %}
@@ -141,7 +167,7 @@
                         {% if viewType == 'HtmlView' %}
                             <div>{% include view.fileName ignore missing %}</div>
                         {% else %}
-                            {{ rowFooterForEditView(_context, view) }}
+                            {{ rowCardsForEditView(_context, view, 'footer') }}
                             {{ modalFormFromColumns(_context, view) }}
                         {% endif %}
                     </div>

--- a/Core/View/Master/PanelControllerTop.html
+++ b/Core/View/Master/PanelControllerTop.html
@@ -153,14 +153,22 @@
                         {% endif %}
 
                         {% if viewType == 'EditView' %}
+                            {# Information Cards Header #}
+                            {{ rowCardsForEditView(_context, view, 'header') }}
+
                             {# Statistical buttons bar #}
                             {{ rowStatisticsForEditView(_context, view) }}
+
                             {# Main Form #}
                             {% set model = view.getModel() %}
                             {{ columnsForEditView(_context, view, model, TRUE) }}
                         {% endif %}
 
                         {% if viewType == 'EditListView' %}
+                            {# Information Cards Header #}
+                            {{ rowCardsForEditView(_context, view, 'header') }}
+
+                            {# Main Form #}
                             {{ columnsForEditListView(_context, view) }}
                         {% endif %}
 

--- a/Core/View/Master/PanelControllerTop.html
+++ b/Core/View/Master/PanelControllerTop.html
@@ -121,9 +121,8 @@
             {{ exportData(fsc, i18n, 'edit') }}
         </div>
         <div class="col-6 text-right">
-            <h2>
-                <i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}
-            </h2>
+            <h2><i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}</h2>
+            <h5 class="text-info">{{ fsc.getPrimaryDescription() }}</h5>
         </div>
     </div>
 

--- a/Core/XMLView/EditCliente.xml
+++ b/Core/XMLView/EditCliente.xml
@@ -123,7 +123,7 @@
         </group>
     </columns>
     <rows>
-        <row type="header">
+        <row type="statistics">
             <button type="calculate" icon="fa-files-o" label="delivery-notes-button" action="calcClientDeliveryNotes" />
             <button type="calculate" icon="fa-money" label="pending-invoices-button" action="calcClientInvoicePending" />
         </row>

--- a/Core/XMLView/SettingsEmail.xml
+++ b/Core/XMLView/SettingsEmail.xml
@@ -61,7 +61,7 @@
             </column>
             <column name="lowsecure" title="low-security" numcolumns="6" order="130">
                 <widget type="checkbox" fieldname="lowsecure" />
-            </column> 
+            </column>
         </group>
     </columns>
     <rows>

--- a/Documentation/EN/EditController.rst
+++ b/Documentation/EN/EditController.rst
@@ -86,7 +86,7 @@ displayed in the header and footer of the data sheet.
         }
 
 We can also customize the view by including it in the group XML file
-*<rows>* and create *<row type = “”>* of the classes **header**, to
+*<rows>* and create *<row type = “”>* of the classes **statistics**, to
 define a list of statistical and relational buttons with other models,
 and **footer**, to add information additional to display to the user
 just after the data sheet.
@@ -96,7 +96,7 @@ Examples:
 .. code:: xml
 
         <rows>
-            <row type="header">
+            <row type="statistics">
                 <option icon="fa-files-o" label="Alb. Pdtes:" calculateby="nombre_function" onclick="#url"></option>
                 <option icon="fa-files-o" label="Pdte Cobro:" calculateby="nombre_function" onclick="#url"></option>
             </row>

--- a/Documentation/EN/Models.rst
+++ b/Documentation/EN/Models.rst
@@ -47,7 +47,7 @@ text string: **tableName** and **primaryColumn**.
 
 .. code:: php
 
-    public function tableName()
+    public static function tableName()
     {
         return 'agentes';
     }
@@ -254,6 +254,8 @@ Métodos comunes
 ===============
 
 -  **primaryColumnValue** : Returns the value of the key field (Primary Key).
+
+-  **primaryDescription** : Returns the descriptive identifier for the data record.
 
 -  **loadFromData** : Load the data of the model with the data array that is passed to it by parameter.
 

--- a/Documentation/EN/XMLViews.rst
+++ b/Documentation/EN/XMLViews.rst
@@ -373,8 +373,8 @@ Example:
         </rows>
 
 
-header
-------
+statistics
+----------
 
 Defines a list of statistical and relational buttons with other models that give
 information to the user and allows consult when you click.
@@ -396,7 +396,7 @@ Example:
 .. code:: xml
 
         <rows>
-            <row type="header">
+            <row type="statistics">
                 <button icon="fa-files-o" label="Pending delivery notes:" calculateby="function_name" onclick="#url"></option>
                 <button icon="fa-files-o" label="Pending collection:" calculateby="function_name" onclick="#url"></option>
             </row>

--- a/Documentation/EN/XMLViews.rst
+++ b/Documentation/EN/XMLViews.rst
@@ -425,10 +425,10 @@ Example:
 
 
 
-footer
-------
+header and footer
+-----------------
 
-It allows adding additional information to visualize the user at the bottom of the view.
+It allows adding additional information to visualize the user at the top and/or the bottom of the view.
 The information is displayed in the form of panels ("Bootstrap cards") where we can
 include messages and buttons for both action and modals. To declare a panel we will use
 the tag *<group>* in which we will include tags *button* (if we need them).
@@ -443,7 +443,18 @@ and/or the footer with attributes:
 
 -  **footer**: indicates a text for the foot of the panel.
 
-Example:
+Example: (Top of the view)
+
+.. code:: xml
+
+        <row type="header">
+            <group name="footer1" footer="specials-actions" label="This is a sample of buttons on a 'bootstrap card'">
+                <button type="modal" label="Modal" color="primary" action="test" icon="fa-users" />
+                <button type="action" label="Action" color="info" action="process1" icon="fa-book" hint="Run the controller with action=process1" />
+            </group>
+        </row>
+
+Example: (Bottom of the view)
 
 .. code:: xml
 

--- a/Documentation/ES/EditController.rst
+++ b/Documentation/ES/EditController.rst
@@ -87,7 +87,7 @@ Existen dos métodos que nos permiten personalizar los datos a visualizar en la 
         }
 
 También podemos personalizar la vista mediante la inclusión en el fichero XML del grupo *<rows>*
-y crear *<row type=“”>* de las clases **header**, para definir una lista de botones estadísticos y
+y crear *<row type=“”>* de las clases **statistics**, para definir una lista de botones estadísticos y
 relacionales con otros modelos, y **footer**, para añadir información adicional a visualizar al
 usuario justo después de la ficha de datos.
 
@@ -96,7 +96,7 @@ Ejemplos:
 .. code:: xml
 
         <rows>
-            <row type="header">
+            <row type="statistics">
                 <option icon="fa-files-o" label="Alb. Pdtes:" calculateby="nombre_function" onclick="#url"></option>
                 <option icon="fa-files-o" label="Pdte Cobro:" calculateby="nombre_function" onclick="#url"></option>
             </row>

--- a/Documentation/ES/Models.rst
+++ b/Documentation/ES/Models.rst
@@ -47,7 +47,7 @@ cadena de texto: **tableName** y **primaryColumn**.
 
 .. code:: php
 
-    public function tableName()
+    public static function tableName()
     {
         return 'agentes';
     }
@@ -255,6 +255,8 @@ Métodos comunes
 ===============
 
 -  **primaryColumnValue** : Devuelve el valor del campo clave (Primary Key).
+
+-  **primaryDescription** : Devuelve el identificador descriptivo para del registro de datos.
 
 -  **loadFromData** : Carga los datos del modelo con el array de datos que se le pasa por parámetro.
 

--- a/Documentation/ES/XMLViews.rst
+++ b/Documentation/ES/XMLViews.rst
@@ -395,8 +395,8 @@ Ejemplo:
         </rows>
 
 
-header
-------
+statistics
+----------
 
 Permite definir una lista de botones estadísticos y relacionales con otros modelos
 que dan información al usuario y le permite consultar al hacer click.
@@ -418,7 +418,7 @@ Ejemplo:
 .. code:: xml
 
         <rows>
-            <row type="header">
+            <row type="statistics">
                 <button icon="fa-files-o" label="Alb. Pdtes:" calculateby="nombre_function" onclick="#url"></option>
                 <button icon="fa-files-o" label="Pdte Cobro:" calculateby="nombre_function" onclick="#url"></option>
             </row>

--- a/Documentation/ES/XMLViews.rst
+++ b/Documentation/ES/XMLViews.rst
@@ -446,10 +446,10 @@ Ejemplo:
         </rows>
 
 
-footer
-------
+header y footer
+---------------
 
-Permite añadir información adicional a visualizar al usuario en el pie de la vista.
+Permite añadir información adicional a visualizar al usuario en la cabecera y/o el pie de la vista.
 La información se muestra en forma de paneles ("cards" de Bootstrap) donde podemos
 incluir mensajes y botones tanto de acción como modales. Para declarar un panel usaremos
 la etiqueta *<group>* en la que incluiremos etiquetas *button* (si los necesitamos).
@@ -464,7 +464,18 @@ y/o el pie con atributos:
 
 -  **footer** : indica un texto para el pie del panel.
 
-Ejemplo:
+Ejemplo: (Cabecera de vista)
+
+.. code:: xml
+
+        <row type="header">
+            <group name="footer1" footer="specials-actions" label="Esto es una muestra de botones en un 'bootstrap card'">
+                <button type="modal" label="Modal" color="primary" action="test" icon="fa-users" />
+                <button type="action" label="Action" color="info" action="process1" icon="fa-book" hint="Ejecuta el controlador con action=process1" />
+            </group>
+        </row>
+
+Ejemplo: (Pie de vista)
 
 .. code:: xml
 

--- a/Test/Core/Model/AgenteTest.php
+++ b/Test/Core/Model/AgenteTest.php
@@ -94,7 +94,7 @@ final class AgenteTest extends TestCase
 
         $this->assertInternalType(
             'string',
-            $model->fullName()
+            $model->primaryDescription()
         );
 
         $this->assertTrue($model->test());


### PR DESCRIPTION
The "head" type rows now become "statistics" type, keeping their operation unchanged.
The RowItemFooter class is renamed by RowItemCards more in line with its new function.
A new "head" type is added to the RowItemCards, similar to the existing ones ("footer") but which are displayed in the header of the views.
