### PR TITLE
Unified creation of folders with FileManager [Trello task 517]

### DIFF
--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -138,13 +138,12 @@ class AppInstaller
     {
         // Check each needed folder to deploy
         foreach (['Plugins', 'Dinamic', 'MyFiles'] as $folder) {
-            if (!file_exists($folder) && !mkdir($folder) && !is_dir($folder)) {
+            if (!FileManager::createFolder($folder)) {
                 $this->miniLog->critical($this->i18n->trans('cant-create-folders', ['%folder%' => $folder]));
                 return false;
             }
         }
 
-        chmod('Plugins', (int) octdec(777));
         $pluginManager = new PluginManager();
         $hiddenPlugins = \explode(',', $this->request->request->get('hidden_plugins', ''));
         foreach ($hiddenPlugins as $pluginName) {

--- a/Core/Base/Cache/FileCache.php
+++ b/Core/Base/Cache/FileCache.php
@@ -18,6 +18,7 @@
  */
 namespace FacturaScripts\Core\Base\Cache;
 
+use FacturaScripts\Core\Base\FileManager;
 use FacturaScripts\Core\Base\MiniLog;
 use FacturaScripts\Core\Base\Translator;
 
@@ -71,7 +72,7 @@ class FileCache implements AdaptorInterface
         $this->minilog = new MiniLog();
 
         $dir = self::$config['cache_path'];
-        if (!file_exists($dir) && !@mkdir($dir, 0775, true) && !is_dir($dir)) {
+        if (!FileManager::createFolder($dir, true)) {
             $this->minilog->critical($this->i18n->trans('cant-create-folder', ['%folderName%' => $dir]));
         }
         $this->minilog->debug($this->i18n->trans('using-filecache'));

--- a/Core/Base/FileManager.php
+++ b/Core/Base/FileManager.php
@@ -30,6 +30,10 @@ namespace FacturaScripts\Core\Base;
  */
 class FileManager
 {
+    /**
+     * Default permissions to create new folders
+     */
+    const DEFAULT_FOLDER_PERMS = 0770;
 
     /**
      * Folders to exclude in scanFolder.
@@ -215,7 +219,7 @@ class FileManager
     {
         $folder = opendir($src);
 
-        if (!@mkdir($dst)) {
+        if (!static::createFolder($dst)) {
             return false;
         }
 
@@ -268,5 +272,23 @@ class FileManager
         }
 
         return $result;
+    }
+
+    /**
+     * Create the folder.
+     *
+     * @param string $folder    Path to folder to create
+     * @param bool   $recursive If needs to be created recursively
+     * @param int    $mode      Perms mode in octal format
+     *
+     * @return bool
+     */
+    public static function createFolder(string $folder, $recursive = false, $mode = self::DEFAULT_FOLDER_PERMS): bool
+    {
+        if (!file_exists($folder) && !@mkdir($folder, $mode, $recursive) && !is_dir($folder)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Core/Base/PluginDeploy.php
+++ b/Core/Base/PluginDeploy.php
@@ -145,7 +145,7 @@ class PluginDeploy
      */
     private function createFolder(string $folder): bool
     {
-        if (!file_exists($folder) && !@mkdir($folder, 0775, true)) {
+        if (!FileManager::createFolder($folder, true)) {
             $this->minilog->critical($this->i18n->trans('cant-create-folder', ['%folderName%' => $folder]));
             return false;
         }

--- a/Core/Model/AttachedFile.php
+++ b/Core/Model/AttachedFile.php
@@ -18,6 +18,7 @@
  */
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\FileManager;
 use finfo;
 
 /**
@@ -197,8 +198,9 @@ class AttachedFile extends Base\ModelClass
 
         $this->filename = $this->path;
         $path = 'MyFiles' . DIRECTORY_SEPARATOR . date('Y' . DIRECTORY_SEPARATOR . 'm', strtotime($this->date));
-        if (!file_exists(FS_FOLDER . DIRECTORY_SEPARATOR . $path)) {
-            mkdir(FS_FOLDER . DIRECTORY_SEPARATOR . $path, 0777, true);
+        if (!FileManager::createFolder(FS_FOLDER . DIRECTORY_SEPARATOR . $path, true)) {
+            self::$miniLog->critical(self::$i18n->trans('cant-create-folder', ['%folderName%' => FS_FOLDER . DIRECTORY_SEPARATOR . $path]));
+            return false;
         }
 
         $basePath = FS_FOLDER . DIRECTORY_SEPARATOR . 'MyFiles';


### PR DESCRIPTION
- Default new folders permissions setted to 0770
- Replaced all mkdir calls with FileManager::createFolder

**Note:** This changes means that only user and group have full access, and nothing to others. This can generate problems if files and folder don't have a correct ownership, because by default new files are assigned to who create it.

If anyone have problems, can try with this:
A unified way to work in local with this permissions between us as owner and Apache with no problems (_Requires ACL enabled_), in my case I use it as Apache userdir to not work directly with Apache root folder, but this is not important, only for comfort and simulate a real case with other permissions than default in Apache root (isn't normal work in default apache root default on most hosting providers):

    PROP="$(whoami)"
    APACHE="www-data" # Can differ from distributions
    PATH="/home/${PROP}/public_html"
    sudo chown -R ${PROP}.${APACHE} ${PATH}
    sudo chmod ug=rwx,o= ${PATH}
    sudo chmod u+s,g+s ${PATH}
    sudo chmod +t ${PATH}
    sudo setfacl -b ${PATH}
    sudo setfacl -R -d -m u:${PROP}:rwx,g:${APACHE}:rwx,o::0 ${PATH}

More info [https://wiki.ubuntu.com/UserDirectoryPHP](https://wiki.ubuntu.com/UserDirectoryPHP)

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [x] PostgreSQL
- [x] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
