### PR TITLE
Minor fix: Remove HTML Tags before resume text

### DIFF
--- a/Core/Lib/ExtendedController/WidgetItemText.php
+++ b/Core/Lib/ExtendedController/WidgetItemText.php
@@ -93,6 +93,7 @@ class WidgetItemText extends WidgetItem
      */
     private function getTextResume($txt, $len = 60)
     {
+        $txt = strip_tags($txt);
         if (mb_strlen($txt) < $len) {
             return $txt;
         }


### PR DESCRIPTION
Is required to remove HTML tags before return the content af the string, because if really contains HTML tags, results on incomplete code extract that break ower code.

In both cases, return a version without HTML tags, because we don't need to see as HTML that can modify base template if it is not removed. When only want to see if has content setted.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
