### PR TITLE
Add improvement facilities to DataBaseWhere with LIKE operator use

### DIFF
--- a/Core/Base/DataBase/DataBaseWhere.php
+++ b/Core/Base/DataBase/DataBaseWhere.php
@@ -99,49 +99,67 @@ class DataBaseWhere
     }
 
     /**
+     * Return list values for IN operator
+     * 
+     * @return string
+     */
+    private function getValueFromOperatorIn(): string
+    {
+        if (0 === stripos($this->value, 'select ')) {
+            return $this->value;
+        }
+        
+        $result = '';
+        $comma = '';
+        foreach (explode(',', $this->value) as $value) {
+            $result .= $comma . "'" . $this->dataBase->escapeString($value) . "'";
+            $comma = ',';
+        }
+       return $result;
+    }
+
+    /**
+     * Return value for LIKE operator
+     * 
+     * @return string
+     */
+    private function getValueFromOperatorLike(): string
+    {
+        if (is_bool($this->value)) {
+            return $this->value ? 'TRUE' : 'FALSE';
+        }
+            
+        if (strpos($this->value, '%')) {
+            return "LOWER('" . $this->dataBase->escapeString($this->value) . "')";
+        }
+        
+        return "LOWER('%" . $this->dataBase->escapeString($this->value) . "%')";
+    }
+
+    /**
      * Returns the value for the operator
      *
      * @return string
      */
-    private function getValueFromOperator()
+    private function getValueFromOperator(): string
     {
         switch ($this->operator) {
             case 'LIKE':
-                if (is_bool($this->value)) {
-                    $result = $this->value ? 'TRUE' : 'FALSE';
-                } else {
-                    $result = "LOWER('%" . $this->dataBase->escapeString($this->value) . "%')";
-                }
-                break;
+                return $this->getValueFromOperatorLike();
 
             case 'IS':
             case 'IS NOT':
-                $result = (string) $this->value;
-                break;
+                return (string) $this->value;
 
             case 'IN':
-                $result = '(';
-                if (0 === stripos($this->value, 'select ')) {
-                    $result .= $this->value;
-                } else {
-                    $comma = '';
-                    foreach (explode(',', $this->value) as $value) {
-                        $result .= $comma . "'" . $this->dataBase->escapeString($value) . "'";
-                        $comma = ',';
-                    }
-                }
-                $result .= ')';
-                break;
+                return '(' . $this->getValueFromOperatorIn() . ')';
 
             case 'REGEXP':
-                $result = "'" . $this->dataBase->escapeString((string) $this->value) . "'";
-                break;
+                return "'" . $this->dataBase->escapeString((string) $this->value) . "'";
 
             default:
-                $result = '';
+                return '';
         }
-
-        return $result;
     }
 
     /**

--- a/Core/Base/DataBase/DataBaseWhere.php
+++ b/Core/Base/DataBase/DataBaseWhere.php
@@ -129,11 +129,10 @@ class DataBaseWhere
             return $this->value ? 'TRUE' : 'FALSE';
         }
             
-        if (strpos($this->value, '%')) {
-            return "LOWER('" . $this->dataBase->escapeString($this->value) . "')";
+        if (strpos($this->value, '%') === false) {
+            return "LOWER('%" . $this->dataBase->escapeString($this->value) . "%')";
         }
-        
-        return "LOWER('%" . $this->dataBase->escapeString($this->value) . "%')";
+        return "LOWER('" . $this->dataBase->escapeString($this->value) . "')";        
     }
 
     /**


### PR DESCRIPTION
Added searches with the LIKE operator using multiple wildcards '%'. Now the user can specify the place for the application of the wildcard '%', and in case of not specifying it is searched for 'content in'.

Add search with multiple values and LIKE operator, now the LIKE operator allows to indicate multiple search values separated by spaces.

- [X] PostgreSQL
- [X] Database with random data
