### PR TITLE
Restructuring classes in ExtendedController views

### DIFF
--- a/Core/Base/DivisaTools.php
+++ b/Core/Base/DivisaTools.php
@@ -49,4 +49,19 @@ class DivisaTools
 
         return $symbol . ' ' . $txt;
     }
+
+    /**
+     * Return format mask for edit grid
+     *
+     * @param type $decimals
+     * @return string
+     */
+    public static function gridMoneyFormat($decimals = FS_NF0)
+    {
+        $moneyFormat = '0.';
+        for ($num = 0; $num < $decimals; $num++) {
+            $moneyFormat .= '0';
+        }
+        return $moneyFormat;
+    }
 }

--- a/Core/Lib/ExtendedController/BaseView.php
+++ b/Core/Lib/ExtendedController/BaseView.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2017  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ * Copyright (C) 2013-2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -20,8 +20,6 @@
 namespace FacturaScripts\Core\Lib\ExtendedController;
 
 use FacturaScripts\Core\Base;
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
-use FacturaScripts\Core\Lib\ExportManager;
 use FacturaScripts\Core\Model;
 
 /**
@@ -74,33 +72,6 @@ abstract class BaseView
      * @var Base\Translator
      */
     public static $i18n;
-
-    /**
-     * Establishes de view/edit state of a column
-     *
-     * @param string $columnName
-     * @param bool   $disabled
-     */
-    abstract public function disableColumn($columnName, $disabled);
-
-    /**
-     * Method to export the view data
-     *
-     * @param ExportManager $exportManager
-     */
-    abstract public function export(&$exportManager);
-
-    /**
-     * Load the data in the model or cursor property, according to the code or
-     * where filter specified.
-     *
-     * @param mixed           $code
-     * @param DataBaseWhere[] $where
-     * @param array           $order
-     * @param int             $offset
-     * @param int             $limit
-     */
-    abstract public function loadData($code = false, $where = [], $order = [], $offset = 0, $limit = FS_ITEM_LIMIT);
 
     /**
      * Construct and initialize the class

--- a/Core/Lib/ExtendedController/DataViewInterface.php
+++ b/Core/Lib/ExtendedController/DataViewInterface.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Core\Lib\ExtendedController;
+
+/**
+ *
+ * @author Artex Trading sa <jcuello@artextrading.com>
+ */
+interface DataViewInterface
+{
+    /**
+     * Column list and its configuration
+     * (Array of ColumnItem)
+     *
+     * @return GroupItem[]
+     */
+    public function getColumns();
+
+    /**
+     * Establishes de view/edit state of a column
+     *
+     * @param string $columnName
+     * @param bool   $disabled
+     */
+    public function disableColumn($columnName, $disabled);
+
+    /**
+     *
+     * @param mixed           $code
+     * @param DataBaseWhere[] $where
+     * @param array           $order
+     * @param int             $offset
+     * @param int             $limit
+     */
+    public function loadData($code = false, $where = [], $order = [], $offset = 0, $limit = FS_ITEM_LIMIT);
+
+    /**
+     * Method to export the view data
+     *
+     * @param ExportManager $exportManager
+     *
+     * @return null
+     */
+    public function export(&$exportManager);
+}

--- a/Core/Lib/ExtendedController/DocumentView.php
+++ b/Core/Lib/ExtendedController/DocumentView.php
@@ -18,12 +18,11 @@
  */
 namespace FacturaScripts\Core\Lib\ExtendedController;
 
-use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Base;
+use FacturaScripts\Core\Model;
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Lib\DocumentCalculator;
 use FacturaScripts\Core\Lib\ExportManager;
-use FacturaScripts\Core\Model\Cliente;
-use FacturaScripts\Core\Model\Proveedor;
 use FacturaScripts\Core\Model\Base\SalesDocumentLine;
 
 /**
@@ -96,16 +95,6 @@ class DocumentView extends BaseView
     }
 
     /**
-     * Establishes de view/edit state of a column
-     *
-     * @param string $columnName
-     * @param bool   $disabled
-     */
-    public function disableColumn($columnName, $disabled)
-    {
-    }
-
-    /**
      * Returns the data of lines to the view.
      *
      * @return string
@@ -117,11 +106,6 @@ class DocumentView extends BaseView
             'columns' => [],
             'rows' => []
         ];
-
-        $moneyFormat = '0.';
-        for ($num = 0; $num < FS_NF0; $num++) {
-            $moneyFormat .= '0';
-        }
 
         foreach ($this->lineOptions as $col) {
             $data['headers'][] = self::$i18n->trans($col->title);
@@ -136,7 +120,7 @@ class DocumentView extends BaseView
             }
             if ($item['type'] === 'number' || $item['type'] === 'money') {
                 $item['type'] = 'numeric';
-                $item['format'] = $moneyFormat;
+                $item['format'] = Base\DivisaTools::gridMoneyFormat();
             }
             $data['columns'][] = $item;
         }
@@ -168,7 +152,7 @@ class DocumentView extends BaseView
      * @param int   $offset
      * @param int   $limit
      */
-    public function loadData($code = false, $where = [], $order = [], $offset = 0, $limit = FS_ITEM_LIMIT)
+    public function loadData($code = false, $where = [])
     {
         if ($this->newCode !== null) {
             $code = $this->newCode;
@@ -202,7 +186,7 @@ class DocumentView extends BaseView
         $newLines = isset($data['lines']) ? $this->processFormLines($data['lines']) : [];
         unset($data['lines']);
         $this->loadFromData($data);
-        
+
         return $this->calculator->calculateForm($this->model, $newLines);
     }
 
@@ -249,7 +233,7 @@ class DocumentView extends BaseView
             return $new ? 'NEW:' . $this->model->url() : $result;
         }
 
-        $miniLog = new MiniLog();
+        $miniLog = new Base\MiniLog();
         foreach ($miniLog->read() as $msg) {
             $result = $msg['message'];
         }
@@ -272,7 +256,7 @@ class DocumentView extends BaseView
             return 'OK';
         }
 
-        $cliente = new Cliente();
+        $cliente = new Model\Cliente();
         if ($cliente->loadFromCode($codcliente)) {
             $this->model->setCliente($cliente);
             return 'OK';
@@ -304,7 +288,7 @@ class DocumentView extends BaseView
             return 'OK';
         }
 
-        $proveedor = new Proveedor();
+        $proveedor = new Model\Proveedor();
         if ($proveedor->loadFromCode($codproveedor)) {
             $this->model->setProveedor($proveedor);
             return 'OK';
@@ -374,6 +358,8 @@ class DocumentView extends BaseView
      */
     public function setNewCode()
     {
+        /// this can be eliminated when the error is fixed when calculating
+        /// a new code when the primary key is numeric
     }
 
     /**

--- a/Core/Lib/ExtendedController/EditListView.php
+++ b/Core/Lib/ExtendedController/EditListView.php
@@ -28,7 +28,7 @@ use FacturaScripts\Core\Lib\ExportManager;
  * @author Carlos García Gómez <carlos@facturascripts.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-class EditListView extends BaseView
+class EditListView extends BaseView implements DataViewInterface
 {
     /**
      * Cursor with the display model's data

--- a/Core/Lib/ExtendedController/EditView.php
+++ b/Core/Lib/ExtendedController/EditView.php
@@ -28,7 +28,7 @@ use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
  * @author Carlos García Gómez <carlos@facturascripts.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-class EditView extends BaseView
+class EditView extends BaseView implements DataViewInterface
 {
     /**
      * EditView constructor and initialization.

--- a/Core/Lib/ExtendedController/HtmlView.php
+++ b/Core/Lib/ExtendedController/HtmlView.php
@@ -19,9 +19,6 @@
 
 namespace FacturaScripts\Core\Lib\ExtendedController;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
-use FacturaScripts\Core\Lib\ExportManager;
-
 /**
  * View definition for its use in ExtendedControllers
  *
@@ -48,40 +45,5 @@ class HtmlView extends BaseView
     {
         parent::__construct($title, $modelName);
         $this->fileName = $fileName;
-    }
-
-    /**
-     * Allow disable a column from a table.
-     *
-     * @param string $columnName
-     * @param bool   $disabled
-     */
-    public function disableColumn($columnName, $disabled)
-    {
-    }
-
-    /**
-     * Method to export the view data
-     *
-     * @param ExportManager $exportManager
-     *
-     * @return null
-     */
-    public function export(&$exportManager)
-    {
-        return null;
-    }
-
-    /**
-     * Does nothing in this class.
-     *
-     * @param mixed           $code
-     * @param DataBaseWhere[] $where
-     * @param array           $order
-     * @param int             $offset
-     * @param int             $limit
-     */
-    public function loadData($code = false, $where = [], $order = [], $offset = 0, $limit = FS_ITEM_LIMIT)
-    {
     }
 }

--- a/Core/Lib/ExtendedController/ListView.php
+++ b/Core/Lib/ExtendedController/ListView.php
@@ -28,7 +28,7 @@ use FacturaScripts\Core\Lib\ExportManager;
  * @author Carlos García Gómez <carlos@facturascripts.com>
  * @author Artex Trading sa <jcuello@artextrading.com>
  */
-class ListView extends BaseView
+class ListView extends BaseView implements DataViewInterface
 {
     /**
      * Order constants


### PR DESCRIPTION
Restructuring classes in ExtendedController views to simplify new future views.
An interface is created for the views that use a data model, thus avoiding the mandatory declaration of those methods in views that inherit from BaseView and do not need those methods.