### PR TITLE
Updated generate method to do it all in one transaction [Trello task 480]

### DIFF
--- a/Core/Lib/RandomDataGenerator/AbstractRandom.php
+++ b/Core/Lib/RandomDataGenerator/AbstractRandom.php
@@ -19,6 +19,7 @@
 namespace FacturaScripts\Core\Lib\RandomDataGenerator;
 
 use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Base\MiniLog;
 use FacturaScripts\Core\Model;
 
 /**
@@ -35,7 +36,14 @@ abstract class AbstractRandom
      *
      * @var DataBase
      */
-    private $dataBase;
+    protected $dataBase;
+
+    /**
+     * App log manager.
+     *
+     * @var MiniLog
+     */
+    protected $miniLog;
 
     /**
      * Contains the model to generate random data.
@@ -61,6 +69,7 @@ abstract class AbstractRandom
     public function __construct($model)
     {
         $this->dataBase = new DataBase();
+        $this->miniLog = new MiniLog();
         $this->model = $model;
     }
 

--- a/Core/Lib/RandomDataGenerator/Agentes.php
+++ b/Core/Lib/RandomDataGenerator/Agentes.php
@@ -46,12 +46,27 @@ class Agentes extends AbstractRandomPeople
     public function generate($num = 50)
     {
         $agente = $this->model;
-        for ($generated = 0; $generated < $num; ++$generated) {
-            $agente->clear();
-            $this->setAgenteData($agente);
 
-            if (!$agente->save()) {
-                break;
+        // start transaction
+        $this->dataBase->beginTransaction();
+
+        // main save process
+        try {
+            for ($generated = 0; $generated < $num; ++$generated) {
+                $agente->clear();
+                $this->setAgenteData($agente);
+
+                if (!$agente->save()) {
+                    break;
+                }
+            }
+            // confirm data
+            $this->dataBase->commit();
+        } catch (\Exception $e) {
+            $this->miniLog->alert($e->getMessage());
+        } finally {
+            if ($this->dataBase->inTransaction()) {
+                $this->dataBase->rollback();
             }
         }
 

--- a/Core/Lib/RandomDataGenerator/AlbaranesProveedor.php
+++ b/Core/Lib/RandomDataGenerator/AlbaranesProveedor.php
@@ -52,21 +52,36 @@ class AlbaranesProveedor extends AbstractRandomDocuments
 
         $alb = $this->model;
         $generated = 0;
-        while ($generated < $num) {
-            $alb->clear();
-            $this->randomizeDocument($alb);
-            $eje = $this->ejercicio->getByFecha($alb->fecha);
-            if (false === $eje) {
-                break;
-            }
 
-            $recargo = (mt_rand(0, 4) === 0);
-            $regimeniva = $this->randomizeDocumentCompra($alb, $eje, $proveedores, $generated);
-            if ($alb->save()) {
-                $this->randomLineas($alb, 'idalbaran', 'FacturaScripts\Dinamic\Model\LineaAlbaranProveedor', $regimeniva, $recargo, 1);
-                ++$generated;
-            } else {
-                break;
+        // start transaction
+        $this->dataBase->beginTransaction();
+
+        // main save process
+        try {
+            while ($generated < $num) {
+                $alb->clear();
+                $this->randomizeDocument($alb);
+                $eje = $this->ejercicio->getByFecha($alb->fecha);
+                if (false === $eje) {
+                    break;
+                }
+
+                $recargo = (mt_rand(0, 4) === 0);
+                $regimeniva = $this->randomizeDocumentCompra($alb, $eje, $proveedores, $generated);
+                if ($alb->save()) {
+                    $this->randomLineas($alb, 'idalbaran', 'FacturaScripts\Dinamic\Model\LineaAlbaranProveedor', $regimeniva, $recargo, 1);
+                    ++$generated;
+                } else {
+                    break;
+                }
+            }
+            // confirm data
+            $this->dataBase->commit();
+        } catch (\Exception $e) {
+            $this->miniLog->alert($e->getMessage());
+        } finally {
+            if ($this->dataBase->inTransaction()) {
+                $this->dataBase->rollback();
             }
         }
 

--- a/Core/Lib/RandomDataGenerator/ArticulosProveedor.php
+++ b/Core/Lib/RandomDataGenerator/ArticulosProveedor.php
@@ -52,23 +52,38 @@ class ArticulosProveedor extends AbstractRandom
         }
 
         $art = $this->model;
-        for ($generated = 0; $generated < $num; ++$generated) {
-            if (!isset($articulos[$generated])) {
-                break;
-            }
 
-            $art->clear();
-            $art->referencia = $articulos[$generated]->referencia;
-            $art->refproveedor = (string) mt_rand(1, 99999999);
-            $art->descripcion = $this->descripcion();
-            $art->codimpuesto = $articulos[$generated]->codimpuesto;
-            $art->codproveedor = $proveedores[$generated]->codproveedor;
-            $art->precio = $this->precio(1, 49, 699);
-            $art->dto = mt_rand(0, 80);
-            $art->nostock = (mt_rand(0, 2) == 0);
-            $art->stockfis = mt_rand(0, 10);
-            if (!$art->save()) {
-                break;
+        // start transaction
+        $this->dataBase->beginTransaction();
+
+        // main save process
+        try {
+            for ($generated = 0; $generated < $num; ++$generated) {
+                if (!isset($articulos[$generated])) {
+                    break;
+                }
+
+                $art->clear();
+                $art->referencia = $articulos[$generated]->referencia;
+                $art->refproveedor = (string) mt_rand(1, 99999999);
+                $art->descripcion = $this->descripcion();
+                $art->codimpuesto = $articulos[$generated]->codimpuesto;
+                $art->codproveedor = $proveedores[$generated]->codproveedor;
+                $art->precio = $this->precio(1, 49, 699);
+                $art->dto = mt_rand(0, 80);
+                $art->nostock = (mt_rand(0, 2) == 0);
+                $art->stockfis = mt_rand(0, 10);
+                if (!$art->save()) {
+                    break;
+                }
+            }
+            // confirm data
+            $this->dataBase->commit();
+        } catch (\Exception $e) {
+            $this->miniLog->alert($e->getMessage());
+        } finally {
+            if ($this->dataBase->inTransaction()) {
+                $this->dataBase->rollback();
             }
         }
 

--- a/Core/Lib/RandomDataGenerator/Fabricantes.php
+++ b/Core/Lib/RandomDataGenerator/Fabricantes.php
@@ -46,12 +46,27 @@ class Fabricantes extends AbstractRandomPeople
     public function generate($num = 50)
     {
         $fabri = $this->model;
-        for ($generated = 0; $generated < $num; ++$generated) {
-            $fabri->clear();
-            $fabri->nombre = $this->empresa();
-            $fabri->codfabricante = $this->txt2codigo($fabri->nombre);
-            if (!$fabri->save()) {
-                break;
+
+        // start transaction
+        $this->dataBase->beginTransaction();
+
+        // main save process
+        try {
+            for ($generated = 0; $generated < $num; ++$generated) {
+                $fabri->clear();
+                $fabri->nombre = $this->empresa();
+                $fabri->codfabricante = $this->txt2codigo($fabri->nombre);
+                if (!$fabri->save()) {
+                    break;
+                }
+            }
+            // confirm data
+            $this->dataBase->commit();
+        } catch (\Exception $e) {
+            $this->miniLog->alert($e->getMessage());
+        } finally {
+            if ($this->dataBase->inTransaction()) {
+                $this->dataBase->rollback();
             }
         }
 

--- a/Core/Lib/RandomDataGenerator/Grupos.php
+++ b/Core/Lib/RandomDataGenerator/Grupos.php
@@ -52,12 +52,27 @@ class Grupos extends AbstractRandomPeople
         $sufijos = ['VIP', 'PRO', 'NEO', 'XL', 'XXL', '50 aniversario', 'C', 'Z'];
 
         $grupo = $this->model;
-        for ($generated = 0; $generated < $num; ++$generated) {
-            $grupo->clear();
-            $grupo->codgrupo = $grupo->newCode();
-            $grupo->nombre = $this->getOneItem($nombres) . ' ' . $this->getOneItem($sufijos) . " $generated";
-            if (!$grupo->save()) {
-                break;
+
+        // start transaction
+        $this->dataBase->beginTransaction();
+
+        // main save process
+        try {
+            for ($generated = 0; $generated < $num; ++$generated) {
+                $grupo->clear();
+                $grupo->codgrupo = $grupo->newCode();
+                $grupo->nombre = $this->getOneItem($nombres) . ' ' . $this->getOneItem($sufijos) . " $generated";
+                if (!$grupo->save()) {
+                    break;
+                }
+            }
+            // confirm data
+            $this->dataBase->commit();
+        } catch (\Exception $e) {
+            $this->miniLog->alert($e->getMessage());
+        } finally {
+            if ($this->dataBase->inTransaction()) {
+                $this->dataBase->rollback();
             }
         }
 


### PR DESCRIPTION
- Changed visibility in AbstractRandom for dataBase and added miniLog, avoid to re-define it on child classes
- All quantity for generation fixed to 50
- More documents can be generated with less time than before with this change, but SQL tab for debugbar cause lag when render the result page because have more than 5.000 SQL queries

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [x] MySQL
- [ ] PostgreSQL
- [x] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
