### PR TITLE
Added console support (Trello task 328)

### DIFF
--- a/Core/Console/ConsoleAbstract.php
+++ b/Core/Console/ConsoleAbstract.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Console;
+
+/**
+ * Class ConsoleAbstract
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+abstract class ConsoleAbstract
+{
+    /**
+     * Arguments received from command execution.
+     *
+     * @var array
+     */
+    protected $argv;
+
+    /**
+     * Start point to run the command.
+     *
+     * @param array $params
+     *
+     * @return int
+     */
+    abstract public function run(...$params): int;
+
+    /**
+     * Return description about this class.
+     *
+     * @return string
+     */
+    abstract public function getDescription(): string;
+
+    /**
+     * Print help information to the user.
+     */
+    abstract public function showHelp();
+
+    /**
+     * Returns an associative array of available methods for the user.
+     * Add more options if you want to add support for custom methods.
+     *      [
+     *          '-h'        => 'showHelp',
+     *          '--help'    => 'showHelp',
+     *      ]
+     *
+     * @return array
+     */
+    public function getUserMethods(): array
+    {
+        return [
+            '-h' => 'showHelp',
+            '--help' => 'showHelp',
+        ];
+    }
+
+    /**
+     * Ask user to continue and return a boolean.
+     *
+     * @return bool
+     */
+    public function areYouSure()
+    {
+        echo \PHP_EOL . 'Are you sure? [y/n] ';
+        $stdin = fgets(STDIN);
+        switch (trim($stdin)) {
+            case 'y':
+            case 'Y':
+            case 'yes':
+            case 'Yes':
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/Core/Console/ConsoleManager.php
+++ b/Core/Console/ConsoleManager.php
@@ -57,7 +57,6 @@ class ConsoleManager extends ConsoleAbstract
                     break;
                 default:
                     $this->run();
-                    die();
             }
         }
 
@@ -136,6 +135,7 @@ class ConsoleManager extends ConsoleAbstract
      */
     public function execute()
     {
+        $status = -1;
         $params = $this->argv;
         \array_shift($params); // Extract console.php
         // command class
@@ -163,7 +163,8 @@ class ConsoleManager extends ConsoleAbstract
                     if (\in_array($method, \get_class_methods($className), false) ||
                         \in_array($method, \get_class_methods(\get_parent_class($className)), false)
                     ) {
-                        exit(\call_user_func_array([new $className(), 'run'], $params));
+                        $status = \call_user_func_array([new $className(), 'run'], $params);
+                        break;
                     }
                     // Can be deleted, but starting with this can be helpful
                     if (FS_DEBUG) {
@@ -173,24 +174,26 @@ class ConsoleManager extends ConsoleAbstract
                             . \PHP_EOL
                             . '#######################################################################################'
                             . \PHP_EOL;
-                        echo $msg;
+
                     }
-                } else {
-                    // Can be deleted, but starting with this can be helpful
-                    if (FS_DEBUG) {
-                        $msg = '#######################################################################################'
-                            . \PHP_EOL . '# ERROR: "' . $alias . '" not in "getUserMethods" for "' . $className . '"'
-                            . \PHP_EOL . '#    Maybe you are missing to put it in to getUserMethods?' . \PHP_EOL
-                            . '#######################################################################################'
-                            . \PHP_EOL;
-                        echo $msg;
-                    }
+                    break;
                 }
+
+                // Can be deleted, but starting with this can be helpful
+                if (FS_DEBUG) {
+                    $msg = '#######################################################################################'
+                        . \PHP_EOL . '# ERROR: "' . $alias . '" not in "getUserMethods" for "' . $className . '"'
+                        . \PHP_EOL . '#    Maybe you are missing to put it in to getUserMethods?' . \PHP_EOL
+                        . '#######################################################################################'
+                        . \PHP_EOL;
+                }
+
+                echo $msg;
 
                 $this->optionNotAvailable($cmd, $alias);
                 $this->getAvailableOptions($cmd);
         }
-        return -1;
+        return $status;
     }
 
     /**
@@ -323,9 +326,9 @@ class ConsoleManager extends ConsoleAbstract
      */
     private function getClassName($fileName)
     {
-        $directoriesAndFilename = explode(DIRECTORY_SEPARATOR, $fileName);
-        $fileName = array_pop($directoriesAndFilename);
-        $nameAndExtension = explode('.', $fileName);
-        return array_shift($nameAndExtension);
+        $dirsAndFile = explode(DIRECTORY_SEPARATOR, $fileName);
+        $fileName = array_pop($dirsAndFile);
+        $nameAndExt = explode('.', $fileName);
+        return array_shift($nameAndExt);
     }
 }

--- a/Core/Console/ConsoleManager.php
+++ b/Core/Console/ConsoleManager.php
@@ -75,7 +75,7 @@ class ConsoleManager extends ConsoleAbstract
         $cmd = $this->argv[1];
 
         if (class_exists(__NAMESPACE__ . '\\' . $cmd)) {
-            return $this->execute();
+            exit($this->execute());
         }
 
         echo \PHP_EOL . 'ERROR: Command "' . $cmd . '" not found.' . \PHP_EOL . \PHP_EOL;
@@ -174,7 +174,7 @@ class ConsoleManager extends ConsoleAbstract
                             . \PHP_EOL
                             . '#######################################################################################'
                             . \PHP_EOL;
-
+                        echo $msg;
                     }
                     break;
                 }
@@ -186,9 +186,8 @@ class ConsoleManager extends ConsoleAbstract
                         . \PHP_EOL . '#    Maybe you are missing to put it in to getUserMethods?' . \PHP_EOL
                         . '#######################################################################################'
                         . \PHP_EOL;
+                    echo $msg;
                 }
-
-                echo $msg;
 
                 $this->optionNotAvailable($cmd, $alias);
                 $this->getAvailableOptions($cmd);

--- a/Core/Console/ConsoleManager.php
+++ b/Core/Console/ConsoleManager.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Console;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * This class is a start point for php-cli commands.
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+class ConsoleManager extends ConsoleAbstract
+{
+    /**
+     * ConsoleManager constructor.
+     *
+     * @param int   $argc
+     * @param array $argv
+     */
+    public function __construct($argc, $argv)
+    {
+        $this->argv = $argv;
+
+        // Check that at least there are 2 params (console.php & command)
+        if ($argc >= 2) {
+            // Check if first param is an option or a command
+            switch ($this->argv[1]) {
+                case '-l':
+                case '--list':
+                    $this->showAvailableCommands();
+                    break;
+
+                case '-h':
+                case '--help':
+                    break;
+
+                case 0 === \strpos($this->argv[1], '-'):
+                case 0 === \strpos($this->argv[1], '--'):
+                    $this->optionNotAvailable($this->argv[0], $this->argv[1]);
+                    break;
+                default:
+                    $this->run();
+                    die();
+            }
+        }
+
+        $this->showHelp();
+    }
+
+    /**
+     * Start point to run the command.
+     *
+     * @param array $params
+     *
+     * @return mixed
+     */
+    public function run(...$params): int
+    {
+        $cmd = $this->argv[1];
+
+        if (class_exists(__NAMESPACE__ . '\\' . $cmd)) {
+            return $this->execute();
+        }
+
+        echo \PHP_EOL . 'ERROR: Command "' . $cmd . '" not found.' . \PHP_EOL . \PHP_EOL;
+
+        $this->showHelp();
+        die();
+    }
+
+    /**
+     * Return description about this class.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'The Console Manager';
+    }
+
+    /**
+     * Print help information to the user.
+     */
+    public function showHelp()
+    {
+        echo 'Use as: php console.php [COMMAND] [OPTIONS]' . \PHP_EOL;
+        echo 'Available options:' . \PHP_EOL;
+        echo '   -h, --help        Show this help.' . \PHP_EOL;
+        echo '   -l, --list        Show a list of available commands.' . \PHP_EOL;
+        echo \PHP_EOL;
+    }
+
+    /**
+     * Returns an associative array of available methods for the user.
+     * Add more options if you want to add support for custom methods.
+     *      [
+     *          '-h'        => 'showHelp',
+     *          '--help'    => 'showHelp',
+     *          '-l'        => 'showAvailableCommands',
+     *          '--list'    => 'showAvailableCommands',
+     *      ]
+     *
+     * @return array
+     */
+    public function getUserMethods(): array
+    {
+        // Adding extra method
+        $methods = parent::getUserMethods();
+        $methods['-l'] = 'showAvailableCommands';
+        $methods['--list'] = 'showAvailableCommands';
+
+        return $methods;
+    }
+
+    /**
+     * Exec the command with the given options
+     *
+     * @return mixed
+     */
+    public function execute()
+    {
+        $params = $this->argv;
+        \array_shift($params); // Extract console.php
+        // command class
+        $cmd = \array_shift($params); // Extract command
+        // $params contains adicional parameters if are received
+
+        switch ($cmd) {
+            case '-h':
+            case '--help':
+                $this->getAvailableOptions($cmd);
+                break;
+            default:
+                $className = __NAMESPACE__ . '\\' . $cmd;
+                $methods = \call_user_func([new $className(), 'getUserMethods']);
+                // Forced in ConsoleAbstract, but we don't want to show it to users
+                $methods['run'] = 'run';
+
+                // If not alias, we want to directly run
+                $alias = $params[0] ?? 'run';
+                // If not method match, show how it works
+                $method = $methods[$alias[0]] ?? 'showHelp';
+
+                if (\array_key_exists($alias, $methods)) {
+                    // Check if method is in class or parent class
+                    if (\in_array($method, \get_class_methods($className), false) ||
+                        \in_array($method, \get_class_methods(\get_parent_class($className)), false)
+                    ) {
+                        exit(\call_user_func_array([new $className(), 'run'], $params));
+                    }
+                    // Can be deleted, but starting with this can be helpful
+                    if (FS_DEBUG) {
+                        $msg = '#######################################################################################'
+                            . \PHP_EOL . '# ERROR: "' . $method . '" not defined in "' . $className . '"' . \PHP_EOL
+                            . '#    Maybe you have a misspelling on the method name or is a missing declaration?'
+                            . \PHP_EOL
+                            . '#######################################################################################'
+                            . \PHP_EOL;
+                        echo $msg;
+                    }
+                } else {
+                    // Can be deleted, but starting with this can be helpful
+                    if (FS_DEBUG) {
+                        $msg = '#######################################################################################'
+                            . \PHP_EOL . '# ERROR: "' . $alias . '" not in "getUserMethods" for "' . $className . '"'
+                            . \PHP_EOL . '#    Maybe you are missing to put it in to getUserMethods?' . \PHP_EOL
+                            . '#######################################################################################'
+                            . \PHP_EOL;
+                        echo $msg;
+                    }
+                }
+
+                $this->optionNotAvailable($cmd, $alias);
+                $this->getAvailableOptions($cmd);
+        }
+        return -1;
+    }
+
+    /**
+     * Returns a list of available methods for this command.
+     *
+     * @param string $cmd
+     */
+    public function getAvailableOptions($cmd)
+    {
+        echo 'Available options for "' . $cmd . '"' . \PHP_EOL . \PHP_EOL;
+
+        $className = __NAMESPACE__ . '\\' . $cmd;
+        $options = \call_user_func([new $className(), 'getUserMethods']);
+
+        foreach ((array) $options as $option => $methods) {
+            echo '   ' . $option . \PHP_EOL;
+        }
+
+        echo \PHP_EOL . 'Use as: php console.php ' . $cmd . ' [OPTIONS]' . \PHP_EOL . \PHP_EOL;
+
+        die();
+    }
+
+    /**
+     * Print help information to the user.
+     */
+    public function showAvailableCommands()
+    {
+        echo 'Available commands:' . \PHP_EOL;
+
+        foreach ($this->getAvailableCommands() as $cmd) {
+            $className = __NAMESPACE__ . '\\' . $cmd;
+            echo '   - ' . $cmd . ' : ' . \call_user_func([new $className(), 'getDescription']) . \PHP_EOL;
+        }
+        echo \PHP_EOL;
+    }
+
+    /**
+     * Return a list of available commands
+     *
+     * @return array
+     */
+    public function getAvailableCommands(): array
+    {
+        $available = [];
+        $allClasses = $this->getAllFcqns(__DIR__);
+        $exclude = [__NAMESPACE__ . '\\' . 'ConsoleManager', __NAMESPACE__ . '\\' . 'ConsoleAbstract'];
+        foreach ($allClasses as $class) {
+            if (0 === \strpos($class, __NAMESPACE__ . '\\') && !\in_array($class, $exclude, false)) {
+                $available[] = \str_replace(__NAMESPACE__ . '\\', '', $class);
+            }
+        }
+        return $available;
+    }
+
+    /**
+     * Show that this option is not available.
+     *
+     * @param string $cmd
+     * @param string $option
+     */
+    private function optionNotAvailable($cmd, $option)
+    {
+        echo 'Option "' . $option . '" not available for "' . $cmd . '".' . \PHP_EOL . \PHP_EOL;
+    }
+
+    /**
+     * TODO: All this following methods can be replaced when we have an alternative way to manage services.
+     *
+     * @example https://symfony.com/doc/current/console.html#getting-services-from-the-service-container
+     * @example https://symfony.com/doc/current/service_container.html#handling-multiple-services
+     *
+     * This way, we can register new services, and get it when needed.
+     *
+     * This isn't the best way to do that, but at this time, is a first rapprochement that works.
+     */
+
+    /**
+     * @param string $projectRoot
+     *
+     * @return array
+     */
+    private function getAllFcqns($projectRoot): array
+    {
+        $fileNames = $this->getFileNames($projectRoot);
+        $fcqns = [];
+        foreach ($fileNames as $fileName) {
+            $fcqns[] = $this->getFullNameSpace($fileName) . '\\' . $this->getClassName($fileName);
+        }
+
+        return $fcqns;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return array
+     */
+    private function getFileNames($path): array
+    {
+        $finder = new Finder();
+        $finder->files()->in($path)->name('*.php');
+        $fileNames = [];
+        foreach ($finder as $finderFile) {
+            $fileNames[] = $finderFile->getRealPath();
+        }
+
+        return $fileNames;
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return mixed
+     */
+    private function getFullNameSpace($fileName)
+    {
+        $lines = file($fileName);
+        $array = preg_grep('/^namespace /', $lines);
+        $namespaceLine = array_shift($array);
+        $matches = [];
+        preg_match('/^namespace (.*);$/', $namespaceLine, $matches);
+        return array_pop($matches);
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return mixed
+     */
+    private function getClassName($fileName)
+    {
+        $directoriesAndFilename = explode(DIRECTORY_SEPARATOR, $fileName);
+        $fileName = array_pop($directoriesAndFilename);
+        $nameAndExtension = explode('.', $fileName);
+        return array_shift($nameAndExtension);
+    }
+}

--- a/Core/Console/OrderXmlTables.php
+++ b/Core/Console/OrderXmlTables.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Console;
+
+use DOMDocument;
+use SimpleXMLElement;
+
+/**
+ * Class OrderXMLTable
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+class OrderXmlTables extends ConsoleAbstract
+{
+    /**
+     * Constant values for return, to easy know how execution ends.
+     */
+    const RETURN_SUCCESS = 0;
+    const RETURN_SRC_FOLDER_NOT_SET = 1;
+    const RETURN_DST_FOLDER_NOT_SET = 2;
+    const RETURN_TAGNAME_NOT_SET = 3;
+    const RETURN_CANT_CREATE_FOLDER = 4;
+    const RETURN_FAIL_SAVING_FILE = 5;
+    const RETURN_NO_FILES = 6;
+    const RETURN_SRC_FOLDER_NOT_EXISTS = 7;
+
+    /**
+     * Folder source path.
+     *
+     * @var string
+     */
+    private $folderSrcPath;
+
+    /**
+     * Folder destiny path.
+     *
+     * @var string
+     */
+    private $folderDstPath;
+
+    /**
+     * Tagname used for order.
+     *
+     * @var string
+     */
+    private $tagName;
+
+    /**
+     * Set default source folder.
+     *
+     * @param string $folderSrcPath
+     */
+    public function setFolderSrcPath($folderSrcPath)
+    {
+        $this->folderSrcPath = $folderSrcPath;
+    }
+
+    /**
+     * Set default destiny folder.
+     *
+     * @param string $folderDstPath
+     */
+    public function setFolderDstPath($folderDstPath)
+    {
+        $this->folderDstPath = $folderDstPath;
+    }
+
+    /**
+     * Set tag name.
+     *
+     * @param string $tagName
+     */
+    public function setTagName($tagName)
+    {
+        $this->tagName = $tagName;
+    }
+
+    /**
+     * Run the OrderXMLTable script.
+     *
+     * @param array $params
+     *
+     * @return int
+     */
+    public function run(...$params): int
+    {
+        $this->checkOptions($params);
+
+        $this->setFolderSrcPath($params[0] ?? \FS_FOLDER . '/Core/Table/');
+        $this->setFolderDstPath($params[1] ?? \FS_FOLDER . '/Core/Table/');
+        $this->setTagName($params[2] ?? 'name');
+
+        echo 'Options setted:' . \PHP_EOL;
+        echo '   Source path: ' . $this->folderSrcPath . \PHP_EOL;
+        echo '   Destiny path: ' . $this->folderDstPath . \PHP_EOL;
+        echo '   Tag name: ' . $this->tagName . \PHP_EOL;
+        if (!$this->areYouSure()) {
+            echo 'Run as: php ' . __CLASS__ . ' [SRC] [DST] [TAG]' . \PHP_EOL;
+            return self::RETURN_SUCCESS;
+        }
+
+        $status = $this->check();
+        if ($status > 0) {
+            return $status;
+        }
+
+        $files = array_diff(scandir($this->folderSrcPath, SCANDIR_SORT_ASCENDING), ['.', '..']);
+
+        if (\count($files) === 0) {
+            echo 'ERROR: No files on folder' . \PHP_EOL;
+            return self::RETURN_NO_FILES;
+        }
+
+        foreach ($files as $fileName) {
+            $xml = simplexml_load_string(file_get_contents($this->folderSrcPath . $fileName));
+            // Get all children of table into an array
+            $table = (array) $xml->children();
+            if (!isset($table['column'])) {
+                echo 'File is incorrect ' . $this->folderSrcPath . $fileName . \PHP_EOL;
+                break;
+            }
+            $columns = $table['column'];
+            if (isset($table['constraint'])) {
+                $constraints = $table['constraint'];
+            }
+
+            // Call usort on the array
+            if (!\is_object($columns)) {
+                usort($columns, [$this, 'sortName']);
+            }
+
+            /** @noinspection NotOptimalIfConditionsInspection */
+            /** @noinspection PhpUndefinedVariableInspection */
+            if (isset($table['constraint']) && !\is_object($constraints)) {
+                usort($constraints, [$this, 'sortName']);
+            }
+
+            // Generate string XML result
+            $strXML = $this->generateXMLHeader($fileName);
+            $strXML .= $this->generateXMLContent($columns);
+            if (isset($table['constraint'])) {
+                /** @noinspection PhpUndefinedVariableInspection */
+                $strXML .= $this->generateXMLContent($constraints, 'constraint');
+            }
+            $strXML .= $this->generateXMLFooter();
+
+            $dom = new DOMDocument();
+            $dom->loadXML($strXML);
+            $filePath = $this->folderDstPath . '/' . $fileName;
+            if ($dom->save($filePath) === false) {
+                echo "ERROR: Can't save file " . $filePath . \PHP_EOL;
+                return self::RETURN_FAIL_SAVING_FILE;
+            }
+        }
+
+        echo 'Finished! Look at "' . $this->folderDstPath . '"' . \PHP_EOL;
+        return self::RETURN_SUCCESS;
+    }
+
+    /**
+     * Return description about this class.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Order XML content files by tag name.';
+    }
+
+    /**
+     * Print help information to the user.
+     */
+    public function showHelp()
+    {
+        $array = \explode('\\', __CLASS__);
+        $class = array_pop($array);
+        echo 'Use as: php console.php ' . $class . ' [OPTIONS]' . \PHP_EOL;
+        echo 'Available options:' . \PHP_EOL;
+        echo '   -h, --help        Show this help.' . \PHP_EOL;
+        echo \PHP_EOL;
+        echo '   OPTION1           Source path' . \PHP_EOL;
+        echo '   OPTION2           Destiny path' . \PHP_EOL;
+        echo '   OPTION3           Tag name' . \PHP_EOL;
+        echo \PHP_EOL;
+    }
+
+    /**
+     * Returns an associative array of available methods for the user.
+     * Add more options if you want to add support for custom methods.
+     *      [
+     *          '-h'        => 'showHelp',
+     *          '--help'    => 'showHelp',
+     *      ]
+     *
+     * @return array
+     */
+    public function getUserMethods(): array
+    {
+        return [
+            '-h' => 'showHelp',
+            '--help' => 'showHelp'
+        ];
+    }
+
+    /**
+     * @param array $params
+     */
+    private function checkOptions(array $params = [])
+    {
+        if (isset($params[0])) {
+            switch ($params[0]) {
+                case '-h':
+                case '--help':
+                    $this->showHelp();
+                    break;
+            }
+            die();
+        }
+    }
+
+    /**
+     * Launch basic checks.
+     *
+     * @return int
+     */
+    private function check(): int
+    {
+        if ($this->folderSrcPath === null) {
+            echo 'ERROR: Source folder not setted.' . \PHP_EOL;
+            return self::RETURN_SRC_FOLDER_NOT_SET;
+        }
+
+        if ($this->folderDstPath === null) {
+            echo 'ERROR: Destiny folder not setted.' . \PHP_EOL;
+            return self::RETURN_DST_FOLDER_NOT_SET;
+        }
+
+        if ($this->tagName === null) {
+            echo 'ERROR: Tag name not setted.' . \PHP_EOL;
+            return self::RETURN_TAGNAME_NOT_SET;
+        }
+
+        if (!is_dir($this->folderSrcPath)) {
+            echo 'ERROR: Source folder ' . $this->folderSrcPath . ' not exists.' . \PHP_EOL;
+            return self::RETURN_SRC_FOLDER_NOT_EXISTS;
+        }
+
+
+        if (!is_file($this->folderDstPath) && !@mkdir($this->folderDstPath) && !is_dir($this->folderDstPath)) {
+            echo "ERROR: Can't create folder " . $this->folderDstPath;
+            return self::RETURN_CANT_CREATE_FOLDER;
+        }
+
+        return self::RETURN_SUCCESS;
+    }
+
+    /**
+     * Custom function to re-order with usort.
+     *
+     * @param SimpleXMLElement $a
+     * @param SimpleXMLElement $b
+     *
+     * @return int
+     */
+    private function sortName($a, $b): int
+    {
+        return strcasecmp($a->{$this->tagName}, $b->{$this->tagName});
+    }
+
+    /**
+     * Generate the content of the XML.
+     *
+     * @param array|object $data
+     * @param string       $tagName
+     *
+     * @return string
+     */
+    private function generateXMLContent($data, $tagName = 'column'): string
+    {
+        $str = '';
+        if (\is_array($data)) {
+            foreach ($data as $field) {
+                $str .= '    <' . $tagName . '>' . PHP_EOL;
+                foreach ((array) $field as $key => $value) {
+                    $str .= '        <' . $key . '>' . $value . '</' . $key . '>' . PHP_EOL;
+                }
+                $str .= '    </' . $tagName . '>' . PHP_EOL;
+            }
+        } else {
+            $str .= '    <' . $tagName . '>' . PHP_EOL;
+            foreach ((array) $data as $key => $value) {
+                $str .= '        <' . $key . '>' . $value . '</' . $key . '>' . PHP_EOL;
+            }
+            $str .= '    </' . $tagName . '>' . PHP_EOL;
+        }
+
+        return $str;
+    }
+
+    /**
+     * Generate the header of the XML.
+     *
+     * @param string $fileName
+     *
+     * @return string
+     */
+    private function generateXMLHeader($fileName): string
+    {
+        $str = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
+        $str .= '<!--' . PHP_EOL;
+        $str .= '    Document   : ' . $fileName . PHP_EOL;
+        $str .= '    Author     : Carlos Garcia Gomez' . PHP_EOL;
+        $str .= '    Description: Structure for the ' . str_replace('.xml', '', $fileName) . ' table.' . PHP_EOL;
+        $str .= '-->' . PHP_EOL;
+        $str .= '<table>' . PHP_EOL;
+
+        return $str;
+    }
+
+    /**
+     * Generate the footer of the XML.
+     *
+     * @return string
+     */
+    private function generateXMLFooter(): string
+    {
+        return '</table>';
+    }
+}

--- a/Core/Console/OrderXmlTables.php
+++ b/Core/Console/OrderXmlTables.php
@@ -274,14 +274,14 @@ class OrderXmlTables extends ConsoleAbstract
     /**
      * Custom function to re-order with usort.
      *
-     * @param SimpleXMLElement $a
-     * @param SimpleXMLElement $b
+     * @param SimpleXMLElement $xmlA
+     * @param SimpleXMLElement $xmlB
      *
      * @return int
      */
-    private function sortName($a, $b): int
+    private function sortName($xmlA, $xmlB): int
     {
-        return strcasecmp($a->{$this->tagName}, $b->{$this->tagName});
+        return strcasecmp($xmlA->{$this->tagName}, $xmlB->{$this->tagName});
     }
 
     /**
@@ -303,7 +303,8 @@ class OrderXmlTables extends ConsoleAbstract
                 }
                 $str .= '    </' . $tagName . '>' . PHP_EOL;
             }
-        } else {
+        }
+        if (\is_object($data)) {
             $str .= '    <' . $tagName . '>' . PHP_EOL;
             foreach ((array) $data as $key => $value) {
                 $str .= '        <' . $key . '>' . $value . '</' . $key . '>' . PHP_EOL;

--- a/Core/Console/OrderXmlTables.php
+++ b/Core/Console/OrderXmlTables.php
@@ -128,6 +128,18 @@ class OrderXmlTables extends ConsoleAbstract
             return self::RETURN_NO_FILES;
         }
 
+        return $this->orderXml($files);
+    }
+
+    /**
+     * Order Xml files
+     *
+     * @param array $files
+     *
+     * @return int
+     */
+    private function orderXml($files)
+    {
         foreach ($files as $fileName) {
             $xml = simplexml_load_string(file_get_contents($this->folderSrcPath . $fileName));
             // Get all children of table into an array
@@ -137,19 +149,17 @@ class OrderXmlTables extends ConsoleAbstract
                 break;
             }
             $columns = $table['column'];
-            if (isset($table['constraint'])) {
-                $constraints = $table['constraint'];
-            }
 
             // Call usort on the array
             if (!\is_object($columns)) {
                 usort($columns, [$this, 'sortName']);
             }
 
-            /** @noinspection NotOptimalIfConditionsInspection */
-            /** @noinspection PhpUndefinedVariableInspection */
-            if (isset($table['constraint']) && !\is_object($constraints)) {
-                usort($constraints, [$this, 'sortName']);
+            if (isset($table['constraint'])) {
+                $constraints = $table['constraint'];
+                if (!\is_object($constraints)) {
+                    usort($constraints, [$this, 'sortName']);
+                }
             }
 
             // Generate string XML result

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "rospdf/pdf-php": "0.12.43",
         "symfony/http-foundation": "^3.4",
         "symfony/translation": "^3.4",
-        "twig/twig": "v2.*"
+        "twig/twig": "v2.*",
+        "symfony/finder": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.*",

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "rospdf/pdf-php": "0.12.43",
         "symfony/http-foundation": "^3.4",
         "symfony/translation": "^3.4",
-        "twig/twig": "v2.*",
-        "symfony/finder": "^4.0"
+        "twig/twig": "v2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.*",
-        "squizlabs/php_codesniffer": "^3.2"
+        "squizlabs/php_codesniffer": "^3.2",
+        "symfony/finder": "^3.4.8"
     },
     "autoload": {
         "psr-4": {

--- a/console.php
+++ b/console.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+if (\PHP_SAPI !== 'cli') {
+    die('Access allowed only in command line.');
+}
+
+define('FS_FOLDER', __DIR__);
+
+/** @noinspection PhpIncludeInspection */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+if (file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'config.php')) {
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'config.php';
+} elseif (file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'config-scrutinizer.php')) {
+    // Allows to use it if you are in development,
+    // but need to use at least this config as development environment.
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'config-scrutinizer.php';
+}
+
+new FacturaScripts\Core\Console\ConsoleManager($_SERVER['argc'], $_SERVER['argv']);


### PR DESCRIPTION
- Added start point from console.php
- Added Core/Console/ConsoleManager.php to centralize an innittial basic control from console.php
    Contains pending work that maybe we need to change in the future (to avoid depends of symfony/finder)
    Maybe symfony/finder can also be useful to look for trans on xml, twig and php files.
- Added Core/Console/ConsoleAbstract.php to abstract common needed methods

Usage samples:
- php console : Show help
- php console -h : Show help
- php console -l : Show a list of available commands
- php console OrderXmlTables : Run with default values
- php console OrderXmlTables -h : Show help for OrderXmlTables, including details about optional parameters