### PR TITLE
Add fieldname tag to row status options

### DIFF
--- a/Core/Lib/ExtendedController/RowItemStatus.php
+++ b/Core/Lib/ExtendedController/RowItemStatus.php
@@ -53,13 +53,17 @@ class RowItemStatus extends RowItem
     /**
      * Returns the status for a given value
      *
-     * @param string $value
+     * @param ModelClass $model
      *
      * @return string
      */
-    public function getStatus($value)
+    public function getStatus(&$model)
     {
+        $rowValue = empty($this->fieldName) ? '' : $model->{$this->fieldName};
+
         foreach ($this->options as $option) {
+            $value = isset($option['fieldname']) ? $model->{$option['fieldname']} : $rowValue;
+
             switch ($option['value'][0]) {
                 case '>':
                     if ($value > (float) substr($option['value'], 1)) {

--- a/Core/View/Macro/BaseController.html.twig
+++ b/Core/View/Macro/BaseController.html.twig
@@ -212,7 +212,7 @@
                 {% set rowClass = 'table-light' %}
                 {% set rowStatus = view.getRow('status') %}
                 {% if rowStatus is not empty %}
-                    {% set rowClass = rowStatus.getStatus( attribute(model, rowStatus.fieldName) ) %}
+                    {% set rowClass = rowStatus.getStatus( model ) %}
                 {% endif %}
 
                 {# checks model url #}

--- a/Core/XMLView/ListAsiento.xml
+++ b/Core/XMLView/ListAsiento.xml
@@ -47,6 +47,8 @@
     </columns>
     <rows>
         <row type="status" fieldname="editable">
+            <option color="table-info" fieldname="importe">&lt;0</option>
+            <option color="table-success" fieldname="importe">&gt;1000</option>
             <option color="table-warning">1</option>
         </row>
         <row type="footer">


### PR DESCRIPTION
Modify the operation of the row status to be able to indicate the fieldname in the option tag.

Now you can indicate the name of the field globally, as it was previously in the declaration of the row, and at the level of each of the option labels.

## How has this been tested?

- [ ] MySQL
- [x] PostgreSQL
- [ ] Clean database
- [x] Database with random data
