### PR TITLE
[FIX] AppInstaller now don't assume that if .htaccess exists is ready for FS

### DIFF
--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -19,6 +19,7 @@
 namespace FacturaScripts\Core\App;
 
 use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Base\Miscellany;
 use FacturaScripts\Core\Base\PluginManager;
 use FacturaScripts\Core\Base\Translator;
 use Symfony\Component\HttpFoundation\Request;
@@ -230,12 +231,8 @@ class AppInstaller
      */
     private function saveHtaccess()
     {
-        if (!file_exists(FS_FOLDER . '/.htaccess')) {
-            $txt = file_get_contents(FS_FOLDER . '/htaccess-sample');
-            file_put_contents(FS_FOLDER . '/.htaccess', \is_string($txt) ? $txt : '');
-        }
-
-        return true;
+        $contentFile = Miscellany::extractFromMarkers(FS_FOLDER . '/htaccess-sample');
+        return Miscellany::insertWithMarkers($contentFile);
     }
 
     /**

--- a/Core/Base/Miscellany.php
+++ b/Core/Base/Miscellany.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2018 Carlos García Gómez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Base;
+
+/**
+ * Class Miscellany.
+ * Mix of different things that at this time are no so specific to be in a concrete class.
+ *
+ * @source https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/misc.php
+ *
+ * @author Francesc Pineda Segarra <francesc.pineda@x-netdigital.com>
+ */
+class Miscellany
+{
+    const MARKER = 'FacturaScripts-generated handler, do not edit';
+    const HTACCESS = \FS_FOLDER . '/.htaccess';
+
+    /**
+     * Extracts strings from between the BEGIN and END markers in the .htaccess file.
+     *
+     * @source https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/misc.php#L67
+     *
+     * @param string $fileName
+     * @param string $marker
+     *
+     * @return array An array of strings from a file (.htaccess ) from between BEGIN and END markers.
+     */
+    public static function extractFromMarkers(string $fileName = self::HTACCESS, string $marker = self::MARKER): array
+    {
+        $result = [];
+        if (!file_exists($fileName)) {
+            return $result;
+        }
+        $markerData = explode(\PHP_EOL, file_get_contents($fileName));
+        $state = false;
+        foreach ($markerData as $markerLine) {
+            if (false !== strpos($markerLine, '# END ' . $marker)) {
+                $state = false;
+            }
+            if ($state) {
+                $result[] = $markerLine;
+            }
+            if (false !== strpos($markerLine, '# BEGIN ' . $marker)) {
+                $state = true;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Inserts an array of strings into a file (.htaccess ), placing it between
+     * BEGIN and END markers.
+     *
+     * Replaces existing marked info. Retains surrounding
+     * data. Creates file if none exists.
+     *
+     * @source https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/misc.php#L106
+     *
+     * @param array|string $insertion The new content to insert.
+     * @param string       $fileName  Filename to alter.
+     * @param string       $marker    The marker to alter.
+     *
+     * @return bool True on write success, false on failure.
+     */
+    public static function insertWithMarkers($insertion, string $fileName = self::HTACCESS, string $marker = self::MARKER): bool
+    {
+        if (!file_exists($fileName)) {
+            if (!is_writable(\dirname($fileName))) {
+                return false;
+            }
+            if (!touch($fileName)) {
+                return false;
+            }
+        } elseif (!is_writable($fileName)) {
+            return false;
+        }
+        if (!\is_array($insertion)) {
+            $insertion = explode(\PHP_EOL, $insertion);
+        }
+        $startMarker = '# BEGIN ' . $marker;
+        $endMarker = '# END ' . $marker;
+        $fp = fopen($fileName, 'rb+');
+        if (!$fp) {
+            return false;
+        }
+        // Attempt to get a lock. If the filesystem supports locking, this will block until the lock is acquired.
+        flock($fp, LOCK_EX);
+        $lines = [];
+        while (!feof($fp)) {
+            $lines[] = rtrim(fgets($fp), "\r\n");
+        }
+        // Split out the existing file into the preceding lines, and those that appear after the marker
+        $preLines = $postLines = $existingLines = [];
+        $foundMarker = $foundEndMarker = false;
+        foreach ($lines as $line) {
+            if (!$foundMarker && false !== strpos($line, $startMarker)) {
+                $foundMarker = true;
+                continue;
+            }
+            if (!$foundEndMarker && false !== strpos($line, $endMarker)) {
+                $foundEndMarker = true;
+                continue;
+            }
+            if (!$foundMarker) {
+                $preLines[] = $line;
+            } elseif ($foundMarker && $foundEndMarker) {
+                $postLines[] = $line;
+            } else {
+                $existingLines[] = $line;
+            }
+        }
+        // Check to see if there was a change
+        if ($existingLines === $insertion) {
+            flock($fp, LOCK_UN);
+            fclose($fp);
+            return true;
+        }
+
+        // If it's true, is the old content version without the tags marker, we can remove it
+        if (empty(\array_diff($insertion, $preLines))) {
+            $preLines = [];
+        }
+
+        // Generate the new file data
+        $newFileData = implode(
+            \PHP_EOL,
+            array_merge(
+                $preLines,
+                [$startMarker],
+                $insertion,
+                [$endMarker],
+                $postLines
+            )
+        );
+        // Write to the start of the file, and truncate it to that length
+        fseek($fp, 0);
+        $bytes = fwrite($fp, $newFileData);
+        if ($bytes) {
+            ftruncate($fp, ftell($fp));
+        }
+        fflush($fp);
+        flock($fp, LOCK_UN);
+        fclose($fp);
+        return (bool) $bytes;
+    }
+}

--- a/htaccess-sample
+++ b/htaccess-sample
@@ -1,3 +1,4 @@
+# BEGIN FacturaScripts-generated handler, do not edit
 Options -Indexes
 
 <IfModule mod_php7.c>
@@ -22,3 +23,4 @@ Options -Indexes
       ExpiresActive Off
    </FilesMatch>
 </IfModule>
+# END FacturaScripts-generated handler, do not edit


### PR DESCRIPTION
Adds support to read/write .htaccess as array of lines, based on read a block between BEGIN/END tag markers.

This simplifies the correct use of add/update the part needed by FacturaScripts, without touch any other possible blocks.

If other blocks exists, delimited or not by tags but also exists before or after FacturaScripts block, this blocks are also respected without loose its content.

**Details:**
- htaccess-sample updated using BEGIN/END tag markers
  - This tags are required to recognized the block part needed by FacturaScripts, and maybe others use a shared .htaccess on same folder, or have pre-generated file by Apache. In this case we only must to touch a specific part of full .htaccess
- saveHtaccess now read original file using BEGIN/END tag markers (the same code works exists or not the final .htaccess file)
- Miscellany class is based on two methods from WordPress, respecting PSR style
  - Adds a little comparition to recognize if previous .htaccess file is founded without tags to update it

**NOTE:** Related information about this tags, but not founded enougth clear details:
- Wordpress: https://codex.wordpress.org/htaccess
  - Founded some sample with security WP plugins are allowed to add some rules using same technique
- cPanel: https://www.first2host.co.uk/f/cpanel-multiphp-manager-change-php-version/
  - Used for example to customized specific user accounts, not default option. For example, use a specific PHP version

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
- [X] Tested with a non existing .htaccess file
- [X] Tested with a previous version of .htaccess file
- [X] Tested with a modified version of .htaccess file, as generated by cPanel and with fake content
<!---- [ ] If additional tests was realized, added here--->
