### PR TITLE
Add dialog when remove a plugin

### DIFF
--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -714,5 +714,6 @@
     "email-bcc": "Email Blind Carbon Copy",
     "delete-plugin": "Delete plugins",
     "you-will-remove-this-plugin": "You will remove this plugin",
-    "are-you-sure?": "Are you sure?"
+    "are-you-sure?": "Are you sure?",
+    "are-you-sure-plugin": "You will delete %pluginName% plugin. Are you sure?"
 }

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -672,7 +672,7 @@
     "attached-file": "Attached file",
     "file-name": "File name",
     "full-path": "Full path",
-    "uploaded-at" : "Uploaded at",
+    "uploaded-at": "Uploaded at",
     "hash": "Hash",
     "field-can-not-be-null": "Field %fieldName% on table %tableName% can't be null",
     "vat-regularization": "VAT Regularization",
@@ -711,5 +711,8 @@
     "bcc": "BCC",
     "email-to": "Email To",
     "email-cc": "Email Carbon Copy",
-    "email-bcc": "Email Blind Carbon Copy"
+    "email-bcc": "Email Blind Carbon Copy",
+    "delete-plugin": "Delete plugins",
+    "you-will-remove-this-plugin": "You will remove this plugin",
+    "are-you-sure?": "Are you sure?"
 }

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -1339,7 +1339,6 @@
     "email-to": "Email para",
     "email-cc": "Email Con Copia",
     "email-bcc": "Email Con Copia Oculta",
-    "delete-plugin": "Eliminar plugin",
     "you-will-remove-this-plugin": "Usted eliminará el plugin seleccionado",
     "are-you-sure?": "¿Estás seguro?"
 }

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -1338,5 +1338,8 @@
     "bcc": "CCO",
     "email-to": "Email para",
     "email-cc": "Email Con Copia",
-    "email-bcc": "Email Con Copia Oculta"
+    "email-bcc": "Email Con Copia Oculta",
+    "delete-plugin": "Eliminar plugin",
+    "you-will-remove-this-plugin": "Usted eliminará el plugin seleccionado",
+    "are-you-sure?": "¿Estás seguro?"
 }

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -29,9 +29,13 @@
     {{ parent() }}
     <script type="text/javascript">
         function deletePlugin(pluginName) {
+            // This is a workaround because we can't translate in real time.
+            var msg = "{{ i18n.trans('are-you-sure-plugin', {'%pluginName%': 'placeholder'}) }}";
+            msg = msg.replace('placeholder', pluginName);
+
             bootbox.confirm({
                 title: "{{ i18n.trans('confirm-delete')|raw }}",
-                message: "{{ i18n.trans('are-you-sure') }}",
+                message: msg,
                 closeButton: false,
                 buttons: {
                     cancel: {

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -28,6 +28,7 @@
 {% block javascripts %}
     {{ parent() }}
     <script type="text/javascript">
+        //Function to show confirmation popup to remove a plugin
         function deletePlugin(pluginName) {
             // This is a workaround because we can't translate in real time.
             var msg = "{{ i18n.trans('are-you-sure-plugin', {'%pluginName%': 'placeholder'}) }}";

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -25,6 +25,36 @@
 
 {% extends "Master/MenuTemplate.html.twig" %}
 
+{% block javascripts %}
+    {{ parent() }}
+    <script type="text/javascript">
+        function deletePlugin(pluginName) {
+            bootbox.confirm({
+                title: "{{ i18n.trans('confirm-delete')|raw }}",
+                message: "{{ i18n.trans('are-you-sure') }}",
+                closeButton: false,
+                buttons: {
+                    cancel: {
+                        label: "<i class='fa fa-times'></i> {{ i18n.trans('cancel') }}"
+                    },
+                    confirm: {
+                        label: "<i class='fa fa-check'></i> {{ i18n.trans('delete') }}",
+                        className: 'btn-danger'
+                    }
+                },
+                callback: function (result) {
+                    if (result) {
+                       execActionForm(pluginName);
+                    }
+                }
+            });
+        }
+        function execActionForm(pluginName) {
+            window.location = "{{fsc.url()}}?action=remove"+"\u0026"+"plugin=" + pluginName;
+        }
+    </script>
+{% endblock %}
+
 {% block body %}
     {# Calculate texts according to language #}
     {% set refresh = i18n.trans('refresh-page') %}
@@ -102,7 +132,7 @@
                                         <i class="fa fa-check" aria-hidden="true"></i>
                                         <span class="d-none d-sm-inline-block">&nbsp;{{ enable }}</span>
                                     </a>
-                                    <a class="btn btn-sm btn-danger" href="{{ fsc.url() }}?action=remove&amp;plugin={{ plugin.name }}">
+                                    <a class="btn btn-sm btn-danger" href="#" onclick="deletePlugin('{{ plugin.name }}' )">
                                         <i class="fa fa-trash" aria-hidden="true"></i>
                                         <span class="d-none d-sm-inline-block">&nbsp;{{ delete }}</span>
                                     </a>

--- a/Dinamic/Lib/ExtendedController/BaseView.php
+++ b/Dinamic/Lib/ExtendedController/BaseView.php
@@ -5,6 +5,6 @@
  * @package FacturaScripts\Dinamic\Lib\ExtendedController
  * @author Carlos García Gómez <carlos@facturascripts.com>
  */
-class BaseView extends \FacturaScripts\Core\Lib\ExtendedController\BaseView
+abstract class BaseView extends \FacturaScripts\Core\Lib\ExtendedController\BaseView
 {
 }


### PR DESCRIPTION
# Pull Request Template

## Description

<!---NOTE: All links like this are comments, no need to be removed.--->
<!---Please include a summary of the change.--->
<!---If solves an open issue, link to it including: Fixes # (issue)--->

Added popup dialog when user try remove a plugin to guarantee the action.


## Type of change

<!---Please delete options that are not relevant.--->

- `Added` (non-breaking change which adds functionality)


## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Please describe the additional tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your custom test configuration.--->

- [X] Clean database
- [X] Database with random data
- [X] Checked with `vendor/bin/phpcbf --tab-width=4 --encoding=utf-8 --standard=phpcs.xml Core -s` before submit
- [X] Checked with `vendor/bin/phpcs --tab-width=4 --encoding=utf-8 --standard=phpcs.xml Core -s` before submit
- [X] Checked with `vendor/bin/phpunit --configuration phpunit.xml` before submit
<!---- [ ] If additional tests was realized, added here--->


## Checklist:

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Please add additional points if needed.--->

- [X] My code follows the [style guidelines](https://github.com/NeoRazorX/facturascripts/blob/master/CONTRIBUTING.md#pull-requests-peticiones-para-incorporar-cambios) of this project. At least [PSR-1](http://www.php-fig.org/psr/psr-1/) and [PSR-2](http://www.php-fig.org/psr/psr-2/)
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes to external code (as plugins) have been notified to be updated
