### PR TITLE
Ampliar CODISO del modelo Divisa a 5 caracteres y adición de ventasinstock a SettingsDefault.xml

### DIFF
--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -32,7 +32,7 @@ class Divisa extends Base\ModelClass
     use Base\ModelTrait;
 
     /**
-     * Primary key. Varchar (3).
+     * Primary key. Varchar (5).
      *
      * @var string
      */
@@ -125,7 +125,7 @@ class Divisa extends Base\ModelClass
         $this->descripcion = Utils::noHtml($this->descripcion);
         $this->simbolo = Utils::noHtml($this->simbolo);
 
-        if (!preg_match('/^[A-Z0-9]{1,3}$/i', $this->coddivisa)) {
+        if (!preg_match('/^[A-Z0-9]{1,5}$/i', $this->coddivisa)) {
             self::$miniLog->alert(self::$i18n->trans('invalid-column-lenght', ['%column%' => 'coddivisa', '%min%' => '1', '%max%' => '3']));
         } elseif ($this->codiso !== null && !preg_match('/^[A-Z0-9]{1,3}$/i', $this->codiso)) {
             self::$miniLog->alert(self::$i18n->trans('invalid-column-lenght', ['%column%' => 'codiso', '%min%' => '1', '%max%' => '3']));

--- a/Core/Model/Divisa.php
+++ b/Core/Model/Divisa.php
@@ -32,7 +32,7 @@ class Divisa extends Base\ModelClass
     use Base\ModelTrait;
 
     /**
-     * Primary key. Varchar (5).
+     * Primary key. Varchar (3).
      *
      * @var string
      */
@@ -125,9 +125,9 @@ class Divisa extends Base\ModelClass
         $this->descripcion = Utils::noHtml($this->descripcion);
         $this->simbolo = Utils::noHtml($this->simbolo);
 
-        if (!preg_match('/^[A-Z0-9]{1,5}$/i', $this->coddivisa)) {
+        if (!preg_match('/^[A-Z0-9]{1,3}$/i', $this->coddivisa)) {
             self::$miniLog->alert(self::$i18n->trans('invalid-column-lenght', ['%column%' => 'coddivisa', '%min%' => '1', '%max%' => '3']));
-        } elseif ($this->codiso !== null && !preg_match('/^[A-Z0-9]{1,3}$/i', $this->codiso)) {
+        } elseif ($this->codiso !== null && !preg_match('/^[A-Z0-9]{1,5}$/i', $this->codiso)) {
             self::$miniLog->alert(self::$i18n->trans('invalid-column-lenght', ['%column%' => 'codiso', '%min%' => '1', '%max%' => '3']));
         } elseif ($this->tasaconv === 0.0 || $this->tasaconvcompra === 0.0) {
             self::$miniLog->alert(self::$i18n->trans('conversion-rate-not-0'));

--- a/Core/Table/divisas.xml
+++ b/Core/Table/divisas.xml
@@ -8,12 +8,12 @@
 <table>
     <column>
         <name>coddivisa</name>
-        <type>character varying(5)</type>
+        <type>character varying(3)</type>
         <null>NO</null>
     </column>
     <column>
         <name>codiso</name>
-        <type>character varying(3)</type>
+        <type>character varying(5)</type>
     </column>
     <column>
         <name>descripcion</name>

--- a/Core/Table/divisas.xml
+++ b/Core/Table/divisas.xml
@@ -8,7 +8,7 @@
 <table>
     <column>
         <name>coddivisa</name>
-        <type>character varying(3)</type>
+        <type>character varying(5)</type>
         <null>NO</null>
     </column>
     <column>

--- a/Core/XMLView/SettingsDefault.xml
+++ b/Core/XMLView/SettingsDefault.xml
@@ -63,6 +63,9 @@
                     <values source="impuestos" fieldcode="codimpuesto" fieldtitle="descripcion"></values>
                 </widget>
             </column>
+            <column name="ventasinstock" numcolumns="3" order="140">
+                <widget type="checkbox" fieldname="ventasinstock" />
+            </column>
         </group>
         <group name="numericformat" title="numeric-formats" numcolumns="12" icon="fa-info-circle fa-lg">
             <column name="decimals" numcolumns="3" order="100">


### PR DESCRIPTION
Se ha modificado la longitud de CODISO tanto en la documentación del modelo como en la función test() y en el XML de la base de datos. 
Se ha añadido a SettingsDefault.xml el checkbox ventasinstock.

