### PR TITLE
Add control on the insert button and minor Fix

### DIFF
--- a/Core/Assets/JS/GridController.js
+++ b/Core/Assets/JS/GridController.js
@@ -62,7 +62,11 @@ function assignSource(data) {
     };
 }
 
-/* Configure source data for autocomplete columns */
+/**
+ * Configure source data for autocomplete columns
+ * 
+ * @param {Object} columns
+ */
 function configureAutocompleteColumns(columns) {
     var column = null;
     var keys = Object.keys(columns);

--- a/Core/Assets/JS/ListController.js
+++ b/Core/Assets/JS/ListController.js
@@ -1,0 +1,163 @@
+/*
+ * This file is part of FacturaScripts
+ * Copyright (C) 2013-2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * @author Carlos García Gómez <carlos@facturascripts.com>
+ * @author Artex Trading sa <jcuello@artextrading.com>
+ */
+
+var tabActive = '';
+var settings = {};
+var urls = {};
+
+/**
+ * Send a action to controller
+ *
+ * @param {string} actionValue
+ */
+function execActionForm(actionValue) {
+    var form = document.getElementById('form' + tabActive);
+    $('<input>').attr({type: 'hidden', name: 'action'}).appendTo(form);
+    $('<input>').attr({type: 'hidden', name: 'code'}).appendTo(form);
+    var lineCodes = getLineCodes();
+    form.action.value = actionValue;
+    form.code.value = lineCodes.join();
+    form.submit();
+}
+
+/**
+ * Get data to configure autocomplete widget
+ *
+ * @param {string} formName
+ * @param {string} source
+ * @param {string} field
+ * @param {string} title
+ * @param {string} term
+ * @returns {Object}
+ */
+function getAutocompleteData(formName, source, field, title, term) {
+    var formData = {};
+    var rawForm = $('form[name="' + formName + '"]').serializeArray();
+    $.each(rawForm, function (i, input) {
+        formData[input.name] = input.value;
+    });
+    formData['action'] = 'autocomplete';
+    formData['source'] = source;
+    formData['field'] = field;
+    formData['title'] = title;
+    formData['term'] = term;
+    return formData;
+}
+
+/**
+ * Get list checked records
+ *
+ * @returns {Array}
+ */
+function getLineCodes() {
+    var lineCodes = [];
+    $('.tab' + tabActive + ' .listAction').each(function () {
+        if ($(this).prop('checked')) {
+            lineCodes.push($(this).val());
+        }
+    });
+    return lineCodes;
+}
+
+/**
+ * Exec export option into controller
+ *
+ * @param {string} option
+ */
+function goToExport(option) {
+    $('#form' + tabActive).append('<input type="hidden" name="option" value="' + option + '"/>');
+    execActionForm('export');
+}
+
+/**
+ * Go to url target
+ *
+ * @param {string} url
+ */
+function goToOptions(url) {
+    var previous = '';
+    if (typeof url !== 'undefined') {
+        previous = '&url=' + encodeURIComponent(url + '?active=' + tabActive);
+    }
+    window.location.href = 'EditPageOption?code=' + tabActive + previous;
+}
+
+/**
+ * Send insert action to controller
+ */
+function insertRecord() {
+    document.insertForm.action = urls[tabActive];
+    document.insertForm.submit();
+}
+
+/**
+ * Send filter data to controller
+ *
+ * @param {string} buttonID
+ * @param {string} operator
+ */
+function setOperator(buttonID, operator) {
+    document.getElementById(buttonID + '-operator').value = operator;
+    document.getElementById(buttonID + '-btn').value = operator;
+    $('#form' + tabActive).submit();
+}
+
+/**
+ * Set order data to controller
+ *
+ * @param {string} value
+ */
+function setOrder(value) {
+    $("#form" + tabActive + " :input[name='order']").val(value);
+    $('#form' + tabActive).submit();
+}
+
+/**
+ * Set disable status to insert button
+ */
+function setInsertStatus() {
+    if (settings[tabActive].insert) {
+        document.getElementById('b_new_record').classList.remove('disabled');
+    } else {
+        document.getElementById('b_new_record').classList.add('disabled');
+    }
+}
+
+/*
+ * Document Ready
+ */
+$(document).ready(function () {
+    // set focus on tab change
+    $('#mainTabs').on('shown.bs.tab', function (e) {
+        tabActive = e.target.hash.substring(1);
+        $('#form' + tabActive + ' :text:first').focus().select();
+        setInsertStatus();
+    });
+    // set/unset all delete checkbox
+    $('.listActionCB').click(function () {
+        var checked = $(this).prop('checked');
+        $('.listAction').prop('checked', checked);
+    });
+    // Update button insert status
+    setInsertStatus();
+});

--- a/Core/Controller/ListCuenta.php
+++ b/Core/Controller/ListCuenta.php
@@ -71,6 +71,7 @@ class ListCuenta extends ExtendedController\ListController
 
         /* Special account */
         $this->addView('ListCuentaEspecial', 'CuentaEspecial', 'special-account', 'fa-newspaper-o');
+        $this->setSettings('ListCuentaEspecial', 'insert', false);
         $this->addSearchFields('ListCuentaEspecial', ['descripcion', 'codcuentaesp']);
 
         $this->addOrderBy('ListCuentaEspecial', 'descripcion', 'description');

--- a/Core/Lib/ExtendedController/BaseController.php
+++ b/Core/Lib/ExtendedController/BaseController.php
@@ -99,13 +99,21 @@ abstract class BaseController extends Base\Controller
     /**
      * Returns the configuration value for the indicated view.
      *
-     * @param string $viewName
-     * @param string $property
+     * @param string|null $viewName
+     * @param string|null $property
      *
      * @return mixed
      */
     public function getSettings($viewName, $property)
     {
+        if (empty($viewName)) {
+            return $this->settings;
+        }
+
+        if (empty($property)) {
+            return $this->settings[$viewName];
+        }
+
         return $this->settings[$viewName][$property];
     }
 

--- a/Core/Lib/ExtendedController/ListController.php
+++ b/Core/Lib/ExtendedController/ListController.php
@@ -315,6 +315,7 @@ abstract class ListController extends BaseController
     {
         $this->views[$viewName] = new ListView($viewTitle, self::MODEL_NAMESPACE . $modelName, $viewName, $this->user->nick);
         $this->setSettings($viewName, 'icon', $icon);
+        $this->setSettings($viewName, 'insert', true);
         if (empty($this->active)) {
             $this->active = $viewName;
         }

--- a/Core/View/Master/GridController.html.twig
+++ b/Core/View/Master/GridController.html.twig
@@ -44,7 +44,7 @@
 {% set masterView = fsc.views|keys|first %}
 {% if fsc.views[masterView].count > 0 %}
 <script src="node_modules/handsontable/dist/handsontable.full.min.js"></script>
-<script src="Core/Assets/JS/gridController.js"></script>
+<script src="Core/Assets/JS/GridController.js"></script>
 <script type="text/javascript">
     documentUrl = '{{ fsc.views[masterView].getURL('edit') | raw }}';
 </script>

--- a/Core/View/Master/ListController.html.twig
+++ b/Core/View/Master/ListController.html.twig
@@ -27,138 +27,75 @@
 {% extends "Master/MenuTemplate.html.twig" %}
 
 {% block javascripts %}
-    {{ parent() }}
+{{ parent() }}
 
-    <script type="text/javascript">
-        var tabActive = '{{ fsc.active }}';
-        function deleteFromList() {
-            var deleteCodes = getLineCodes();
-            if (deleteCodes.length) {
-                bootbox.confirm({
-                    title: "{{ i18n.trans('confirm-delete')|raw }}",
-                    message: "{{ i18n.trans('are-you-sure') }}",
-                    closeButton: false,
-                    buttons: {
-                        cancel: {
-                            label: '<i class="fa fa-times"></i> {{ i18n.trans("cancel") }}'
-                        },
-                        confirm: {
-                            label: '<i class="fa fa-check"></i> {{ i18n.trans("confirm") }}',
-                            className: 'btn-danger'
-                        }
+<script src="Core/Assets/JS/ListController.js"></script>
+<script type="text/javascript">
+    tabActive = '{{ fsc.active }}';
+    settings = {{ fsc.getSettings(null, null)|json_encode|raw }};
+    urls = { {{ fsc.getStringURLs('new') | raw }} };
+
+    function deleteFromList() {
+        var deleteCodes = getLineCodes();
+        if (deleteCodes.length) {
+            bootbox.confirm({
+                title: "{{ i18n.trans('confirm-delete')|raw }}",
+                message: "{{ i18n.trans('are-you-sure') }}",
+                closeButton: false,
+                buttons: {
+                    cancel: {
+                        label: '<i class="fa fa-times"></i> {{ i18n.trans("cancel") }}'
                     },
-                    callback: function (result) {
-                        if (result) {
-                            execActionForm('delete');
-                        }
+                    confirm: {
+                        label: '<i class="fa fa-check"></i> {{ i18n.trans("confirm") }}',
+                        className: 'btn-danger'
                     }
-                });
-            }
-
-            return false;
-        }
-        function execActionForm(actionValue) {
-            var form = document.getElementById('form' + tabActive);
-            $('<input>').attr({type: 'hidden', name: 'action'}).appendTo(form);
-            $('<input>').attr({type: 'hidden', name: 'code'}).appendTo(form);
-            var lineCodes = getLineCodes();
-            form.action.value = actionValue;
-            form.code.value = lineCodes.join();
-            form.submit();
-        }
-        function getAutocompleteData(formName, source, field, title, term) {
-            var formData = {};
-            var rawForm = $('form[name="' + formName + '"]').serializeArray();
-            $.each(rawForm, function (i, input) {
-                formData[input.name] = input.value;
-            });
-            formData['action'] = 'autocomplete';
-            formData['source'] = source;
-            formData['field'] = field;
-            formData['title'] = title;
-            formData['term'] = term;
-            console.log(formData);
-            return formData;
-        }
-        function getLineCodes() {
-            var lineCodes = [];
-            $('.tab' + tabActive + ' .listAction').each(function () {
-                if ($(this).prop('checked')) {
-                    lineCodes.push($(this).val());
+                },
+                callback: function (result) {
+                    if (result) {
+                        execActionForm('delete');
+                    }
                 }
             });
-            return lineCodes;
         }
-        function goToExport(option) {
-            $('#form' + tabActive).append('<input type="hidden" name="option" value="' + option + '"/>');
-            execActionForm('export');
-        }
-        function goToOptions(url) {
-            var previous = '';
-            if (typeof url !== 'undefined') {
-                previous = '&url=' + encodeURIComponent(url + '?active=' + tabActive);
-            }
-            window.location.href = 'EditPageOption?code=' + tabActive + previous;
-        }
-        function insertRecord() {
-            var urls = { {{ fsc.getStringURLs('new') | raw }} };
-            document.insertForm.action = urls[tabActive];
-            document.insertForm.submit();
-        }
-        function setOperator(buttonID, operator) {
-            document.getElementById(buttonID + '-operator').value = operator;
-            document.getElementById(buttonID + '-btn').value = operator;
-            $('#form' + tabActive).submit();
-        }
-        function setOrder(value) {
-            $("#form" + tabActive + " :input[name='order']").val(value);
-            $('#form' + tabActive).submit();
-        }
-        $(document).ready(function () {
-            // set focus on tab change
-            $('#mainTabs').on('shown.bs.tab', function (e) {
-                tabActive = e.target.hash.substring(1);
-                $('#form' + tabActive + ' :text:first').focus().select();
-            });
-            // set/unset all delete checkbox
-            $('.listActionCB').click(function () {
-                var checked = $(this).prop('checked');
-                $('.listAction').prop('checked', checked);
-            });
-            // autocomplete filters
-            $('.autocomplete').each(function () {
-                var source = $(this).attr('data-source');
-                var field = $(this).attr('data-field');
-                var title = $(this).attr('data-title');
-                var formName = $(this).closest('form').attr('name');
-                $(this).autocomplete({
-                    source: function (request, response) {
-                        $.ajax({
-                            method: 'POST',
-                            url: '{{ fsc.url() }}',
-                            data: getAutocompleteData(formName, source, field, title, request.term),
-                            dataType: 'json',
-                            success: function (results) {
-                                var values = [];
-                                results.forEach(function (element) {
-                                    values.push({key: element.key, value: element.key + " | " + element.value});
-                                });
-                                response(values);
-                            },
-                            error: function (msg) {
-                                alert(msg.status + ' ' + msg.statusText);
-                            }
-                        });
-                    },
-                    select: function (event, ui) {
-                        $('#' + field + 'Autocomplete').val(ui.item.key);
-                        ui.item.value = ui.item.value.split(' | ')[1];
-                        $(this).form().submit();
-                    }
-                });
+
+        return false;
+    }
+    $(document).ready(function () {
+        // autocomplete filters
+        $('.autocomplete').each(function () {
+            var source = $(this).attr('data-source');
+            var field = $(this).attr('data-field');
+            var title = $(this).attr('data-title');
+            var formName = $(this).closest('form').attr('name');
+            $(this).autocomplete({
+                source: function (request, response) {
+                    $.ajax({
+                        method: 'POST',
+                        url: '{{ fsc.url() }}',
+                        data: getAutocompleteData(formName, source, field, title, request.term),
+                        dataType: 'json',
+                        success: function (results) {
+                            var values = [];
+                            results.forEach(function (element) {
+                                values.push({key: element.key, value: element.key + " | " + element.value});
+                            });
+                            response(values);
+                        },
+                        error: function (msg) {
+                            alert(msg.status + ' ' + msg.statusText);
+                        }
+                    });
+                },
+                select: function (event, ui) {
+                    $('#' + field + 'Autocomplete').val(ui.item.key);
+                    ui.item.value = ui.item.value.split(' | ')[1];
+                    $(this).form().submit();
+                }
             });
         });
-    </script>
+    });
+</script>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
- Now you can control whether a view can or not insert data using the settings of the controller. When it can not insert data, the 'insert' button goes to the 'disabled' state.

**Into Controller for disable insert action**:
`$this->setSettings('MyViewName', 'insert', false);`

- Rename to UpperCamelCase gridController.js file.

- Separated the JavaScript code from the List Controller template to a separate file.

## How has this been tested?

- [X] PostgreSQL
- [X] Database with random data
