### PR TITLE
Remove getModel function from BaseView

### DIFF
--- a/Core/Controller/EditDashboardData.php
+++ b/Core/Controller/EditDashboardData.php
@@ -99,7 +99,7 @@ class EditDashboardData extends ExtendedController\EditController
      */
     protected function editAction()
     {
-        $model = $this->views[$this->active]->getModel();
+        $model = $this->views[$this->active]->model;
         $properties = array_keys($this->getPropertiesFields());
         $fields = array_keys($model->properties);
         foreach ($fields as $key) {

--- a/Core/Controller/EditSettings.php
+++ b/Core/Controller/EditSettings.php
@@ -34,8 +34,8 @@ class EditSettings extends ExtendedController\PanelController
     /**
      * Returns the configuration property value for a specified $field
      *
-     * @param mixed  $model
-     * @param string $field
+     * @param ModelClass $model
+     * @param string     $field
      *
      * @return mixed
      */
@@ -153,14 +153,13 @@ class EditSettings extends ExtendedController\PanelController
     {
         $this->exportManager->newDoc($this->request->get('option'));
         foreach ($this->views as $view) {
-            $model = $view->getModel();
-            if ($model === null || !isset($model->properties)) {
+            if ($view->model === null || !isset($view->model->properties)) {
                 continue;
             }
 
             $headers = ['key' => 'key', 'value' => 'value'];
             $rows = [];
-            foreach ($model->properties as $key => $value) {
+            foreach ($view->model->properties as $key => $value) {
                 $rows[] = ['key' => $key, 'value' => $value];
             }
 
@@ -192,17 +191,16 @@ class EditSettings extends ExtendedController\PanelController
      */
     protected function loadData($viewName, $view)
     {
-        if (empty($view->getModel())) {
+        if (empty($view->model)) {
             return;
         }
 
         $code = $this->getKeyFromViewName($viewName);
         $view->loadData($code);
 
-        $model = $view->getModel();
-        if ($model->name === null) {
-            $model->description = $model->name = strtolower(substr($viewName, 8));
-            $model->save();
+        if ($view->model->name === null) {
+            $view->model->description = $view->model->name = strtolower(substr($viewName, 8));
+            $view->model->save();
         }
     }
 
@@ -212,7 +210,7 @@ class EditSettings extends ExtendedController\PanelController
     private function testViews()
     {
         foreach ($this->views as $viewName => $view) {
-            if (!$view->getModel()) {
+            if (!$view->model) {
                 continue;
             }
 

--- a/Core/Controller/ListAsiento.php
+++ b/Core/Controller/ListAsiento.php
@@ -78,8 +78,7 @@ class ListAsiento extends ExtendedController\ListController
     {
         switch ($action) {
             case 'renumber':
-                $model = $this->views['ListAsiento']->getModel();
-                if ($model->renumber()) {
+                if ($this->views['ListAsiento']->model->renumber()) {
                     $this->miniLog->notice($this->i18n->trans('renumber-accounting-ok'));
                 }
                 return true;

--- a/Core/Lib/ExtendedController/BaseView.php
+++ b/Core/Lib/ExtendedController/BaseView.php
@@ -47,7 +47,7 @@ abstract class BaseView
     /**
      * Model to use in this view.
      *
-     * @var mixed
+     * @var ModelClass
      */
     public $model;
 
@@ -71,7 +71,7 @@ abstract class BaseView
      * @var string
      */
     public $title;
-    
+
     /**
      * Method to export the view data.
      */
@@ -160,16 +160,6 @@ abstract class BaseView
     public function getModals()
     {
         return $this->pageOption->modals;
-    }
-
-    /**
-     * Returns the pointer to the data model
-     *
-     * @return mixed
-     */
-    public function getModel()
-    {
-        return $this->model;
     }
 
     /**

--- a/Core/Lib/ExtendedController/EditController.php
+++ b/Core/Lib/ExtendedController/EditController.php
@@ -55,7 +55,7 @@ abstract class EditController extends PanelController
     public function getModel()
     {
         $viewName = array_keys($this->views)[0];
-        return $this->views[$viewName]->getModel();
+        return $this->views[$viewName]->model;
     }
 
     /**
@@ -69,7 +69,7 @@ abstract class EditController extends PanelController
         $viewName = 'Edit' . $this->getModelClassName();
         $title = $this->getPageData()['title'];
         $viewIcon = $this->getPageData()['icon'];
-        
+
         $this->addEditView($viewName, $modelName, $title, $viewIcon);
     }
 

--- a/Core/Lib/ExtendedController/GridView.php
+++ b/Core/Lib/ExtendedController/GridView.php
@@ -68,7 +68,7 @@ class GridView extends BaseView
 
         // Join the parent view
         $this->parentView = $parent;
-        $this->parentModel = $parent->getModel();
+        $this->parentModel = $parent->model;
 
         // Loads the view configuration for the user
         $this->pageOption->getForUser($viewName, $userNick);

--- a/Core/Lib/ExtendedController/ListController.php
+++ b/Core/Lib/ExtendedController/ListController.php
@@ -339,7 +339,7 @@ abstract class ListController extends BaseController
             return false;
         }
 
-        $model = $this->views[$this->active]->getModel();
+        $model = $this->views[$this->active]->model;
         $code = $this->request->get('code');
         $numDeletes = 0;
         foreach (explode(',', $code) as $cod) {

--- a/Core/Lib/ExtendedController/PanelController.php
+++ b/Core/Lib/ExtendedController/PanelController.php
@@ -91,9 +91,7 @@ abstract class PanelController extends BaseController
     public function getPrimaryDescription()
     {
         $viewName = array_keys($this->views)[0];
-        $model = $this->views[$viewName]->getModel();
-
-        return $model->primaryDescription();
+        return $this->views[$viewName]->model->primaryDescription();
     }
 
     /**
@@ -132,7 +130,7 @@ abstract class PanelController extends BaseController
      */
     public function getViewModelValue($viewName, $fieldName)
     {
-        $model = $this->views[$viewName]->getModel();
+        $model = $this->views[$viewName]->model;
         return isset($model->{$fieldName}) ? $model->{$fieldName} : null;
     }
 
@@ -319,7 +317,7 @@ abstract class PanelController extends BaseController
             return false;
         }
 
-        $model = $this->views[$this->active]->getModel();
+        $model = $this->views[$this->active]->model;
         $code = $this->request->get($model->primaryColumn(), '');
         if ($model->loadFromCode($code) && $model->delete()) {
             $this->miniLog->notice($this->i18n->trans('record-deleted-correctly'));

--- a/Core/View/Macro/BaseController.html.twig
+++ b/Core/View/Macro/BaseController.html.twig
@@ -262,7 +262,6 @@
 
     {% for group in view.getModals() %}
         {% set formName = context.indexView ~ '-' ~ group.name %}
-        {% set model = view.getModel() %}
 
         <div class="modal" id="{{ group.name }}" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog" role="document">
@@ -279,7 +278,7 @@
                         <div class="modal-body">
                             <div class="row">
                                 {% for column in group.columns %}
-                                    {% set value = context.fsc.getFieldValue(model, column.widget.fieldName) %}
+                                    {% set value = context.fsc.getFieldValue(view.model, column.widget.fieldName) %}
                                     {% if column.display == 'none' %}
                                         <input type="hidden" name="{{ column.widget.fieldName }}" value="{{ value }}">
                                     {% else %}

--- a/Core/View/Macro/BusinessDocumentController.html.twig
+++ b/Core/View/Macro/BusinessDocumentController.html.twig
@@ -29,7 +29,7 @@
     {% import _self as macros %}
 
     {# -- Calculate common values -- #}
-    {% set model = view.getModel() %}
+    {% set model = view.model %}
 
     <script type="text/javascript">
         documentLineData = {{ view.getLineData() | raw }};

--- a/Core/View/Master/BusinessDocumentController.html.twig
+++ b/Core/View/Master/BusinessDocumentController.html.twig
@@ -79,8 +79,7 @@
                             {{ BaseMacros.rowStatisticsForEditView(_context, view) }}
 
                             {# Main Form #}
-                            {% set model = view.getModel() %}
-                            {{ BaseMacros.columnsForEditView(_context, view, model, TRUE) }}
+                            {{ BaseMacros.columnsForEditView(_context, view, view.model, TRUE) }}
                         {% elseif viewType == 'EditListView' %}
                             {# Information Cards Header #}
                             {{ BaseMacros.rowCardsForEditView(_context, view, 'header') }}

--- a/Core/View/Master/GridController.html.twig
+++ b/Core/View/Master/GridController.html.twig
@@ -59,7 +59,7 @@
 {# -- Working Variables -- #}
 {% set parentIndexView = fsc.views|keys|first %}
 {% set parentView = fsc.views[parentIndexView] %}
-{% set parentModel = parentView.getModel() %}
+{% set parentModel = parentView.model %}
 {% set isNewRecord = (parentView.count == 0) %}
 
 {# -- Main Body -- #}
@@ -192,7 +192,7 @@
                         {{ BaseController.rowStatisticsForEditView(_context, view) }}
 
                         {# Main Form #}
-                        {{ BaseController.columnsForEditView(_context, view, view.getModel(), TRUE) }}
+                        {{ BaseController.columnsForEditView(_context, view, view.model, TRUE) }}
                     {% endif %}
 
                     {# Edit Multiple #}

--- a/Core/View/Master/PanelController.html.twig
+++ b/Core/View/Master/PanelController.html.twig
@@ -250,8 +250,7 @@
                                         {{ BaseController.rowStatisticsForEditView(_context, view) }}
 
                                         {# Main Form #}
-                                        {% set model = view.getModel() %}
-                                        {{ BaseController.columnsForEditView(_context, view, model, TRUE) }}
+                                        {{ BaseController.columnsForEditView(_context, view, view.model, TRUE) }}
                                     {% elseif viewType == 'EditListView' %}
                                         {{ BaseController.columnsForEditListView(_context, view) }}
                                     {% elseif viewType == 'HtmlView' %}

--- a/Core/View/Master/PanelControllerBottom.html.twig
+++ b/Core/View/Master/PanelControllerBottom.html.twig
@@ -52,8 +52,7 @@
                         {{ BaseController.rowStatisticsForEditView(_context, view) }}
 
                         {# Main Form #}
-                        {% set model = view.getModel() %}
-                        {{ BaseController.columnsForEditView(_context, view, model, TRUE) }}
+                        {{ BaseController.columnsForEditView(_context, view, view.model, TRUE) }}
                     {% elseif viewType == 'EditListView' %}
                         {{ BaseController.columnsForEditListView(_context, view) }}
                     {% elseif viewType == 'HtmlView' %}
@@ -99,8 +98,7 @@
                             {{ BaseController.rowStatisticsForEditView(_context, view) }}
 
                             {# Main Form #}
-                            {% set model = view.getModel() %}
-                            {{ BaseController.columnsForEditView(_context, view, model, TRUE) }}
+                            {{ BaseController.columnsForEditView(_context, view, view.model, TRUE) }}
                         {% endif %}
 
                         {% if viewType == 'EditListView' %}

--- a/Core/View/Master/PanelControllerTop.html.twig
+++ b/Core/View/Master/PanelControllerTop.html.twig
@@ -64,8 +64,7 @@
                             {{ BaseController.rowStatisticsForEditView(_context, view) }}
 
                             {# Main Form #}
-                            {% set model = view.getModel() %}
-                            {{ BaseController.columnsForEditView(_context, view, model, TRUE) }}
+                            {{ BaseController.columnsForEditView(_context, view, view.model, TRUE) }}
                         {% elseif viewType == 'EditListView' %}
                             {# Information Cards Header #}
                             {{ BaseController.rowCardsForEditView(_context, view, 'header') }}


### PR DESCRIPTION
The getModel method has been removed because the model property has been elevated to public.

There is only one method that is called equal in EditController but that performs actions to calculate which is the model to use, so the method is left.

## How has this been tested?

- [ ] MySQL
- [x] PostgreSQL
- [ ] Clean database
- [x] Database with random data
