### PR TITLE
Fixed problem when added a menu on rules

### DIFF
--- a/Core/Controller/EditRole.php
+++ b/Core/Controller/EditRole.php
@@ -59,7 +59,7 @@ class EditRole extends ExtendedController\PanelController
     {
         // add Pages to Rol
         if (!Model\RoleAccess::addPagesToRole($codrole, $pages)) {
-            throw new \Exception(self::$i18n->trans('cancel-process'));
+            throw new \Exception($this->i18n->trans('cancel-process'));
         }
     }
 


### PR DESCRIPTION
The problem was the form how call to the variable.
self is to static variables or constant.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [X] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->
