### PR TITLE
Fix Options css style and translate title in WidgetSelect

### DIFF
--- a/Core/Lib/ExtendedController/WidgetItemSelect.php
+++ b/Core/Lib/ExtendedController/WidgetItemSelect.php
@@ -19,6 +19,7 @@
 namespace FacturaScripts\Core\Lib\ExtendedController;
 
 use FacturaScripts\Core\Model;
+use FacturaScripts\Core\Base\Translator;
 
 /**
  * This class manage all specific method for a WidgetItem of Select type.
@@ -73,8 +74,8 @@ class WidgetItemSelect extends WidgetItem
         foreach ($this->values as $option) {
             /// don't use strict comparation (===)
             $selected = ($option['value'] == $value) ? ' selected="selected" ' : '';
-            $html .= '<option value="' . $option['value'] . '" ' . $selected . '>' . $option['title']
-                . '</option>';
+            $title = empty($option['title']) ? $option['value'] : $option['title'];
+            $html .= '<option value="' . $option['value'] . '" ' . $selected . '>' . $title . '</option>';
         }
         $html .= '</select>';
 
@@ -102,13 +103,28 @@ class WidgetItemSelect extends WidgetItem
         foreach ($this->values as $option) {
             /// don't use strict comparation (===)
             if ($option['value'] == $value) {
-                $txt = $option['title'];
+                $txt = empty($option['title']) ? $option['value'] : $option['title'];
                 break;
             }
         }
 
-        return empty($this->onClick) ? '<span>' . $txt . '</span>' : '<a href="' . $this->onClick
-            . '?code=' . $value . '">' . $txt . '</a>';
+        $style = $this->getTextOptionsHTML($value);
+
+        return empty($this->onClick) ? '<span' . $style . '>' . $txt . '</span>' : '<a href="' . $this->onClick
+            . '?code=' . $value . '" ' . $style . '>' . $txt . '</a>';
+    }
+
+    /**
+     *  Translate the fixed titles, if they exist
+     */
+    private function applyTranslations()
+    {
+        $i18n = new Translator();
+        for ($index = 0; $index < count($this->values); $index++) {
+            if (!empty($this->values[$index]['title'])) {
+                $this->values[$index]['title'] = $i18n->trans($this->values[$index]['title']);
+            }
+        }
     }
 
     /**
@@ -120,6 +136,7 @@ class WidgetItemSelect extends WidgetItem
     {
         parent::loadFromJSON($widget);
         $this->values = (array) $widget['values'];
+        $this->applyTranslations();
     }
 
     /**
@@ -131,6 +148,7 @@ class WidgetItemSelect extends WidgetItem
     {
         parent::loadFromXML($column);
         $this->getAttributesGroup($this->values, $column->widget->values);
+        $this->applyTranslations();
     }
 
     /**
@@ -141,9 +159,10 @@ class WidgetItemSelect extends WidgetItem
         $tableName = $this->values[0]['source'];
         $fieldCode = $this->values[0]['fieldcode'];
         $fieldDesc = $this->values[0]['fieldtitle'];
+        $translate = isset($this->values[0]['translate']);
         $allowEmpty = !$this->required;
         $rows = Model\CodeModel::all($tableName, $fieldCode, $fieldDesc, $allowEmpty);
-        $this->setValuesFromCodeModel($rows);
+        $this->setValuesFromCodeModel($rows, $translate);
     }
 
     /**
@@ -177,27 +196,32 @@ class WidgetItemSelect extends WidgetItem
 
             $this->values[] = [
                 'value' => $value,
-                'title' => $value,
+                'title' => '',
             ];
         }
+        $this->applyTranslations();
     }
 
     /**
      * Loads the value list from an array with value and title (description)
      *
      * @param array $rows
+     * @param bool $translate
      */
-    public function setValuesFromCodeModel(&$rows)
+    public function setValuesFromCodeModel(&$rows, $translate = False)
     {
         $this->values = [];
+        $i18n = new Translator();
+
         foreach ($rows as $codeModel) {
             if ($codeModel->code === null) {
                 continue;
             }
 
+            $title = $translate ? $i18n->trans($codeModel->description) : $codeModel->description;
             $this->values[] = [
                 'value' => $codeModel->code,
-                'title' => $codeModel->description,
+                'title' => $title
             ];
         }
     }

--- a/Core/XMLView/EditRoleAccess.xml
+++ b/Core/XMLView/EditRoleAccess.xml
@@ -35,7 +35,7 @@
             </column>
             <column name="pagename" order="120">
                 <widget type="select" fieldname="pagename" required="true">
-                    <values source="pages" fieldcode="name" fieldtitle="name"></values>
+                    <values source="pages" fieldcode="name" fieldtitle="name" translate="true"></values>
                 </widget>
             </column>
             <column name="allow-update" order="130">
@@ -57,7 +57,7 @@
         <group name="add-rol-access" icon="fa-user-plus">
             <column name="select-menu" title="menu">
                 <widget type="select" fieldname="menu">
-                    <values source="pages" fieldcode="menu" fieldtitle="menu"></values>
+                    <values source="pages" fieldcode="menu" fieldtitle="menu" translate="true"></values>
                 </widget>
             </column>
         </group>

--- a/Core/XMLView/ListEjercicio.xml
+++ b/Core/XMLView/ListEjercicio.xml
@@ -19,7 +19,7 @@
  *
  * Initial description for the controller ListEjercicio
  *
- * @author Artex Trading sa <jcuello@artextrading.com>  
+ * @author Artex Trading sa <jcuello@artextrading.com>
 -->
 
 <view>
@@ -37,7 +37,10 @@
             <widget type="text" fieldname="fechafin" />
         </column>
         <column name="state" display="center" order="140">
-            <widget type="text" fieldname="estado">
+            <widget type="select" fieldname="estado">
+                <values title="open">ABIERTO</values>
+                <values title="closed">CERRADO</values>
+
                 <option color="red" font-weight="bold">ABIERTO</option>
                 <option color="blue">CERRADO</option>
             </widget>

--- a/Core/XMLView/ListRoleAccess.xml
+++ b/Core/XMLView/ListRoleAccess.xml
@@ -51,7 +51,7 @@
         <group name="add-rol-access" icon="fa-user-plus">
             <column name="select-menu" title="menu">
                 <widget type="select" fieldname="menu">
-                    <values source="pages" fieldcode="menu" fieldtitle="menu"></values>
+                    <values source="pages" fieldcode="menu" fieldtitle="menu" translate="true" translate="true"></values>
                 </widget>
             </column>
         </group>

--- a/Core/XMLView/SettingsDefault.xml
+++ b/Core/XMLView/SettingsDefault.xml
@@ -96,7 +96,7 @@
             </column>
             <column name="homepage" numcolumns="3" order="100">
                 <widget type="select" fieldname="homepage">
-                    <values source="pages" fieldcode="name" fieldtitle="name"></values>
+                    <values source="pages" fieldcode="name" fieldtitle="name" translate="true"></values>
                 </widget>
             </column>
             <column name="item_limit" numcolumns="3" order="100">


### PR DESCRIPTION
The Select widget now applies the css styles indicated with the "option" tags.

Now translation is applied to the titles when the values are loaded from an array and the "title" is informed. If "title" is not reported, the "value" content is displayed as a description without applying translation.

For cases in which titles and values are loaded from the database, translation is applied if the attribute "translate" is added to the declaration of the "value" tag with value "true".

## How has this been tested?

- [ ] MySQL
- [x] PostgreSQL
- [ ] Clean database
- [x] Database with random data
