### PR TITLE
EditDashboardData error when no component set [Trello task 447]

### DIFF
--- a/Core/Assets/JS/EditDashboardData.js
+++ b/Core/Assets/JS/EditDashboardData.js
@@ -1,0 +1,32 @@
+/*
+ * This file is part of FacturaScripts
+ * Copyright (C) 2013-2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * @author Carlos García Gómez <carlos@facturascripts.com>
+ * @author Artex Trading sa <jcuello@artextrading.com>
+ * @author Francesc Pineda Segarra <francesc.pineda.segarra@x-netdigital.com>
+ */
+
+/**
+ * Send insert action to controller
+ */
+function insertRecord() {
+    let component = $("input[name='component']").val();
+    document.insertForm.action = url + '?code=&component=' + component;
+    document.insertForm.submit();
+}

--- a/Core/Controller/EditDashboardData.php
+++ b/Core/Controller/EditDashboardData.php
@@ -19,6 +19,7 @@
  */
 namespace FacturaScripts\Core\Controller;
 
+use FacturaScripts\Core\Base;
 use FacturaScripts\Core\Lib\ExtendedController;
 use FacturaScripts\Core\Lib\Dashboard as DashboardLib;
 use FacturaScripts\Core\Model\User;
@@ -136,8 +137,9 @@ class EditDashboardData extends ExtendedController\EditController
         $model = $this->getModel();
         if ($model->component === NULL)
             $model->component = $_REQUEST['component'];
+
         $component = 'FacturaScripts\\Dinamic\\Lib\\Dashboard\\'
-            . $model->component
+            . ($model->component ?? 'Messages')
             . DashboardLib\BaseComponent::SUFIX_COMPONENTS;
 
         return $component::getPropertiesFields();


### PR DESCRIPTION
This Edit controller requires and adicional parameter component.

- Added as default component Messages if it's not setted.
- From JS, use component setted on edit to use it as new component type

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
