### PR TITLE
Added support to check integrity of the FS installation files

### DIFF
--- a/Core/Base/FileManager.php
+++ b/Core/Base/FileManager.php
@@ -20,7 +20,7 @@ namespace FacturaScripts\Core\Base;
 
 /**
  * Class to manage the actions with folders and files
- * 
+ *
  * @package FacturaScripts\Core\Base
  *
  * @author Carlos García Gómez <carlos@facturascripts.com>
@@ -53,7 +53,7 @@ class FileManager
 
     /**
      * Returns an array with all not writable folders.
-     * 
+     *
      * @return array
      */
     public static function notWritableFolders(): array
@@ -70,7 +70,7 @@ class FileManager
 
     /**
      * Copy all files and folders from $src to $dst
-     * 
+     *
      * @param string $src
      * @param string $dst
      */
@@ -92,20 +92,21 @@ class FileManager
 
     /**
      * Returns an array with files and folders inside given $folder
-     * 
+     *
      * @param string $folder
      * @param bool   $recursive
+     * @param array  $exclude
      *
      * @return array
      */
-    public static function scanFolder(string $folder, bool $recursive = false): array
+    public static function scanFolder(string $folder, bool $recursive = false, array $exclude = ['.', '..']): array
     {
         $scan = scandir($folder, SCANDIR_SORT_ASCENDING);
         if (!is_array($scan)) {
             return [];
         }
 
-        $rootFolder = array_diff($scan, ['.', '..']);
+        $rootFolder = array_diff($scan, $exclude);
         if (!$recursive) {
             return $rootFolder;
         }

--- a/Core/Base/IntegrityCheck.php
+++ b/Core/Base/IntegrityCheck.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Base;
+
+/**
+ * Class to check integrity system
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+class IntegrityCheck
+{
+    /**
+     * Path to list of integrity file.
+     */
+    const BASE = FS_FOLDER . DIRECTORY_SEPARATOR . 'MyFiles' . DIRECTORY_SEPARATOR;
+    const INTEGRITY_FILE = self::BASE . 'integrity.json';
+    const INTEGRITY_USER_FILE = self::BASE . 'integrity-validation.json';
+
+    /**
+     * Return an array with integrity files hash.
+     *
+     * @return array
+     */
+    public static function getIntegrityFiles(): array
+    {
+        $resources = [];
+        $fileManager = new FileManager();
+        // Ignore the minimum files/folders possible.
+        $exclude = ['.', '..', 'Dinamic', 'Documentation', 'MyFiles', 'node_modules', 'Plugins', 'Test', 'vendor'];
+        $exclude[] = '.htaccess';
+        $exclude[] = 'config.php';
+        $files = $fileManager::scanFolder(FS_FOLDER, true, $exclude);
+        foreach ($files as $fileName) {
+            $resources[$fileName] = self::getFileHash($fileName);
+        }
+        return $resources;
+    }
+
+    /**
+     * Save the integrity files to disk,
+     *
+     * @param string $file
+     *
+     * @return bool
+     */
+    public static function saveIntegrity($file = self::INTEGRITY_FILE): bool
+    {
+        $integrity = self::getIntegrityFiles();
+        $content = json_encode($integrity, \JSON_PRETTY_PRINT);
+        return file_put_contents($file, $content) !== false;
+    }
+
+    /**
+     * Return the integrity files from disk,
+     *
+     * @param string $file
+     *
+     * @return array
+     */
+    public static function loadIntegrity($file = self::INTEGRITY_FILE): array
+    {
+        if (file_exists($file)) {
+            $content = file_get_contents($file);
+            if ($content !== false) {
+                return json_decode($content, true);
+            }
+        }
+
+        if (self::saveIntegrity($file)) {
+            $content = file_get_contents($file);
+            if ($content !== false) {
+                return json_decode($content, true);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Return the file hash.
+     *
+     * @param string $file
+     * @param string $algo
+     *
+     * @return string
+     */
+    public static function getFileHash($file = self::INTEGRITY_FILE, $algo = 'sha512'): string
+    {
+        return \file_exists($file) ? hash_file($algo, $file) : '';
+    }
+
+    /**
+     * Compare the array and return a list of differences.
+     *
+     * @return array
+     */
+    public static function compareIntegrity(): array
+    {
+        // Fast check, if hashes are equals, content is the same
+        if (self::getFileHash() === self::getFileHash(self::INTEGRITY_USER_FILE)) {
+            return [];
+        }
+
+        $origArray = self::loadIntegrity();
+        $userArray = self::loadIntegrity(self::INTEGRITY_USER_FILE);
+        $types = ['MISSING_FILE', 'INVALID_HASH', 'EXTRA_FILE'];
+        $result = [];
+        foreach ($types as $type) {
+            $result[$type] = [];
+        }
+
+        self::getAlteredUserFiles($result, $origArray, $userArray);
+        self::getExtraUserFiles($result, $origArray, $userArray);
+        self::cleanResults($result, $types);
+
+        return $result;
+    }
+
+    /**
+     * Add items if user integrity files have missing or invalid hashes.
+     *
+     * @param array $result
+     * @param array $origArray
+     * @param array $userArray
+     */
+    private static function getAlteredUserFiles(array &$result, array $origArray = [], array $userArray = [])
+    {
+        foreach ($origArray as $item => $hash) {
+            if (!isset($userArray[$item])) {
+                $result['MISSING_FILE'][] = $item;
+            } elseif ($userArray[$item] !== $hash) {
+                $result['INVALID_HASH'][] = $item;
+            }
+        }
+    }
+
+    /**
+     * Add items if user integrity files have no needed files.
+     *
+     * @param array $result
+     * @param array $origArray
+     * @param array $userArray
+     */
+    private static function getExtraUserFiles(array &$result, array $origArray = [], array $userArray = [])
+    {
+        foreach ($userArray as $item => $hash) {
+            if (!isset($origArray[$item])) {
+                $result['EXTRA_FILE'][] = $item;
+            }
+        }
+    }
+
+    /**
+     * Unset empty validations that are unneeded.
+     *
+     * @param array $result
+     * @param array $types
+     */
+    private static function cleanResults(array &$result, array $types)
+    {
+        foreach ($types as $type) {
+            if (empty($result[$type])) {
+                unset($result[$type]);
+            }
+        }
+    }
+}

--- a/Core/Controller/IntegritySystemCheck.php
+++ b/Core/Controller/IntegritySystemCheck.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Base;
+use FacturaScripts\Core\Model\User;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * IntegritySystemCheck.
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+class IntegritySystemCheck extends Base\Controller
+{
+
+    /**
+     * List of files with integrity problems.
+     *
+     * @var array
+     */
+    public $integrity;
+
+    /**
+     * Returns basic page attributes
+     *
+     * @return array
+     */
+    public function getPageData()
+    {
+        $pageData = parent::getPageData();
+        $pageData['menu'] = 'admin';
+        $pageData['submenu'] = 'control-panel';
+        $pageData['title'] = 'integrity-check';
+        $pageData['icon'] = 'fa-shield';
+        $pageData['showonmenu'] = false;
+
+        return $pageData;
+    }
+
+    /**
+     * Runs the controller's private logic.
+     *
+     * @param Response                   $response
+     * @param User                       $user
+     * @param Base\ControllerPermissions $permissions
+     */
+    public function privateCore(&$response, $user, $permissions)
+    {
+        parent::privateCore($response, $user, $permissions);
+
+        // Store action to execute
+        $action = $this->request->get('action', '');
+
+        // Operations with data, before execute action
+        if (!$this->execPreviousAction($action)) {
+            return;
+        }
+        $this->integrity = Base\IntegrityCheck::compareIntegrity();
+
+        // This check must be do it to have more real time notification if it's failling
+        if ($this->user->admin && !empty($this->integrity)) {
+            $this->miniLog->critical(
+                '<i class="fa fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;'
+                . $this->i18n->trans('not-passed-integrity-check')
+            );
+        }
+    }
+
+    /**
+     * Run the actions that alter data before reading it.
+     *
+     * @param string $action
+     *
+     * @return bool
+     */
+    protected function execPreviousAction($action)
+    {
+        switch ($action) {
+            case 'system':
+                Base\IntegrityCheck::saveIntegrity();
+                return false;
+
+            default:
+                Base\IntegrityCheck::saveIntegrity(Base\IntegrityCheck::INTEGRITY_USER_FILE);
+                break;
+        }
+
+        return true;
+    }
+}

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -716,5 +716,15 @@
     "create-accounting-entry": "Create Accounting Entry",
     "hint-create-accounting-entry": "Create the accounting entry for the regularization of the taxes of the period",
     "previous-balance": "Previous Balance",
-    "result": "Result"
+    "result": "Result",
+    "integrity-check": "Integrity check",
+    "integrity-check-help": "This is a check of system integrity, described as",
+    "missing-file": "Missing file",
+    "missing-file-help": "This file seems to be missing from your installation. Maybe you don't use it, but <em>you can't remove it</em>.",
+    "invalid-hash-file": "Invalid hash file",
+    "invalid-hash-file-help": "This file have a different validation hash from when they were added and generated. This may imply that the core system has been compromised, corrupt files, or that <em>it has been modified improperly without using a plugin</em> to do so.",
+    "extra-file": "Extra file",
+    "extra-file-help": "This is a new file founded in a wrong place. This may imply that the core system has been compromised, or that <em>is a new feature that is in Work In Progress and isn't accepted yet to FacturaScripts Core</em>.",
+    "not-passed-integrity-check": "Some files have not passed the integrity check...<br/>You can <a class='alert-link' target='_blank' href='IntegritySystemCheck'>get more details here</a>.",
+    "recreate-system-integrity": "Recreate system integrity"
 }

--- a/Core/View/IntegritySystemCheck.html.twig
+++ b/Core/View/IntegritySystemCheck.html.twig
@@ -1,0 +1,126 @@
+{#
+   /**
+     * Integrity System Check view template.
+     *
+     * Main page to know if integrity of system is being compromised.
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program. If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
+{% extends "Master/MenuTemplate.html.twig" %}
+
+{% block body %}
+    {# Calculate texts according to language #}
+    {% set refresh = i18n.trans('refresh-page') %}
+    {% set defaultT, defaultF = i18n.trans('mark-as-homepage'), i18n.trans('marked-as-homepage') %}
+    {% set add = i18n.trans('add') %}
+    {% set disable, enable, delete = i18n.trans('disable'), i18n.trans('enable'), i18n.trans('delete') %}
+    {% set title = i18n.trans(fsc.getPageData()['title']) | capitalize %}
+    {% set recreateSystem, recreateUser = i18n.trans('recreate-system-integrity'), i18n.trans('recreate-user-integrity') %}
+
+    {# Page Header #}
+    <div class="container-fluid">
+        {{ parent() }}
+
+        {# Header Row #}
+        <div class="row">
+            <div class="col-sm-7 col-6">
+                <div class="btn-group d-xs-none">
+                    <a class="btn btn-sm btn-outline-secondary" href="{{ fsc.url() }}">
+                        <i class="fa fa-refresh" aria-hidden="true"></i>
+                    </a>
+                    {% if fsc.getPageData()['name'] == fsc.user.homepage %}
+                        <a class="btn btn-sm btn-outline-secondary active" href="{{ fsc.url() }}?defaultPage=FALSE">
+                            <i class="fa fa-bookmark" aria-hidden="true"></i>
+                        </a>
+                    {% else %}
+                        <a class="btn btn-sm btn-outline-secondary" href="{{ fsc.url() }}?defaultPage=TRUE">
+                            <i class="fa fa-bookmark-o" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
+                </div>
+                <div class="btn-group d-xs-none">
+                    {% if constant('FS_DEBUG') %}
+                        <a class="btn btn-sm btn-success" href="{{ fsc.url() }}?action=system">
+                            <i class="fa fa-retweet" aria-hidden="true"></i>
+                            <span class="d-none d-sm-inline-block">&nbsp;{{ recreateSystem }}</span>
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col-sm-5 col-6 text-right">
+                <h1 style="margin-top: 0; margin-bottom: 0;">
+                    <i class="fa {{ fsc.getPageData()['icon'] }}" aria-hidden="true"></i> {{ title }}
+                </h1>
+            </div>
+        </div>
+        <hr/>
+    </div>
+
+    <div class="container-fluid form-text text-muted">
+        <div class="row">
+            <div class="col-12">
+                <small>
+                    {{ i18n.trans('integrity-check-help') }}:
+                    <ul>
+                        <li><b>{{ i18n.trans('missing-file') }}</b>: {{ i18n.trans('missing-file-help') | raw }}</li>
+                        <li>
+                            <b>{{ i18n.trans('invalid-hash-file') }}</b>: {{ i18n.trans('invalid-hash-file-help') | raw }}
+                        </li>
+                        <li><b>{{ i18n.trans('extra-file') }}</b>: {{ i18n.trans('extra-file-help') | raw }}</li>
+                    </ul>
+                </small>
+            </div>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+                <th>{{ i18n.trans('name') }}</th>
+                <th>{{ i18n.trans('description') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% set types = ['MISSING_FILE', 'INVALID_HASH', 'EXTRA_FILE'] %}
+            {% for type in types %}
+                {% if type == 'MISSING_FILE' %}
+                    {% set msg = i18n.trans('missing-file') %}
+                {% elseif type == 'INVALID_HASH' %}
+                    {% set msg = i18n.trans('invalid-hash-file') %}
+                {% elseif type == 'EXTRA_FILE' %}
+                    {% set msg = i18n.trans('extra-file') %}
+                {% endif %}
+                {% for file in fsc.integrity[type] %}
+                    <tr>
+                        <td><b>{{ file }}</b></td>
+                        <td>{{ msg }}</td>
+                    </tr>
+                {% else %}
+                    <tr class="table-warning">
+                        <td colspan="2"><b>{{ i18n.trans('no-data') }}</b></td>
+                    </tr>
+                {% endfor %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+{% endblock %}

--- a/Test/Core/Base/IntegrityCheckTest.php
+++ b/Test/Core/Base/IntegrityCheckTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Base\Utils;
+
+use FacturaScripts\Core\Base\IntegrityCheck;
+
+/**
+ * Class to test integrity files of FacturaScripts Core
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@gmail.com>
+ */
+class IntegrityCheckTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var IntegrityCheck
+     */
+    protected $object;
+
+    /**
+     * Generate the integrity.json.
+     *
+     * @covers \FacturaScripts\Core\Base\IntegrityCheck::saveIntegrity()
+     */
+    public function testSaveIntegrity()
+    {
+        $this->assertTrue($this->object::saveIntegrity());
+        $this->assertFileExists($this->object::INTEGRITY_FILE, 'File not exists');
+    }
+
+    /**
+     * Generate the integrity.json.
+     *
+     * @covers \FacturaScripts\Core\Base\IntegrityCheck::saveIntegrity()
+     */
+    public function testSaveUserIntegrity()
+    {
+        $this->assertTrue($this->object::saveIntegrity($this->object::INTEGRITY_USER_FILE));
+        $this->assertFileExists($this->object::INTEGRITY_USER_FILE, 'File not exists');
+    }
+
+    /**
+     * Read the integrity.json.
+     *
+     * @covers \FacturaScripts\Core\Base\IntegrityCheck::getIntegrityFiles()
+     */
+    public function testGetIntegrityFiles()
+    {
+        $this->assertNotEmpty($this->object::getIntegrityFiles(), 'integrity.json is empty');
+    }
+
+    /**
+     * Load the integrity.json file.
+     *
+     * @covers \FacturaScripts\Core\Base\IntegrityCheck::loadIntegrity()
+     */
+    public function testLoadIntegrityFiles()
+    {
+        $this->assertNotEmpty($this->object::loadIntegrity(), 'Is empty');
+    }
+
+    /**
+     * Try to load and generate the user integrity file.
+     */
+    public function testUserLoadIntegrityFiles()
+    {
+        $this->assertNotEmpty($this->object::loadIntegrity($this->object::INTEGRITY_USER_FILE), 'Is empty');
+    }
+
+    /**
+     * Test that hash file are the same, without reading the content.
+     *
+     * @covers \FacturaScripts\Core\Base\IntegrityCheck::getFileHash()
+     */
+    public function testGetFileHash()
+    {
+        $this->assertNotEmpty(
+            $this->object::getFileHash(),
+            'Is not a string "' . print_r($this->object::getFileHash() . '"', true)
+        );
+        $this->assertNotEmpty(
+            $this->object::getFileHash($this->object::INTEGRITY_USER_FILE),
+            'Is not a string "' . print_r($this->object::getFileHash($this->object::INTEGRITY_USER_FILE) . '"', true)
+        );
+    }
+
+    /**
+     * Compare the diff between integrity files.
+     *
+     * @covers \FacturaScripts\Core\Base\IntegrityCheck::compareIntegrity()
+     */
+    public function testCompareIntegrity()
+    {
+        $list = $this->object::compareIntegrity();
+        $excludes = ['.idea', '.vscode'];
+        foreach ($excludes as $exclude) {
+            if (isset($list[$exclude])) {
+                unset($list[$exclude]);
+            }
+        }
+
+        // Must be equals
+        $this->assertEmpty(
+            $list,
+            'Integrity check test not passed. A false positive on development width IDE files? '
+            . print_r($this->object::compareIntegrity(), true)
+        );
+
+        // Must be different, because were adding a dummy file
+        touch(\FS_FOLDER . '/DummyFile');
+        if (\file_exists(\FS_FOLDER . '/MyFiles/integrity-validation.json')) {
+            unlink(\FS_FOLDER . '/MyFiles/integrity-validation.json');
+        }
+        $this->assertNotEmpty(
+            $this->object::compareIntegrity(),
+            'Integrity check test not passed: "' . print_r($this->object::compareIntegrity(), true) . '"'
+        );
+        if (\file_exists(\FS_FOLDER . '/DummyFile')) {
+            unlink(\FS_FOLDER . '/DummyFile');
+        }
+    }
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->object = new IntegrityCheck();
+
+        // Remove it because if asserts fails don't unlink it
+        if (\file_exists(\FS_FOLDER . '/DummyFile')) {
+            unlink(\FS_FOLDER . '/DummyFile');
+        }
+    }
+}


### PR DESCRIPTION
- Can save and load integrity files from/to json file with file => hash options on MyFiles folder
- Compare system and user looking for missing files, invalid hashes and extra files
- Innitial tests for this class
- Updated: FileManager::scanFolder to allow pass a different exclude list than the default, needed to ignore some files and folders

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
- [X] Changes not related with database
<!---- [ ] If additional tests was realized, added here--->
