### PR TITLE
Detection of missing mod_rewrite Apache module on installation

### DIFF
--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -309,6 +309,19 @@ class AppInstaller
             }
         }
 
+        foreach (['mod_rewrite'] as $module) {
+            if (!in_array($module, apache_get_modules())) {
+                $this->miniLog->critical($this->i18n->trans('apache-module-not-found', ['%module%' => $module]));
+                $errors = true;
+            }
+        }
+
+        foreach (['mod_expires', 'mod_php7'] as $module) {
+            if (!in_array($module, apache_get_modules())) {
+                $this->miniLog->info($this->i18n->trans('apache-module-not-found', ['%module%' => $module]));
+            }
+        }
+
         if (!is_writable(FS_FOLDER)) {
             $this->miniLog->critical($this->i18n->trans('folder-not-writable'));
             $errors = true;

--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -316,12 +316,6 @@ class AppInstaller
             }
         }
 
-        foreach (['mod_expires', 'mod_php7'] as $module) {
-            if (function_exists('apache_get_modules') && !in_array($module, apache_get_modules())) {
-                $this->miniLog->info($this->i18n->trans('apache-module-not-found', ['%module%' => $module]));
-            }
-        }
-
         if (!is_writable(FS_FOLDER)) {
             $this->miniLog->critical($this->i18n->trans('folder-not-writable'));
             $errors = true;

--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -310,14 +310,14 @@ class AppInstaller
         }
 
         foreach (['mod_rewrite'] as $module) {
-            if (!in_array($module, apache_get_modules())) {
+            if (function_exists('apache_get_modules') && !in_array($module, apache_get_modules())) {
                 $this->miniLog->critical($this->i18n->trans('apache-module-not-found', ['%module%' => $module]));
                 $errors = true;
             }
         }
 
         foreach (['mod_expires', 'mod_php7'] as $module) {
-            if (!in_array($module, apache_get_modules())) {
+            if (function_exists('apache_get_modules') && !in_array($module, apache_get_modules())) {
                 $this->miniLog->info($this->i18n->trans('apache-module-not-found', ['%module%' => $module]));
             }
         }

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -826,5 +826,6 @@
     "contacts": "Contacts",
     "points": "Points",
     "verified": "Verified",
-    "allow-marketing": "Allow marketing"
+    "allow-marketing": "Allow marketing",
+    "apache-module-not-found": "You don't have the Apache %module% module installed or enabled."
 }


### PR DESCRIPTION
If _mod_rewrite_ is not enabled on Apache, custom routes aren't working and FS don't works.

**NOTE:** Added also a check for _mod_expires_ and _mod_php7_, but only show a info message without error.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [x] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
