### PR TITLE
 Translated using Weblate and  Change '%' into name per 'percentage'

### DIFF
--- a/Core/Translation/ca_ES.json
+++ b/Core/Translation/ca_ES.json
@@ -1196,5 +1196,8 @@
     "asset": "Actiu",
     "liabilities": "Passiu",
     "profit-and-loss": "Pèrdues i Guanys",
-    "income-and-expenses": "Ingressos i Despeses"
+    "income-and-expenses": "Ingressos i Despeses",
+    "percentage-vat": "% IVA",
+    "percentage-surcharge": "% R.E.",
+    "percentage-commission": "% Comissió"
 }

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -1,7 +1,4 @@
 {
-    "%-surcharge": "% Surcharge",
-    "%-vat": "% VAT",
-    "%-commission": "% Commission",
     "about": "About",
     "accept": "Accept",
     "account": "Account",
@@ -662,5 +659,8 @@
     "asset": "Asset",
     "liabilities": "Liabilities",
     "profit-and-loss": "Profit and Loss",
-    "income-and-expenses": "Income and Expenses"
+    "income-and-expenses": "Income and Expenses",
+    "percentage-vat": "% VAT",
+    "percentage-surcharge": "% Surcharge",
+    "percentage-commission": "% Commission"
 }

--- a/Core/Translation/en_US.json
+++ b/Core/Translation/en_US.json
@@ -1123,5 +1123,8 @@
     "asset": "Asset",
     "liabilities": "Liabilities",
     "profit-and-loss": "Profit and Loss",
-    "income-and-expenses": "Income and Expenses"
+    "income-and-expenses": "Income and Expenses",
+    "percentage-vat": "% VAT",
+    "percentage-surcharge": "% Surcharge",
+    "percentage-commission": "% Commission"
 }

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -1286,5 +1286,8 @@
     "asset": "Activo",
     "liabilities": "Pasivo",
     "profit-and-loss": "Pérdidas y Ganancias",
-    "income-and-expenses": "Ingresos y Gastos"
+    "income-and-expenses": "Ingresos y Gastos",
+    "percentage-vat": "% IVA",
+    "percentage-surcharge": "% R.E.",
+    "percentage-commission": "% Comisión"
 }

--- a/Core/XMLView/EditAgente.xml
+++ b/Core/XMLView/EditAgente.xml
@@ -40,7 +40,7 @@
             <column name="position" numcolumns="4" order="140">
                 <widget type="text" fieldname="cargo" />
             </column>
-            <column name="commission" title="%-commission" numcolumns="4" order="150">
+            <column name="commission" title="percentage-commission" numcolumns="4" order="150">
                 <widget type="number" fieldname="porcomision" />
             </column>
             <column name="phone" numcolumns="4" order="160">

--- a/Core/XMLView/ListImpuesto.xml
+++ b/Core/XMLView/ListImpuesto.xml
@@ -19,7 +19,7 @@
  *
  * Initial description for the controller ListImpuesto
  *
- * @author Artex Trading sa <jcuello@artextrading.com>  
+ * @author Artex Trading sa <jcuello@artextrading.com>
 -->
 
 <view>
@@ -30,10 +30,10 @@
         <column name="description" order="110">
             <widget type="text" fieldname="descripcion" />
         </column>
-        <column name="vat" title="%-vat" display="right" order="120">
+        <column name="vat" title="percentage-vat" display="right" order="120">
             <widget type="number" decimal="2" fieldname="iva" />
         </column>
-        <column name="surcharge" title="%-surcharge" display="right" order="130">
+        <column name="surcharge" title="percentage-surcharge" display="right" order="130">
             <widget type="number" decimal="2" fieldname="recargo" />
         </column>
     </columns>


### PR DESCRIPTION
The '%' symbol is changed to 'percentage' text to avoid errors and confusion with the variables that use the same symbol in their declaration.