### PR TITLE
Add Autocomplete from Widget values

### DIFF
--- a/Core/Assets/JS/PanelController.js
+++ b/Core/Assets/JS/PanelController.js
@@ -60,7 +60,7 @@ function getAutocompleteData(formName, field, source, fieldcode, fieldtitle, ter
     formData["fieldcode"] = fieldcode;
     formData["fieldtitle"] = fieldtitle;
     formData["term"] = term;
-    console.log(formData);
+    formData["formname"] = formName;
     return formData;
 }
 

--- a/Core/Lib/ExtendedController/BaseController.php
+++ b/Core/Lib/ExtendedController/BaseController.php
@@ -149,12 +149,36 @@ abstract class BaseController extends Base\Controller
      */
     protected function autocompleteAction(): array
     {
+        $data = $this->requestGet(['field', 'source', 'fieldcode', 'fieldtitle', 'term', 'formname']);
+
+        if ($data['source'] == '') {
+            return $this->getAutocompleteValues($data['formname'], $data['field']);
+        }
+
         $results = [];
-        $data = $this->requestGet(['field', 'source', 'fieldcode', 'fieldtitle', 'term']);
         foreach ($this->codeModel->search($data['source'], $data['fieldcode'], $data['fieldtitle'], $data['term']) as $value) {
             $results[] = ['key' => $value->code, 'value' => $value->description];
         }
         return $results;
+    }
+
+    /**
+     * Return values from Widget Values for autocomplete action
+     *
+     * @param string $viewName
+     * @param string $fieldName
+     * @return array
+     */
+    protected function getAutocompleteValues(string $viewName, string $fieldName): array
+    {
+        $result = [];
+        $column = $this->views[$viewName]->columnForField($fieldName);
+        if (!empty($column)) {
+            foreach ($column->widget->values as $value) {
+                $result[] = ['key' => $this->i18n->trans($value['title']), 'value' => $value['value']];
+            }
+        }
+        return $result;
     }
 
     protected function getFormData(): array


### PR DESCRIPTION
Now you can indicate the values for the autocomplete by defining a list of values in the xml file of the view.

How to use:

Autocomplete from database table:

```
<widget type="autocomplete" fieldname="codsubcuenta" required="true">
    <values source="subcuentas" fieldcode="codsubcuenta" fieldtitle="descripcion"></values>
</widget>
```

Autocomplete from fixes values:

```
<widget type="autocomplete" fieldname="codsubcuenta" required="true">
    <values title="title-to-translate1">Value1</values>
    <values title="title-to-translate2">Value2</values>
    <values title="title-to-translate3">Value3</values>
</widget>
```

## How has this been tested?

- [X] PostgreSQL
- [X] Database with random data
