### PR TITLE
Add sort listcontroller by more than one field

### DIFF
--- a/Core/Controller/ListCliente.php
+++ b/Core/Controller/ListCliente.php
@@ -54,7 +54,7 @@ class ListCliente extends ExtendedController\ListController
         $this->addSearchFields('ListCliente', ['nombre', 'razonsocial', 'codcliente', 'email']);
         $this->addOrderBy('ListCliente', 'codcliente', 'code');
         $this->addOrderBy('ListCliente', 'nombre', 'name', 1);
-        $this->addOrderBy('ListCliente', 'fecha', 'date');
+        $this->addOrderBy('ListCliente', ['fechaalta', 'codcliente'], 'date');
 
         $selectValues = $this->codeModel->all('gruposclientes', 'codgrupo', 'nombre');
         $this->addFilterSelect('ListCliente', 'codgrupo', 'group', 'codgrupo', $selectValues);

--- a/Core/Lib/ExtendedController/ListController.php
+++ b/Core/Lib/ExtendedController/ListController.php
@@ -282,13 +282,13 @@ abstract class ListController extends BaseController
      * Adds an order field to the ListView.
      *
      * @param string $viewName
-     * @param string $field
+     * @param string|[] $fields
      * @param string $label
      * @param int    $default   (0 = None, 1 = ASC, 2 = DESC)
      */
-    protected function addOrderBy($viewName, $field, $label = '', $default = 0)
+    protected function addOrderBy($viewName, $fields, $label = '', $default = 0)
     {
-        $this->views[$viewName]->addOrderBy($field, $label, $default);
+        $this->views[$viewName]->addOrderBy($fields, $label, $default);
     }
 
     /**

--- a/Core/Lib/ExtendedController/ListView.php
+++ b/Core/Lib/ExtendedController/ListView.php
@@ -138,20 +138,21 @@ class ListView extends BaseView implements DataViewInterface
     /**
      * Adds a field to the Order By list
      *
-     * @param string $field
+     * @param string|[] $fields
      * @param string $label
      * @param int    $default (0 = None, 1 = ASC, 2 = DESC)
      */
-    public function addOrderBy($field, $label = '', $default = 0)
+    public function addOrderBy($fields, $label, $default = 0)
     {
-        $key1 = strtolower($field) . '_asc';
-        $key2 = strtolower($field) . '_desc';
-        if (empty($label)) {
-            $label = $field;
+        if (!is_array($fields)) {
+            $fields = [$fields];
         }
 
-        $this->orderby[$key1] = ['icon' => self::ICON_ASC, 'label' => static::$i18n->trans($label)];
-        $this->orderby[$key2] = ['icon' => self::ICON_DESC, 'label' => static::$i18n->trans($label)];
+        $key1 = strtolower($label) . '_asc';
+        $key2 = strtolower($label) . '_desc';
+
+        $this->orderby[$key1] = ['icon' => self::ICON_ASC, 'fields' => $fields, 'label' => static::$i18n->trans($label)];
+        $this->orderby[$key2] = ['icon' => self::ICON_DESC, 'fields' => $fields, 'label' => static::$i18n->trans($label)];
 
         switch ($default) {
             case 1:
@@ -294,19 +295,18 @@ class ListView extends BaseView implements DataViewInterface
      */
     public function getSQLOrderBy($orderKey = '')
     {
-        if (empty($this->orderby)) {
-            return [];
-        }
+        $result = [];
+        if (!empty($this->orderby)) {
+            if ($orderKey === '') {
+                $orderKey = array_keys($this->orderby)[0];
+            }
 
-        if ($orderKey === '') {
-            $orderKey = array_keys($this->orderby)[0];
+            $direction = (substr($orderKey, -5) == '_desc') ? 'DESC' : 'ASC';
+            foreach ($this->orderby[$orderKey]['fields'] as $field) {
+                $result[$field] = $direction;
+            }
         }
-
-        if (substr($orderKey, -4) == '_asc') {
-            return [substr($orderKey, 0, -4) => 'ASC'];
-        }
-
-        return [substr($orderKey, 0, -5) => 'DESC'];
+        return $result;
     }
 
     public function getURL(string $type)


### PR DESCRIPTION
Now you can specify one or more fields for the sort in each of the sorting options.

To indicate more than one sort field in one of the options, an array of strings with the field names must be reported when the sort order is added from the controller.

## Example:

- Sort by ONE FIELD
`$this->addOrderBy('ListCliente', 'codcliente', 'code');`

- Sort by MORE ONE FIELD
` $this->addOrderBy('ListCliente', ['fechaalta', 'codcliente'], 'date');`

## How has this been tested?

- [X] PostgreSQL
- [X] Database with random data
