### PR TITLE
fs2018: Fix Randomizer::Subcuentas generator

### DIFF
--- a/Core/Lib/RandomDataGenerator/Subcuentas.php
+++ b/Core/Lib/RandomDataGenerator/Subcuentas.php
@@ -48,14 +48,14 @@ class Subcuentas extends AbstractRandomAccounting
     {
         $subcuenta = $this->model;
         $this->shuffle($cuentas, new Model\Cuenta());
-
+        $ejercicio = new Model\Ejercicio();
         for ($generated = 0; $generated < $num; ++$generated) {
             $cuenta = $this->getOneItem($cuentas);
-
+            $ejercicioDetails = $ejercicio->get($cuenta->codejercicio);
             $subcuenta->clear();
             $subcuenta->codcuenta = $cuenta->codcuenta;
             $subcuenta->codejercicio = $cuenta->codejercicio;
-            $subcuenta->codsubcuenta = $cuenta->codcuenta . mt_rand(0, 9999);
+            $subcuenta->codsubcuenta = str_pad($cuenta->codcuenta . mt_rand(0, 9999), $ejercicioDetails->longsubcuenta, 0);
             $subcuenta->descripcion = $this->descripcion();
             $subcuenta->idcuenta = $cuenta->idcuenta;
             if (!$subcuenta->save()) {


### PR DESCRIPTION
The Subcuentas generator fails because the codsubcuenta field needs an exact length that is setted in the Accounting Year Model.

In the Randomizer::Subcuentas controller has been added a call to the Model\Ejercicio and generated the codsubcuenta inside a str_pad filling with zeros the number to match the length. 