### PR TITLE
Added Twig Filter to use Utils:fixHtml

### DIFF
--- a/Core/App/WebRender.php
+++ b/Core/App/WebRender.php
@@ -21,9 +21,11 @@ namespace FacturaScripts\Core\App;
 use FacturaScripts\Core\Base\MiniLog;
 use FacturaScripts\Core\Base\PluginManager;
 use FacturaScripts\Core\Base\Translator;
+use FacturaScripts\Core\Base\Utils;
 use FacturaScripts\Dinamic\Lib\AssetManager;
 use Twig_Environment;
 use Twig_Extension_Debug;
+use Twig_Filter;
 use Twig_Function;
 use Twig_Loader_Filesystem;
 
@@ -112,6 +114,12 @@ class WebRender
             return AssetManager::combine($fileList);
         });
         $twig->addFunction($assetCombineFunction);
+
+        /// fixHtml functions
+        $fixHtmlFunction = new Twig_Filter('fixHtml', function ($string) {
+            return Utils::fixHtml($string);
+        });
+        $twig->addFilter($fixHtmlFunction);
 
         /// debug extension
         $twig->addExtension(new Twig_Extension_Debug());


### PR DESCRIPTION
To convert parsed HTML to real HTML and lets Twig to rendered it.

This is needed in case anyone needs to store HTML code in database to render it later. Not the same as store code sample (as in documentation), that can be used directly escaped without use this filter.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
