### PR TITLE
Add autocomplete and date filter

### DIFF
--- a/Core/Controller/ListLogMessage.php
+++ b/Core/Controller/ListLogMessage.php
@@ -66,5 +66,6 @@ class ListLogMessage extends ExtendedController\ListController
         ];
         $this->addFilterSelect('ListLogMessage', 'level', 'level', 'level', $values);
         $this->addFilterAutocomplete('ListLogMessage', 'nick', 'user', 'nick', 'users', 'nick' , 'nick');
+        $this->addFilterDatePicker('ListLogMessage', 'time', 'time', 'time');
     }
 }

--- a/Core/Controller/ListLogMessage.php
+++ b/Core/Controller/ListLogMessage.php
@@ -65,5 +65,6 @@ class ListLogMessage extends ExtendedController\ListController
             ['code' => 'emergency', 'description' => $this->i18n->trans('type-emergency')]
         ];
         $this->addFilterSelect('ListLogMessage', 'level', 'level', 'level', $values);
+        $this->addFilterAutocomplete('ListLogMessage', 'nick', 'user', 'nick', 'users', 'nick' , 'nick');
     }
 }


### PR DESCRIPTION
Added autocomplete filter and date filter on ListLogMessage controller.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [X] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->
