### PR TITLE
<feature> Use Symfony phpunit bridge for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ package-lock.json
 .settings
 .buildpath
 
-###> phpunit/phpunit ###
+###> symfony/phpunit-bridge ###
+.phpunit
 /phpunit.xml
-###< phpunit/phpunit ###
+###< symfony/phpunit-bridge ###

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
+    echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+    exit(1);
+}
+if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
+    putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');
+}
+if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
+    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
+}
+if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
+    putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
+}
+
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit';

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "twig/twig": "v2.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*",
         "squizlabs/php_codesniffer": "^3.2",
-        "symfony/dotenv": "^3.4"
+        "symfony/dotenv": "^3.4",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "config": {
         "preferred-install": {

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        public: true
+
+    # If you need to access services in a test, create an alias
+    # and then fetch that alias from the container. As a convention,
+    # aliases are prefixed with test. For example:
+    #
+    # test.App\Service\MyService: '@App\Service\MyService'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,13 +19,17 @@
 
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>tests</directory>
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory>src</directory>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Deprecate raw use of phpunit and use Symfony phpunit bridge for testing