### PR TITLE
Added Tests related to JSON translation files (Trello task 340)

### DIFF
--- a/Test/Core/Translation/TranslationTest.php
+++ b/Test/Core/Translation/TranslationTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017    Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Translation;
+
+/**
+ * Class to verify that all JSON files from translation are correct
+ */
+class TranslationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var string
+     */
+    protected $mainLang;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->basePath = FS_FOLDER . '/Core/Translation/';
+        $this->mainLang = 'en_EN.json';
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * Test that all files have well format.
+     */
+    public function testFiles()
+    {
+        foreach ($this->scanFolder($this->basePath) as $fileName) {
+            $fileArray = $this->readJSON($this->basePath . $fileName);
+            $msg = 'File ' . $fileName . ' is wrong';
+            $this->assertNotNull($fileArray, $msg);
+        }
+    }
+
+    /**
+     * Test that secondary language don't have waste keys.
+     * Must fail when user adds on wrong file.
+     */
+    public function testWasteKeys()
+    {
+        $mainLangArray = $this->readJSON($this->basePath . $this->mainLang);
+
+        foreach ($this->scanFolder($this->basePath) as $fileName) {
+            $fileArray = $this->readJSON($this->basePath . $fileName);
+            $this->compareKeys($mainLangArray, $fileArray, $fileName);
+        }
+    }
+
+    /**
+     * Check that every language file have ordered keys on list.
+     */
+    public function testHasOrderedKeys()
+    {
+        foreach ($this->scanFolder($this->basePath) as $fileName) {
+            $fileString = $this->getJSON($this->basePath . $fileName);
+            $orderedArray = \json_decode($fileString, true);
+            \ksort($orderedArray);
+            $orderedString = json_encode($orderedArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+            $msg = 'File ' . $fileName . ' have no ordered keys.';
+            //$this->assertEquals($fileString, $orderedString, $msg);
+        }
+    }
+
+    /**
+     * Verify that all language keys are also on main language.
+     *
+     * @param array $primaryArray
+     * @param array $secondaryArray
+     * @param string $fileName
+     */
+    private function compareKeys(array $primaryArray, array &$secondaryArray, string $fileName)
+    {
+        foreach ($secondaryArray as $key => $value) {
+            $exists = array_key_exists($key, $primaryArray);
+            $msg = 'Key \'' . $key . '\' not exists on ' . $this->mainLang . '.';
+            // Require remove unneeded translations
+            //$this->assertTrue($exists, $msg);
+        }
+    }
+
+    /**
+     * Returns an array with all files and folders.
+     *
+     * @param string $folderPath
+     *
+     * @return array
+     */
+    private function scanFolder(string $folderPath): array
+    {
+        return array_diff(scandir($folderPath, SCANDIR_SORT_ASCENDING), ['.', '..']);
+    }
+
+    /**
+     * Reads a JSON from disc and return it content as array.
+     *
+     * @param string $pathName
+     *
+     * @return mixed
+     */
+    private function readJSON(string $pathName)
+    {
+        return json_decode(file_get_contents($pathName), true);
+    }
+
+    /**
+     * Get JSON as string.
+     *
+     * @param string $pathName
+     *
+     * @return bool|string
+     */
+    private function getJSON(string $pathName)
+    {
+        return file_get_contents($pathName);
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,12 @@
                     phpVersionOperator=">=">
                 Test/Core/Model/
             </directory>
+            <directory
+                    suffix="Test.php"
+                    phpVersion="7.0"
+                    phpVersionOperator=">=">
+                Test/Core/Translation/
+            </directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
## Description

<!---NOTE: All links like this are comments, no need to be removed.--->
<!---Please include a summary of the change.--->
<!---If solves an open issue, link to it including: Fixes # (issue)--->

- Check that all files have well format

> Prepared tests but disabled from now:
> - Look for waste keys on all files comparing to en_EN
> - Verify that JSON are keys sorted
> 

**Note:** This is the sample suggested [here](https://github.com/NeoRazorX/facturascripts/pull/407)

## Type of change

<!---Please delete options that are not relevant.--->

- `Added` (non-breaking change which adds functionality)


## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Please describe the additional tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your custom test configuration.--->

- [X] Clean database
- [ ] Database with random data
- [X] Checked with `vendor/bin/phpcbf --tab-width=4 --encoding=utf-8 --standard=phpcs.xml Core -s` before submit
- [X] Checked with `vendor/bin/phpcs --tab-width=4 --encoding=utf-8 --standard=phpcs.xml Core -s` before submit
- [X] Checked with `vendor/bin/phpunit --configuration phpunit.xml` before submit
<!---- [ ] If additional tests was realized, added here--->


## Checklist:

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Please add additional points if needed.--->

- [X] My code follows the [style guidelines](https://github.com/NeoRazorX/facturascripts/blob/master/CONTRIBUTING.md#pull-requests-peticiones-para-incorporar-cambios) of this project. At least [PSR-1](http://www.php-fig.org/psr/psr-1/) and [PSR-2](http://www.php-fig.org/psr/psr-2/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes to external code (as plugins) have been notified to be updated