### PR TITLE
Force to use PSR3 monolog logger

### DIFF
--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -156,7 +156,7 @@ class AppController extends App
             $permissions = new ControllerPermissions($user, $pageName);
 
             try {
-                $this->controller = new $controllerName($this->cache, $this->i18n, $this->miniLog, $pageName);
+                $this->controller = new $controllerName($this->cache, $this->i18n, $pageName);
                 if ($user === false) {
                     $this->controller->publicCore($this->response);
                     $template = $this->controller->getTemplate();

--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -155,7 +155,7 @@ class Controller extends SymfonyController
      * @param MiniLog    $miniLog
      * @param string     $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
         $this->assets = AssetManager::getAssetsForPage($className);
         $this->cache = &$cache;
@@ -164,7 +164,6 @@ class Controller extends SymfonyController
         $this->dispatcher = new EventDispatcher();
         $this->divisaTools = new DivisaTools();
         $this->i18n = &$i18n;
-        $this->miniLog = &$miniLog;
         $this->numberTools = new NumberTools();
         $this->request = Request::createFromGlobals();
         $this->template = $this->className . '.html.twig';

--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -289,7 +289,7 @@ class PluginManager
                 }
 
                 try {
-                    $controller = new $controllerNamespace($cache, self::$i18n, self::$minilog, $controllerName);
+                    $controller = new $controllerNamespace($cache, self::$i18n, $controllerName);
                     $menuManager->selectPage($controller->getPageData());
                 } catch (Exception $exc) {
                     self::$minilog->critical(self::$i18n->trans('cant-load-controller', ['%controllerName%' => $controllerName]));

--- a/Core/Controller/AccountingReports.php
+++ b/Core/Controller/AccountingReports.php
@@ -105,7 +105,7 @@ class AccountingReports extends Controller
         }
 
         if (empty($pages)) {
-            $this->miniLog->info($this->i18n->trans('no-data'));
+            $this->get('logger')->info($this->i18n->trans('no-data'));
 
             return;
         }

--- a/Core/Controller/AdminHome.php
+++ b/Core/Controller/AdminHome.php
@@ -105,7 +105,7 @@ class AdminHome extends Base\Controller
     private function disablePlugin($pluginName)
     {
         if (!$this->permissions->allowUpdate) {
-            $this->miniLog->alert($this->i18n->trans('not-allowed-modify'));
+            $this->get('logger')->alert($this->i18n->trans('not-allowed-modify'));
             return false;
         }
 
@@ -123,7 +123,7 @@ class AdminHome extends Base\Controller
     private function enablePlugin($pluginName)
     {
         if (!$this->permissions->allowUpdate) {
-            $this->miniLog->alert($this->i18n->trans('not-allowed-modify'));
+            $this->get('logger')->alert($this->i18n->trans('not-allowed-modify'));
             return false;
         }
 
@@ -171,7 +171,7 @@ class AdminHome extends Base\Controller
     private function removePlugin($pluginName)
     {
         if (!$this->permissions->allowDelete) {
-            $this->miniLog->alert($this->i18n->trans('not-allowed-delete'));
+            $this->get('logger')->alert($this->i18n->trans('not-allowed-delete'));
             return false;
         }
 
@@ -188,12 +188,12 @@ class AdminHome extends Base\Controller
     {
         foreach ($uploadFiles as $uploadFile) {
             if (!$uploadFile->isValid()) {
-                $this->miniLog->error($uploadFile->getErrorMessage());
+                $this->get('logger')->error($uploadFile->getErrorMessage());
                 continue;
             }
 
             if ($uploadFile->getMimeType() !== 'application/zip') {
-                $this->miniLog->error($this->i18n->trans('file-not-supported'));
+                $this->get('logger')->error($this->i18n->trans('file-not-supported'));
                 continue;
             }
 

--- a/Core/Controller/Dashboard.php
+++ b/Core/Controller/Dashboard.php
@@ -47,7 +47,7 @@ class Dashboard extends Base\Controller
      * @param Base\MiniLog    $miniLog
      * @param string          $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
         parent::__construct($cache, $i18n, $miniLog, $className);
 

--- a/Core/Controller/DocumentReports.php
+++ b/Core/Controller/DocumentReports.php
@@ -77,7 +77,7 @@ class DocumentReports extends Controller
      * @param MiniLog    $miniLog
      * @param string     $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
         parent::__construct($cache, $i18n, $miniLog, $className);
 

--- a/Core/Controller/EditEjercicio.php
+++ b/Core/Controller/EditEjercicio.php
@@ -118,7 +118,7 @@ class EditEjercicio extends ExtendedController\PanelController
         $codejercicio = $this->getViewModelValue('EditEjercicio', 'codejercicio');
         $uploadFile = $this->request->files->get('accountingfile', false);
         if ($uploadFile === false) {
-            $this->miniLog->alert($this->i18n->trans('file-not-found', ['%fileName%' => '']));
+            $this->get('logger')->alert($this->i18n->trans('file-not-found', ['%fileName%' => '']));
 
             return false;
         }
@@ -134,7 +134,7 @@ class EditEjercicio extends ExtendedController\PanelController
                 break;
 
             default:
-                $this->miniLog->error($this->i18n->trans('file-not-supported'));
+                $this->get('logger')->error($this->i18n->trans('file-not-supported'));
         }
     }
 }

--- a/Core/Controller/EditPageOption.php
+++ b/Core/Controller/EditPageOption.php
@@ -60,9 +60,9 @@ class EditPageOption extends Base\Controller
      * @param MiniLog    $miniLog
      * @param string     $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
-        parent::__construct($cache, $i18n, $miniLog, $className);
+        parent::__construct($cache, $i18n, $className);
         $this->setTemplate('EditPageOption');
         $this->model = new Model\PageOption();
     }
@@ -129,11 +129,11 @@ class EditPageOption extends Base\Controller
         }
 
         if ($this->model->save()) {
-            $this->miniLog->notice($this->i18n->trans('record-updated-correctly'));
+            $this->get('logger')->notice($this->i18n->trans('record-updated-correctly'));
 
             return;
         }
-        $this->miniLog->alert($this->i18n->trans('data-save-error'));
+        $this->get('logger')->alert($this->i18n->trans('data-save-error'));
     }
 
     /**

--- a/Core/Controller/EditRole.php
+++ b/Core/Controller/EditRole.php
@@ -143,7 +143,7 @@ class EditRole extends ExtendedController\PanelController
                     $this->dataBase->commit();
                 } catch (\Exception $e) {
                     $this->dataBase->rollback();
-                    $this->miniLog->notice($e->getMessage());
+                    $this->get('logger')->notice($e->getMessage());
                 }
 
                 return true;

--- a/Core/Controller/EditSettings.php
+++ b/Core/Controller/EditSettings.php
@@ -86,9 +86,9 @@ class EditSettings extends ExtendedController\PanelController
             case 'testmail':
                 $emailTools = new EmailTools();
                 if ($emailTools->test()) {
-                    $this->miniLog->info($this->i18n->trans('mail-test-ok'));
+                    $this->get('logger')->info($this->i18n->trans('mail-test-ok'));
                 } else {
-                    $this->miniLog->error($this->i18n->trans('mail-test-error'));
+                    $this->get('logger')->error($this->i18n->trans('mail-test-error'));
                 }
                 break;
         }
@@ -212,7 +212,7 @@ class EditSettings extends ExtendedController\PanelController
             }
 
             if ($error) {
-                $this->miniLog->critical($this->i18n->trans('error-no-name-in-settings', ['%viewName%' => $viewName]));
+                $this->get('logger')->critical($this->i18n->trans('error-no-name-in-settings', ['%viewName%' => $viewName]));
             }
         }
     }

--- a/Core/Controller/ListAsiento.php
+++ b/Core/Controller/ListAsiento.php
@@ -70,7 +70,7 @@ class ListAsiento extends ExtendedController\ListController
             case 'renumber':
                 $model = $this->views['ListAsiento']->getModel();
                 if ($model->renumber()) {
-                    $this->miniLog->notice($this->i18n->trans('renumber-accounting-ok'));
+                    $this->get('logger')->notice($this->i18n->trans('renumber-accounting-ok'));
                 }
                 break;
 

--- a/Core/Controller/Randomizer.php
+++ b/Core/Controller/Randomizer.php
@@ -85,84 +85,84 @@ class Randomizer extends Base\Controller
         switch ($option) {
             case 'agentes':
                 $num = $modelDataGenerator->agentes();
-                $this->miniLog->info($this->i18n->trans('generated-agents', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-agents', ['%quantity%' => $num]));
                 break;
 
             case 'albaranescli':
                 $num = $documentGenerator->albaranesCliente();
-                $this->miniLog->info($this->i18n->trans('generated-customer-delivery-notes', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-customer-delivery-notes', ['%quantity%' => $num]));
                 break;
 
             case 'albaranesprov':
                 $num = $documentGenerator->albaranesProveedor();
-                $this->miniLog->info($this->i18n->trans('generated-supplier-delivery-notes', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-supplier-delivery-notes', ['%quantity%' => $num]));
                 break;
 
             case 'articulos':
                 $num = $modelDataGenerator->articulos();
-                $this->miniLog->info($this->i18n->trans('generated-products', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-products', ['%quantity%' => $num]));
                 break;
 
             case 'articulosprov':
                 $num = $modelDataGenerator->articulosProveedor();
-                $this->miniLog->info($this->i18n->trans('generated-products', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-products', ['%quantity%' => $num]));
                 break;
 
             case 'asientos':
                 $num = $accountingGenerator->asientos();
-                $this->miniLog->info($this->i18n->trans('generated-accounting-entries', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-accounting-entries', ['%quantity%' => $num]));
                 break;
 
             case 'clientes':
                 $num = $modelDataGenerator->clientes();
-                $this->miniLog->info($this->i18n->trans('generated-customers', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-customers', ['%quantity%' => $num]));
                 break;
 
             case 'cuentas':
                 $accountingGenerator->gruposEpigrafes(2);
                 $accountingGenerator->epigrafes(4);
                 $num = $accountingGenerator->cuentas(8);
-                $this->miniLog->info($this->i18n->trans('generated-accounts', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-accounts', ['%quantity%' => $num]));
                 break;
 
             case 'fabricantes':
                 $num = $modelDataGenerator->fabricantes();
-                $this->miniLog->info($this->i18n->trans('generated-manufacturers', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-manufacturers', ['%quantity%' => $num]));
                 break;
 
             case 'familias':
                 $num = $modelDataGenerator->familias();
-                $this->miniLog->info($this->i18n->trans('generated-families', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-families', ['%quantity%' => $num]));
                 break;
 
             case 'grupos':
                 $num = $modelDataGenerator->gruposClientes();
-                $this->miniLog->info($this->i18n->trans('generated-customer-groups', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-customer-groups', ['%quantity%' => $num]));
                 break;
 
             case 'pedidoscli':
                 $num = $documentGenerator->pedidosCliente();
-                $this->miniLog->info($this->i18n->trans('generated-customer-orders', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-customer-orders', ['%quantity%' => $num]));
                 break;
 
             case 'pedidosprov':
                 $num = $documentGenerator->pedidosProveedor();
-                $this->miniLog->info($this->i18n->trans('generated-supplier-orders', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-supplier-orders', ['%quantity%' => $num]));
                 break;
 
             case 'presupuestoscli':
                 $num = $documentGenerator->presupuestosCliente();
-                $this->miniLog->info($this->i18n->trans('generated-customer-estimations', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-customer-estimations', ['%quantity%' => $num]));
                 break;
 
             case 'proveedores':
                 $num = $modelDataGenerator->proveedores();
-                $this->miniLog->info($this->i18n->trans('generated-supplier', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-supplier', ['%quantity%' => $num]));
                 break;
 
             case 'subcuentas':
                 $num = $accountingGenerator->subcuentas();
-                $this->miniLog->info($this->i18n->trans('generated-subaccounts', ['%quantity%' => $num]));
+                $this->get('logger')->info($this->i18n->trans('generated-subaccounts', ['%quantity%' => $num]));
                 break;
         }
     }

--- a/Core/Lib/ExtendedController/DocumentController.php
+++ b/Core/Lib/ExtendedController/DocumentController.php
@@ -40,9 +40,9 @@ abstract class DocumentController extends PanelController
      * @param MiniLog    $miniLog
      * @param string     $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
-        parent::__construct($cache, $i18n, $miniLog, $className);
+        parent::__construct($cache, $i18n, $className);
         $this->setTemplate('Master/DocumentController');
     }
 

--- a/Core/Lib/ExtendedController/EditController.php
+++ b/Core/Lib/ExtendedController/EditController.php
@@ -40,9 +40,9 @@ abstract class EditController extends PanelController
      * @param Base\MiniLog    $miniLog
      * @param string          $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
-        parent::__construct($cache, $i18n, $miniLog, $className);
+        parent::__construct($cache, $i18n, $className);
         $this->setTabsPosition('bottom');
     }
 

--- a/Core/Lib/ExtendedController/ListController.php
+++ b/Core/Lib/ExtendedController/ListController.php
@@ -96,9 +96,9 @@ abstract class ListController extends Base\Controller
      * @param Base\MiniLog    $miniLog
      * @param string          $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
-        parent::__construct($cache, $i18n, $miniLog, $className);
+        parent::__construct($cache, $i18n, $className);
 
         $this->setTemplate('Master/ListController');
 

--- a/Core/Lib/ExtendedController/PanelController.php
+++ b/Core/Lib/ExtendedController/PanelController.php
@@ -100,9 +100,9 @@ abstract class PanelController extends Base\Controller
      * @param Base\MiniLog    $miniLog
      * @param string          $className
      */
-    public function __construct(&$cache, &$i18n, &$miniLog, $className)
+    public function __construct(&$cache, &$i18n, $className)
     {
-        parent::__construct($cache, $i18n, $miniLog, $className);
+        parent::__construct($cache, $i18n, $className);
 
         $this->active = $this->request->get('active', '');
         $this->codeModel = new CodeModel();


### PR DESCRIPTION
This PR avoid the param minilog in controllers or extended controllers and it uses the injected logger via symfony monolog bridge service. 

Note: Future PR should affect to othe parts that still use the old Minilog class. For models shouldn't have logs or logic for the logger and throw exceptions instead to upper controllers.