### PR TITLE
Updated Wizard to set default predefined settings [Trello task 511]

### DIFF
--- a/Core/Data/Codpais/ESP/default.json
+++ b/Core/Data/Codpais/ESP/default.json
@@ -1,0 +1,17 @@
+{
+  "default": {
+    "codpais": "ESP",
+    "coddivisa": "EUR",
+    "idempresa": "1",
+    "codalmacen": "ALG",
+    "codserie": "A",
+    "codpago": "CONT",
+    "codimpuesto": "IVA21",
+    "decimals": "2",
+    "decimal_separator": ",",
+    "thousands_separator": ".",
+    "currency_position": "right",
+    "homepage": "Dashboard",
+    "item_limit": "100"
+  }
+}


### PR DESCRIPTION
Now we can set pre-defined values for AppSettings based on default codpais code on Wizard page load.

**Note:** In this case default.json only includes default group, but supports pre-set all groups that we can need.
**Note 2:** Can be useful on save AppSettings generate a copy on MyFiles folder, and Wizard can force by default codpais data or the stored on MyFiles folder.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [x] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
