### PR TITLE
Added external access to setLangCode, to change default language

### DIFF
--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -183,6 +183,14 @@ class Translator
     }
 
     /**
+     * Sets the language code in use.
+     */
+    public function setLangCode($lang)
+    {
+        self::$defaultLang = $this->firstMatch($lang);
+    }
+
+    /**
      * Returns the missing strings.
      *
      * @return array
@@ -200,5 +208,32 @@ class Translator
     public function getUsedStrings()
     {
         return self::$usedStrings;
+    }
+
+    /**
+     * Return first exact match, or first partial match with language key identifier,
+     * or it not match founded, return default language.
+     *
+     * @param string $langCode
+     *
+     * @return string
+     */
+    private function firstMatch(string $langCode): string
+    {
+        $finalKey = null;
+        // First match is with default lang? (Avoid match with variants)
+        if (0 === strpos(\FS_LANG, $langCode)) {
+            return \FS_LANG;
+        }
+        // If not, check with all available languages
+        foreach ($this->getAvailableLanguages() as $key => $language) {
+            if ($key === $langCode) {
+                return $key;
+            }
+            if ($finalKey === null && 0 === strpos($key, $langCode)) {
+                $finalKey = $key;
+            }
+        }
+        return $finalKey ?? \FS_LANG;
     }
 }


### PR DESCRIPTION
- Added support for change default translator language from external place (for example, webportal fully rendered in english, french, ...)
- Find first code lang match (webportal use 2 digits lang code versus FS use 5 digits), found the first match, BUT checking first default language.
  - For example es_ES is after es_AR, but if not checked first, es_AR is used as default lang if FS_LANG=es_ES.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
