### PR TITLE
Implement authentication via token for API. Trello Issue 94

### DIFF
--- a/Core/App/AppAPI.php
+++ b/Core/App/AppAPI.php
@@ -18,7 +18,6 @@
  */
 namespace FacturaScripts\Core\App;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use Symfony\Component\HttpFoundation\Response;
 use FacturaScripts\Core\Model\ApiKey;
 
@@ -315,7 +314,11 @@ class AppAPI extends App
     /**
      * Returns true if the client is authenticated with the header token.
      *
-     * @return bool
+     * @param string token The token to check as api key
+     *
+     * @author Ángel Guzmán Maeso <angel@guzmanmaeso.com>
+     *
+     * @return boolean
      */
     private function checkAuthToken()
     {
@@ -323,8 +326,9 @@ class AppAPI extends App
 
         if(NULL != $token)
         {
-            return (new ApiKey())->loadFromCode('', 'token=' . $token . ' AND enabled=1');
+            return (new ApiKey())->checkAuthToken($token);
         }
+
         return FALSE;
     }
 }

--- a/Core/App/AppAPI.php
+++ b/Core/App/AppAPI.php
@@ -20,6 +20,7 @@ namespace FacturaScripts\Core\App;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use Symfony\Component\HttpFoundation\Response;
+use FacturaScripts\Core\Model\ApiKey;
 
 /**
  * AppAPI is the class used for API.
@@ -57,6 +58,13 @@ class AppAPI extends App
         if ($this->isIPBanned()) {
             $this->response->setStatusCode(Response::HTTP_FORBIDDEN);
             $this->response->setContent(json_encode(['error' => 'IP-BANNED']));
+
+            return false;
+        }
+
+        if (!$this->checkAuthToken()) {
+            $this->response->setStatusCode(Response::HTTP_FORBIDDEN);
+            $this->response->setContent(json_encode(['error' => 'AUTH-TOKEN-INVALID']));
 
             return false;
         }
@@ -302,5 +310,21 @@ class AppAPI extends App
         }
 
         $this->response->setContent(json_encode($json));
+    }
+
+    /**
+     * Returns true if the client is authenticated with the header token.
+     *
+     * @return bool
+     */
+    private function checkAuthToken()
+    {
+        $token = $this->request->headers->get('Token');
+
+        if(NULL != $token)
+        {
+            return (new ApiKey())->loadFromCode('', 'token=' . $token . ' AND enabled=1');
+        }
+        return FALSE;
     }
 }

--- a/Core/App/AppAPI.php
+++ b/Core/App/AppAPI.php
@@ -20,6 +20,7 @@ namespace FacturaScripts\Core\App;
 
 use Symfony\Component\HttpFoundation\Response;
 use FacturaScripts\Core\Model\ApiKey;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 
 /**
  * AppAPI is the class used for API.

--- a/Core/Model/ApiKey.php
+++ b/Core/Model/ApiKey.php
@@ -19,6 +19,8 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+
 /**
  * ApiKey model to manage the connection tokens through the api
  * that will be generated to synchronize different applications.
@@ -101,5 +103,24 @@ class ApiKey extends Base\ModelClass
         $this->description = '';
         $this->enabled = false;
         $this->creationdate = date('d-m-Y');
+    }
+
+    /**
+     * Checks the token provided as api key
+     *
+     * @param string token The token to check as api key
+     *
+     * @author Ángel Guzmán Maeso <angel@guzmanmaeso.com>
+     *
+     * @return boolean
+     */
+    public function checkAuthToken(string $token = NULL)
+    {
+        // SELECT id FROM api_keys WHERE apikey='TOKEN' AND enabled=1
+        $where = [
+            new DataBaseWhere('apikey', $token, 'AND'),
+            new DataBaseWhere('enabled', 1)
+        ];
+        return $this->loadFromCode('', $where);
     }
 }


### PR DESCRIPTION
This PR implements the [trello issue 94](https://trello.com/c/6OZb8ttJ/94-a%C3%B1adir-autenticaci%C3%B3n-a-la-api-archivo-core-app-appapiphp). A basic authentication via header "Token" and respecting if the api key is enabled or not.

FYI: The idea and if it gets accepted in the future could be use the Security Firewall from Symfony and the API authentication
https://symfony.com/doc/current/security/api_key_authentication.html

For testing:

The token is "hola" in md5. Could be whatever string that you want.

`
INSERT INTO api_keys VALUES(1, '916f4c31aaa35d6b867dae9a7f54270d', 'Prueba', 1, NOW(), 'shakaran');`

```
mysql> select * from api_keys;
+----+----------------------------------+-------------+---------+--------------+----------+
| id | apikey                           | description | enabled | creationdate | nick     |
+----+----------------------------------+-------------+---------+--------------+----------+
|  1 | 916f4c31aaa35d6b867dae9a7f54270d | Prueba      |       1 | 2018-04-09   | shakaran |
+----+----------------------------------+-------------+---------+--------------+----------+
1 row in set (0.00 sec)

```

Valid:

```
 curl -i  -H  'Token: 916f4c31aaa35d6b867dae9a7f54270d' http://127.0.0.1:8000/api/3
HTTP/1.0 200 OK
Host: 127.0.0.1:8000
Date: Tue, 10 Apr 2018 11:54:51 +0200
Connection: close
X-Powered-By: PHP/7.1.15-0ubuntu0.17.10.1
Cache-Control: no-cache, private
Date: Tue, 10 Apr 2018 09:54:51 GMT
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, PUT, DELETE
Content-Type: application/json

{"resources":["agenciatransportes","agentes","albaranclientes","albaranproveedores","almacenes","apikeyes","articulos","articuloproveedores","asientos","atributos","atributovalores","balances","balancecuentas","balancecuentaaes","clientes","codemodeles","conceptopartidas","contactos","contactoclientes","contactoproveedores","cuentas","cuentabancos","cuentabancoclientes","cuentabancoproveedores","cuentaespeciales","dashboardes","dashboarddatas","direccionclientes","direccionproveedores","divisas","ejercicios","empresas","estadodocumentos","fabricantes","facturaclientes","facturaproveedores","familias","formapagos","grupoclientes","impuestos","lineaalbaranclientes","lineaalbaranproveedores","lineafacturaclientes","lineafacturaproveedores","lineaivafacturaclientes","lineaivafacturaproveedores","lineapedidoclientes","lineapedidoproveedores","lineapresupuestoclientes","lineapresupuestoproveedores","lineatransferenciastocks","pages","pageoptions","pais","partidas","pedidoclientes","pedidoproveedores","presupuestoclientes","presupuestoproveedores","proveedores","provincias","regularizacionivas","regularizacionstocks","roles","roleaccess","roleusers","series","settings","stocks","subcuentas","subcuentasaldos","tarifas","totalmodeles","transferenciastocks","users"]}

```

```
$ curl -s -i  -H  'Token: blabla' http://127.0.0.1:8000/api/3
HTTP/1.0 403 Forbidden
Host: 127.0.0.1:8000
Date: Tue, 10 Apr 2018 11:54:21 +0200
Connection: close
X-Powered-By: PHP/7.1.15-0ubuntu0.17.10.1
Cache-Control: no-cache, private
Date: Tue, 10 Apr 2018 09:54:21 GMT
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, PUT, DELETE
Content-Type: application/json

{"error":"AUTH-TOKEN-INVALID"}
```