### PR TITLE
Fix empty value for lastactivity

### DIFF
--- a/Core/Model/Contacto.php
+++ b/Core/Model/Contacto.php
@@ -286,7 +286,7 @@ class Contacto extends Base\Contact
         $this->provincia = Utils::noHtml($this->provincia);
 
         /// transform empty values in null
-        $fields = ['codagente', 'codcliente', 'codpais', 'codproveedor'];
+        $fields = ['codagente', 'codcliente', 'codpais', 'codproveedor', 'lastactivity'];
         foreach ($fields as $field) {
             if (empty($this->{$field})) {
                 $this->{$field} = null;


### PR DESCRIPTION
When recording the contact record, if the lastactivity field is empty, it contains an empty string instead of a null string. It is corrected in the test function.

## How has this been tested?

- [X] PostgreSQL
- [X] Database with random data
