### PR TITLE
Minor improvements to login/logout

### DIFF
--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -114,7 +114,8 @@ class AppController extends App
             $this->response->setContent('IP-BANNED');
         } elseif ($this->request->query->get('logout')) {
             $this->userLogout();
-            $this->renderHtml('Login/Login.html.twig');
+            $homeUrl = AppSettings::get('webportal', 'url', \FS_FOLDER);
+            $this->response->headers->set('Refresh', '0; ' . $homeUrl);
         } else {
             $this->user = $this->userAuth();
 

--- a/Core/App/AppController.php
+++ b/Core/App/AppController.php
@@ -114,8 +114,7 @@ class AppController extends App
             $this->response->setContent('IP-BANNED');
         } elseif ($this->request->query->get('logout')) {
             $this->userLogout();
-            $homeUrl = AppSettings::get('webportal', 'url', \FS_FOLDER);
-            $this->response->headers->set('Refresh', '0; ' . $homeUrl);
+            $this->response->headers->set('Refresh', '0; ' . \FS_ROUTE);
         } else {
             $this->user = $this->userAuth();
 

--- a/Core/View/Login/Login.html.twig
+++ b/Core/View/Login/Login.html.twig
@@ -6,7 +6,7 @@
     {{ parent() }}
     {% endblock %}
     {% block body %}
-    <form action="index.php" method="post" class="form">
+    <form action="{{ fsc.url() }}" method="post" class="form">
         <div class="container">
             <div class="row justify-content-md-center">
                 <div class="col-md-6">


### PR DESCRIPTION
- When user logout, replaced login view to a redirection to main page
  - Webportal default url or if not setted to FS_FOLDER
- When user is doing a new login, post action url must be do it to fsc.url and not to index.php (index.php it's implicit), and user goes to page he expects after login

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
- [X] Not needed, another kind of change
<!---- [ ] If additional tests was realized, added here--->
