### PR TITLE
Updated AppInstaller to allow more custom values from unattended installer

### DIFF
--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -249,9 +249,9 @@ class AppInstaller
         $file = fopen(FS_FOLDER . '/config.php', 'wb');
         if (\is_resource($file)) {
             fwrite($file, "<?php\n");
-            fwrite($file, "define('FS_COOKIES_EXPIRE', 604800);\n");
-            fwrite($file, "define('FS_DEBUG', true);\n");
-            fwrite($file, "define('FS_ROUTE', '" . $this->getUri() . "');\n");
+            fwrite($file, "define('FS_COOKIES_EXPIRE', " . $this->request->request->get('fs_cookie_expire', 604800) . ");\n");
+            fwrite($file, "define('FS_DEBUG', " . $this->request->request->get('fs_debug', 'false') . ");\n");
+            fwrite($file, "define('FS_ROUTE', '" . $this->request->request->get('fs_route', $this->getUri()) . "');\n");
             fwrite($file, "define('FS_DB_FOREIGN_KEYS', true);\n");
             fwrite($file, "define('FS_DB_INTEGER', 'INTEGER');\n");
             fwrite($file, "define('FS_DB_TYPE_CHECK', true);\n");

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -726,5 +726,6 @@
     "extra-file": "Extra file",
     "extra-file-help": "This is a new file founded in a wrong place. This may imply that the core system has been compromised, or that <em>is a new feature that is in Work In Progress and isn't accepted yet to FacturaScripts Core</em>.",
     "not-passed-integrity-check": "Some files have not passed the integrity check...<br/>You can <a class='alert-link' target='_blank' href='IntegritySystemCheck'>get more details here</a>.",
-    "recreate-system-integrity": "Recreate system integrity"
+    "recreate-system-integrity": "Recreate system integrity",
+    "debug-mode": "Debug mode"
 }

--- a/Core/View/Installer/Install.html.twig
+++ b/Core/View/Installer/Install.html.twig
@@ -195,6 +195,14 @@
                                     <p class="form-text">{{ i18n.trans('mysql-socket-p') }}</p>
                                 </div>
                             </div>
+                            <div class="col-sm-4">
+                                <div class="form-check mb-2 mb-sm-0">
+                                    <label class="form-check-label">
+                                        <input class="form-check-input" type="checkbox" name="fs_debug" value="true"/>
+                                        {{ i18n.trans('debug-mode') }}
+                                    </label>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div role="tabpanel" class="tab-pane" id="memcache">


### PR DESCRIPTION
Related to [Trello task](https://trello.com/c/4v43crHu/367-modificar-el-install-para-añadir-como-inputs-las-variables-cookieexpire-debug-y-route)

- Adds support for receive POST values for:
   - fs_cookies_expire by default 604800
   - fs_route by default getUri()
   - The previous values aren't required to be added also on view as hidden input type as described on task
   - fs_debug by default false
- Added checkbox for enable/disable debug mode from user on view

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
