### PR TITLE
Add support for custom commands in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,16 @@
         "crm",
         "billing",
         "accounting"
-    ]
+    ],
+    "scripts": {
+        "auto-scripts": {
+
+        },
+        "post-install-cmd": [
+            "npm install"
+        ],
+        "post-update-cmd": [
+            "npm update"
+        ]
+    }
 }


### PR DESCRIPTION
When do:
   - composer install, also is auto-called to npm install.
   - composer update, also is auto-called to npm update.

Doing something like that at the end of composer execution:
> npm update


Only for test, for users that maybe hasn't all dependecies installed on system, they can see a message like that:

> non-existing-command
sh: non-existing-command: command not found
Script non-existing-command handling the post-update-cmd event returned with error code 127

Replace 'non-existing-command' for any binary call, including the npm added here.