### PR TITLE
Removed shipping address fields from sales documents [Trello task 499]

### DIFF
--- a/Core/Model/Base/PurchaseDocument.php
+++ b/Core/Model/Base/PurchaseDocument.php
@@ -51,6 +51,11 @@ abstract class PurchaseDocument extends BusinessDocument
      */
     public $numproveedor;
 
+    /**
+     * Returns an array with the column for identify the subject(s),
+     *
+     * @return array
+     */
     public function getSubjectColumns()
     {
         return ['codproveedor'];

--- a/Core/Model/Base/SalesDocument.php
+++ b/Core/Model/Base/SalesDocument.php
@@ -37,32 +37,11 @@ abstract class SalesDocument extends BusinessDocument
     public $apartado;
 
     /**
-     * Post box of the shipping address.
-     *
-     * @var string
-     */
-    public $apartadoenv;
-
-    /**
-     * Last name of the shipping address.
-     *
-     * @var string
-     */
-    public $apellidosenv;
-
-    /**
      * Customer's city
      *
      * @var string
      */
     public $ciudad;
-
-    /**
-     * City of the shipping address.
-     *
-     * @var string
-     */
-    public $ciudadenv;
 
     /**
      * Employee who created this document. Agent model.
@@ -79,13 +58,6 @@ abstract class SalesDocument extends BusinessDocument
     public $codcliente;
 
     /**
-     * ID of the customer's address. Customer_address model.
-     *
-     * @var int
-     */
-    public $coddir;
-
-    /**
      * Shipping tracking code.
      *
      * @var string
@@ -100,25 +72,11 @@ abstract class SalesDocument extends BusinessDocument
     public $codpais;
 
     /**
-     * Country code of the shipping address.
-     *
-     * @var string
-     */
-    public $codpaisenv;
-
-    /**
      * Customer's postal code.
      *
      * @var string
      */
     public $codpostal;
-
-    /**
-     * Postal code of the shipping address.
-     *
-     * @var string
-     */
-    public $codpostalenv;
 
     /**
      * Shipping code for the shipment.
@@ -149,13 +107,6 @@ abstract class SalesDocument extends BusinessDocument
     public $nombrecliente;
 
     /**
-     * Name of the shipping address.
-     *
-     * @var string
-     */
-    public $nombreenv;
-
-    /**
      * Optional number available to the user.
      *
      * @var string
@@ -177,13 +128,6 @@ abstract class SalesDocument extends BusinessDocument
     public $provincia;
 
     /**
-     * Province of the shipping address.
-     *
-     * @var string
-     */
-    public $provinciaenv;
-
-    /**
      * Reset the values of all model properties.
      */
     public function clear()
@@ -193,6 +137,11 @@ abstract class SalesDocument extends BusinessDocument
         $this->porcomision = 0.0;
     }
 
+    /**
+     * Returns an array with the column for identify the subject(s),
+     *
+     * @return array
+     */
     public function getSubjectColumns()
     {
         return ['codcliente'];
@@ -215,7 +164,6 @@ abstract class SalesDocument extends BusinessDocument
         $this->nombrecliente = $subjects[0]->razonsocial;
         $this->cifnif = $subjects[0]->cifnif;
         foreach ($subjects[0]->getDirecciones() as $dir) {
-            $this->coddir = $dir->id;
             $this->codpais = $dir->codpais;
             $this->provincia = $dir->provincia;
             $this->ciudad = $dir->ciudad;
@@ -238,20 +186,14 @@ abstract class SalesDocument extends BusinessDocument
     public function test()
     {
         $this->apartado = Utils::noHtml($this->apartado);
-        $this->apartadoenv = Utils::noHtml($this->apartadoenv);
-        $this->apellidosenv = Utils::noHtml($this->apellidosenv);
         $this->ciudad = Utils::noHtml($this->ciudad);
-        $this->ciudadenv = Utils::noHtml($this->ciudadenv);
         $this->codigoenv = Utils::noHtml($this->codigoenv);
         $this->codpostal = Utils::noHtml($this->codpostal);
-        $this->codpostalenv = Utils::noHtml($this->codpostalenv);
         $this->direccion = Utils::noHtml($this->direccion);
         $this->direccionenv = Utils::noHtml($this->direccionenv);
         $this->nombrecliente = Utils::noHtml($this->nombrecliente);
-        $this->nombreenv = Utils::noHtml($this->nombreenv);
         $this->numero2 = Utils::noHtml($this->numero2);
         $this->provincia = Utils::noHtml($this->provincia);
-        $this->provinciaenv = Utils::noHtml($this->provinciaenv);
 
         return parent::test();
     }

--- a/Core/Model/Base/SalesDocument.php
+++ b/Core/Model/Base/SalesDocument.php
@@ -93,13 +93,6 @@ abstract class SalesDocument extends BusinessDocument
     public $direccion;
 
     /**
-     * Address of the shipping address.
-     *
-     * @var string
-     */
-    public $direccionenv;
-
-    /**
      * Customer name.
      *
      * @var string
@@ -190,7 +183,6 @@ abstract class SalesDocument extends BusinessDocument
         $this->codigoenv = Utils::noHtml($this->codigoenv);
         $this->codpostal = Utils::noHtml($this->codpostal);
         $this->direccion = Utils::noHtml($this->direccion);
-        $this->direccionenv = Utils::noHtml($this->direccionenv);
         $this->nombrecliente = Utils::noHtml($this->nombrecliente);
         $this->numero2 = Utils::noHtml($this->numero2);
         $this->provincia = Utils::noHtml($this->provincia);

--- a/Core/Table/albaranescli.xml
+++ b/Core/Table/albaranescli.xml
@@ -11,24 +11,12 @@
         <type>character varying(10)</type>
     </column>
     <column>
-        <name>apartadoenv</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>apellidosenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>cifnif</name>
         <type>character varying(30)</type>
         <null>NO</null>
     </column>
     <column>
         <name>ciudad</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>ciudadenv</name>
         <type>character varying(100)</type>
     </column>
     <column>
@@ -42,10 +30,6 @@
     <column>
         <name>codcliente</name>
         <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>coddir</name>
-        <type>integer</type>
     </column>
     <column>
         <name>coddivisa</name>
@@ -76,15 +60,7 @@
         <type>character varying(20)</type>
     </column>
     <column>
-        <name>codpaisenv</name>
-        <type>character varying(20)</type>
-    </column>
-    <column>
         <name>codpostal</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>codpostalenv</name>
         <type>character varying(10)</type>
     </column>
     <column>
@@ -157,10 +133,6 @@
         <type>character varying(100)</type>
     </column>
     <column>
-        <name>nombreenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>numero</name>
         <type>character varying(12)</type>
         <null>NO</null>
@@ -179,10 +151,6 @@
     </column>
     <column>
         <name>provincia</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>provinciaenv</name>
         <type>character varying(100)</type>
     </column>
     <column>

--- a/Core/Table/albaranescli.xml
+++ b/Core/Table/albaranescli.xml
@@ -78,10 +78,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>direccionenv</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
         <name>editable</name>
         <type>boolean</type>
     </column>

--- a/Core/Table/facturascli.xml
+++ b/Core/Table/facturascli.xml
@@ -88,10 +88,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>direccionenv</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
         <name>editable</name>
         <type>boolean</type>
     </column>

--- a/Core/Table/facturascli.xml
+++ b/Core/Table/facturascli.xml
@@ -17,24 +17,12 @@
         <type>character varying(10)</type>
     </column>
     <column>
-        <name>apartadoenv</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>apellidosenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>cifnif</name>
         <type>character varying(30)</type>
         <null>NO</null>
     </column>
     <column>
         <name>ciudad</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>ciudadenv</name>
         <type>character varying(100)</type>
     </column>
     <column>
@@ -48,10 +36,6 @@
     <column>
         <name>codcliente</name>
         <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>coddir</name>
-        <type>integer</type>
     </column>
     <column>
         <name>coddivisa</name>
@@ -86,15 +70,7 @@
         <type>character varying(20)</type>
     </column>
     <column>
-        <name>codpaisenv</name>
-        <type>character varying(20)</type>
-    </column>
-    <column>
         <name>codpostal</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>codpostalenv</name>
         <type>character varying(10)</type>
     </column>
     <column>
@@ -174,10 +150,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>nombreenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>numero</name>
         <type>character varying(12)</type>
         <null>NO</null>
@@ -202,10 +174,6 @@
     </column>
     <column>
         <name>provincia</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>provinciaenv</name>
         <type>character varying(100)</type>
     </column>
     <column>

--- a/Core/Table/pedidoscli.xml
+++ b/Core/Table/pedidoscli.xml
@@ -78,10 +78,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>direccionenv</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
         <name>editable</name>
         <type>boolean</type>
     </column>

--- a/Core/Table/pedidoscli.xml
+++ b/Core/Table/pedidoscli.xml
@@ -11,24 +11,12 @@
         <type>character varying(10)</type>
     </column>
     <column>
-        <name>apartadoenv</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>apellidosenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>cifnif</name>
         <type>character varying(30)</type>
         <null>NO</null>
     </column>
     <column>
         <name>ciudad</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>ciudadenv</name>
         <type>character varying(100)</type>
     </column>
     <column>
@@ -42,10 +30,6 @@
     <column>
         <name>codcliente</name>
         <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>coddir</name>
-        <type>integer</type>
     </column>
     <column>
         <name>coddivisa</name>
@@ -76,15 +60,7 @@
         <type>character varying(20)</type>
     </column>
     <column>
-        <name>codpaisenv</name>
-        <type>character varying(20)</type>
-    </column>
-    <column>
         <name>codpostal</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>codpostalenv</name>
         <type>character varying(10)</type>
     </column>
     <column>
@@ -159,10 +135,6 @@
         <type>character varying(100)</type>
     </column>
     <column>
-        <name>nombreenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>numero</name>
         <type>character varying(12)</type>
         <null>NO</null>
@@ -181,10 +153,6 @@
     </column>
     <column>
         <name>provincia</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>provinciaenv</name>
         <type>character varying(100)</type>
     </column>
     <column>

--- a/Core/Table/presupuestoscli.xml
+++ b/Core/Table/presupuestoscli.xml
@@ -78,10 +78,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>direccionenv</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
         <name>editable</name>
         <type>boolean</type>
     </column>

--- a/Core/Table/presupuestoscli.xml
+++ b/Core/Table/presupuestoscli.xml
@@ -11,24 +11,12 @@
         <type>character varying(10)</type>
     </column>
     <column>
-        <name>apartadoenv</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>apellidosenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>cifnif</name>
         <type>character varying(30)</type>
         <null>NO</null>
     </column>
     <column>
         <name>ciudad</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>ciudadenv</name>
         <type>character varying(100)</type>
     </column>
     <column>
@@ -42,10 +30,6 @@
     <column>
         <name>codcliente</name>
         <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>coddir</name>
-        <type>integer</type>
     </column>
     <column>
         <name>coddivisa</name>
@@ -76,15 +60,7 @@
         <type>character varying(20)</type>
     </column>
     <column>
-        <name>codpaisenv</name>
-        <type>character varying(20)</type>
-    </column>
-    <column>
         <name>codpostal</name>
-        <type>character varying(10)</type>
-    </column>
-    <column>
-        <name>codpostalenv</name>
         <type>character varying(10)</type>
     </column>
     <column>
@@ -159,10 +135,6 @@
         <type>character varying(100)</type>
     </column>
     <column>
-        <name>nombreenv</name>
-        <type>character varying(200)</type>
-    </column>
-    <column>
         <name>numero</name>
         <type>character varying(12)</type>
         <null>NO</null>
@@ -181,10 +153,6 @@
     </column>
     <column>
         <name>provincia</name>
-        <type>character varying(100)</type>
-    </column>
-    <column>
-        <name>provinciaenv</name>
         <type>character varying(100)</type>
     </column>
     <column>

--- a/Core/XMLView/EditAlbaranCliente.xml
+++ b/Core/XMLView/EditAlbaranCliente.xml
@@ -67,11 +67,6 @@
                 </widget>
             </column>
         </group>
-        <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="addressship" title="address" numcolumns="5" order="120">
-                <widget type="text" fieldname="direccionenv" />
-            </column>
-        </group>
         <group name="codattributes" title="attributes" numcolumns="12">
             <column name="warehouse" numcolumns="3">
                 <widget type="select" fieldname="codalmacen">

--- a/Core/XMLView/EditAlbaranCliente.xml
+++ b/Core/XMLView/EditAlbaranCliente.xml
@@ -68,31 +68,8 @@
             </column>
         </group>
         <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="nameship" title="name" numcolumns="3" order="100">
-                <widget type="text" fieldname="nombreenv" />
-            </column>
-            <column name="surnameship" title="surname" numcolumns="4" order="110">
-                <widget type="text" fieldname="apellidosenv" />
-            </column>
             <column name="addressship" title="address" numcolumns="5" order="120">
                 <widget type="text" fieldname="direccionenv" />
-            </column>
-            <column name="zip-codeship" title="zip-code" numcolumns="2" order="130">
-                <widget type="text" fieldname="codpostalenv" />
-            </column>
-            <column name="postalmailship" title="postalmail" numcolumns="2" order="140">
-                <widget type="text" fieldname="apartadoenv" />
-            </column>
-            <column name="cityship" title="city" numcolumns="4" order="150">
-                <widget type="text" fieldname="ciudadenv" />
-            </column>
-            <column name="provinceship" title="province" numcolumns="4" order="160">
-                <widget type="text" fieldname="provinciaenv" />
-            </column>
-            <column name="codecountryship" title="country" numcolumns="2" order="170">
-                <widget type="select" fieldname="codpaisenv">
-                    <values source="paises" fieldcode="codpais" fieldtitle="nombre"></values>
-                </widget>
             </column>
         </group>
         <group name="codattributes" title="attributes" numcolumns="12">

--- a/Core/XMLView/EditFacturaCliente.xml
+++ b/Core/XMLView/EditFacturaCliente.xml
@@ -66,11 +66,6 @@
                 </widget>
             </column>
         </group>
-        <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="addressship" title="address" numcolumns="5" order="120">
-                <widget type="text" fieldname="direccionenv" />
-            </column>
-        </group>
         <group name="codattributes" title="attributes" numcolumns="12">
             <column name="warehouse" numcolumns="3">
                 <widget type="select" fieldname="codalmacen">

--- a/Core/XMLView/EditFacturaCliente.xml
+++ b/Core/XMLView/EditFacturaCliente.xml
@@ -67,31 +67,8 @@
             </column>
         </group>
         <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="nameship" title="name" numcolumns="3" order="100">
-                <widget type="text" fieldname="nombreenv" />
-            </column>
-            <column name="surnameship" title="surname" numcolumns="4" order="110">
-                <widget type="text" fieldname="apellidosenv" />
-            </column>
             <column name="addressship" title="address" numcolumns="5" order="120">
                 <widget type="text" fieldname="direccionenv" />
-            </column>
-            <column name="zip-codeship" title="zip-code" numcolumns="2" order="130">
-                <widget type="text" fieldname="codpostalenv" />
-            </column>
-            <column name="postalmailship" title="postalmail" numcolumns="2" order="140">
-                <widget type="text" fieldname="apartadoenv" />
-            </column>
-            <column name="cityship" title="city" numcolumns="4" order="150">
-                <widget type="text" fieldname="ciudadenv" />
-            </column>
-            <column name="provinceship" title="province" numcolumns="4" order="160">
-                <widget type="text" fieldname="provinciaenv" />
-            </column>
-            <column name="codecountryship" title="country" numcolumns="2" order="170">
-                <widget type="select" fieldname="codpaisenv">
-                    <values source="paises" fieldcode="codpais" fieldtitle="nombre"></values>
-                </widget>
             </column>
         </group>
         <group name="codattributes" title="attributes" numcolumns="12">

--- a/Core/XMLView/EditPedidoCliente.xml
+++ b/Core/XMLView/EditPedidoCliente.xml
@@ -67,11 +67,6 @@
                 </widget>
             </column>
         </group>
-        <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="addressship" title="address" numcolumns="5" order="120">
-                <widget type="text" fieldname="direccionenv" />
-            </column>
-        </group>
         <group name="codattributes" title="attributes" numcolumns="12">
             <column name="warehouse" numcolumns="3">
                 <widget type="select" fieldname="codalmacen">

--- a/Core/XMLView/EditPedidoCliente.xml
+++ b/Core/XMLView/EditPedidoCliente.xml
@@ -68,31 +68,8 @@
             </column>
         </group>
         <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="nameship" title="name" numcolumns="3" order="100">
-                <widget type="text" fieldname="nombreenv" />
-            </column>
-            <column name="surnameship" title="surname" numcolumns="4" order="110">
-                <widget type="text" fieldname="apellidosenv" />
-            </column>
             <column name="addressship" title="address" numcolumns="5" order="120">
                 <widget type="text" fieldname="direccionenv" />
-            </column>
-            <column name="zip-codeship" title="zip-code" numcolumns="2" order="130">
-                <widget type="text" fieldname="codpostalenv" />
-            </column>
-            <column name="postalmailship" title="postalmail" numcolumns="2" order="140">
-                <widget type="text" fieldname="apartadoenv" />
-            </column>
-            <column name="cityship" title="city" numcolumns="4" order="150">
-                <widget type="text" fieldname="ciudadenv" />
-            </column>
-            <column name="provinceship" title="province" numcolumns="4" order="160">
-                <widget type="text" fieldname="provinciaenv" />
-            </column>
-            <column name="codecountryship" title="country" numcolumns="2" order="170">
-                <widget type="select" fieldname="codpaisenv">
-                    <values source="paises" fieldcode="codpais" fieldtitle="nombre"></values>
-                </widget>
             </column>
         </group>
         <group name="codattributes" title="attributes" numcolumns="12">

--- a/Core/XMLView/EditPresupuestoCliente.xml
+++ b/Core/XMLView/EditPresupuestoCliente.xml
@@ -67,11 +67,6 @@
                 </widget>
             </column>
         </group>
-        <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="addressship" title="address" numcolumns="5" order="120">
-                <widget type="text" fieldname="direccionenv" />
-            </column>
-        </group>
         <group name="codattributes" title="attributes" numcolumns="12">
             <column name="warehouse" numcolumns="3">
                 <widget type="select" fieldname="codalmacen">

--- a/Core/XMLView/EditPresupuestoCliente.xml
+++ b/Core/XMLView/EditPresupuestoCliente.xml
@@ -68,31 +68,8 @@
             </column>
         </group>
         <group name="shippingaddr" title="shipping-address" numcolumns="12">
-            <column name="nameship" title="name" numcolumns="3" order="100">
-                <widget type="text" fieldname="nombreenv" />
-            </column>
-            <column name="surnameship" title="surname" numcolumns="4" order="110">
-                <widget type="text" fieldname="apellidosenv" />
-            </column>
             <column name="addressship" title="address" numcolumns="5" order="120">
                 <widget type="text" fieldname="direccionenv" />
-            </column>
-            <column name="zip-codeship" title="zip-code" numcolumns="2" order="130">
-                <widget type="text" fieldname="codpostalenv" />
-            </column>
-            <column name="postalmailship" title="postalmail" numcolumns="2" order="140">
-                <widget type="text" fieldname="apartadoenv" />
-            </column>
-            <column name="cityship" title="city" numcolumns="4" order="150">
-                <widget type="text" fieldname="ciudadenv" />
-            </column>
-            <column name="provinceship" title="province" numcolumns="4" order="160">
-                <widget type="text" fieldname="provinciaenv" />
-            </column>
-            <column name="codecountryship" title="country" numcolumns="2" order="170">
-                <widget type="select" fieldname="codpaisenv">
-                    <values source="paises" fieldcode="codpais" fieldtitle="nombre"></values>
-                </widget>
             </column>
         </group>
         <group name="codattributes" title="attributes" numcolumns="12">


### PR DESCRIPTION
Remove fields apartadoenv, apellidosenv, ciudadenv, coddir, codpaisenv, codpostalenv, nombreenv y provinciaenv:

- From Table, Model and XMLView
- From Core/Model/Base/SalesDocument

Minor fix on PhpDoc for getSubjectColumns

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
