### PR TITLE
Replace Core/Lib/MenuItem class with a Twig macro

### DIFF
--- a/Core/View/Macro/MenuItems.html.twig
+++ b/Core/View/Macro/MenuItems.html.twig
@@ -27,16 +27,6 @@
 #}
 
 {#
-    Generate the menu items of private core
-#}
-{% macro generate(menuManager) %}
-    {% import _self as menuTree %}
-    {% for menuItem in menuManager.getMenu() %}
-        {{ menuTree.getHTML(menuItem) }}
-    {% endfor %}
-{% endmacro %}
-
-{#
     Returns the HTML for the icon of the item.
 #}
 {% macro getHTMLIcon(menuItem) %}

--- a/Core/View/Macro/MenuItems.html.twig
+++ b/Core/View/Macro/MenuItems.html.twig
@@ -1,0 +1,120 @@
+{#
+   /**
+     * Obtains and generate the menu items for the user logged in.
+     *
+     * Adds twig functions to display the ExtendedController elements
+     * Examples imports:
+     *  {% import 'Macro/MenuItems.html.twig' as menuItems %}
+     *  {{ menuItems.generate(menuManager) }}
+     *
+     * This file is part of FacturaScripts
+     * Copyright (C) 2017-2018  Carlos Garcia Gomez  <carlos@facturascripts.com>
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation, either version 3 of the
+     * License, or (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+     * GNU Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public License
+     * along with this program. If not, see <http://www.gnu.org/licenses/>.
+     *
+    */
+#}
+
+{#
+    Generate the menu items of private core
+#}
+{% macro generate(menuManager) %}
+    {% import _self as menuTree %}
+    {% for menuItem in menuManager.getMenu() %}
+        {{ menuTree.getHTML(menuItem) }}
+    {% endfor %}
+{% endmacro %}
+
+{#
+    Returns the HTML for the icon of the item.
+#}
+{% macro getHTMLIcon(menuItem) %}
+    {% if menuItem.icon is empty %}
+        <i class="fa fa-file-o fa-fw" aria-hidden="true"></i>
+    {% else %}
+        <i class="fa {{ menuItem.icon }} fa-fw" aria-hidden="true"></i>
+    {% endif %}
+{% endmacro %}
+
+{#
+    Returns the HTML for the label of the item.
+#}
+{% macro getMenuLabel(menuItem) %}
+    {% set title = menuItem.title|capitalize %}
+    <span class="d-md-none">{{ title|slice(0, 2) }}</span>
+    <span class="d-none d-md-inline-block">{{ title }}</span>
+{% endmacro %}
+
+{#
+    Returns the identifier of the menu.
+    NOTE: Don't change it to multi-line, breaks HTML code
+#}
+{% macro getMenuId(menuItem, parent) %}
+    {% if parent is empty %}menu-{{ menuItem.title }}{% else %}{{ parent }}{{ menuItem.name }}{% endif %}
+{% endmacro %}
+
+{#
+    Returns the html for the menu / submenu.
+#}
+{% macro getHTML(menuItem, parent) %}
+    {% import _self as menuTree %}
+    {% set active = '' %}
+    {% if menuItem.active %}
+        {% set active = ' active' %}
+    {% endif %}
+    {% set menuId = menuTree.getMenuId(menuItem, parent) %}
+
+    {% if parent is empty %}
+        {# Main level menu/submenu #}
+        <li class="nav-item dropdown{{ active }}">
+            <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {{ menuTree.getMenuLabel(menuItem) }}
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="{{ menuId }}">
+    {% else %}
+        {# Child level submenu #}
+        <li class="dropdown-submenu">
+            <a class="dropdown-item{{ active }}" href="#">
+                <i class="fa fa-folder-open fa-fw" aria-hidden="true"></i>
+                &nbsp; {{ menuItem.title|capitalize }}
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="{{ menuId }}">
+    {% endif %}
+
+    {{ menuTree.getItem(menuItem, menuId) }}
+    </ul>
+{% endmacro %}
+
+{# Direct menu item, or recursive call to draw a submenu #}
+{% macro getItem(menuItem, menuId) %}
+    {% import _self as menuTree %}
+    {% for item in menuItem.menu %}
+        {% set extraClass = '' %}
+        {% if item.active %}
+            {% set extraClass = ' active' %}
+        {% endif %}
+
+        {% if item.menu is empty %}
+            {# Main level menu/submenu #}
+            <li>
+                <a class="dropdown-item{{ extraClass }}" href="{{ item.url }}">
+                    {{ menuTree.getHTMLIcon(item) }} &nbsp; {{ item.title|capitalize }}
+                </a>
+            </li>
+        {% else %}
+            {# Child level submenu #}
+            {{ menuTree.getHTML(item, menuId) }}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -75,9 +75,8 @@
                         </a>
                         <div class="navbar-collapse collapse">
                             <ul class="navbar-nav pt-1">
-                                {% for menuItem in menuManager.getMenu() %}
-                                    {{ menuItem.getHTML()|raw }}
-                                {% endfor %}
+                                {% import 'Macro/MenuItems.html.twig' as menuItems %}
+                                {{ menuItems.generate(menuManager) }}
                             </ul>
                             <ul class="navbar-nav flex-row ml-auto">
                                 <li class="nav-item dropdown">

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -76,7 +76,9 @@
                         <div class="navbar-collapse collapse">
                             <ul class="navbar-nav pt-1">
                                 {% import 'Macro/MenuItems.html.twig' as menuItems %}
-                                {{ menuItems.generate(menuManager) }}
+                                {% for menuItem in menuManager.getMenu() %}
+                                    {{ menuItems.getHTML(menuItem) }}
+                                {% endfor %}
                             </ul>
                             <ul class="navbar-nav flex-row ml-auto">
                                 <li class="nav-item dropdown">


### PR DESCRIPTION
- Replaced MenuTemplate call to macro
- Added 6 little macros to replace all previous method on class:
  - generate() as entry point
  - getHTMLIcon()
  - getMenuLabel()
  - getMenuId()
  - getHTML()
  - getItem()

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
