### PR TITLE
Delete log messages based on search filter with and special action [Trello task 519]

### DIFF
--- a/Core/Controller/ListLogMessage.php
+++ b/Core/Controller/ListLogMessage.php
@@ -94,7 +94,6 @@ class ListLogMessage extends ExtendedController\ListController
                             $this->miniLog->alert('cant-delete-item', ['%modelName%' => 'LogMessage', '%code%' => $log->primaryColumnValue()]);
                             break;
                         }
-
                     }
                     // confirm data
                     $this->dataBase->commit();

--- a/Core/XMLView/ListLogMessage.xml
+++ b/Core/XMLView/ListLogMessage.xml
@@ -56,5 +56,10 @@
             <option color="table-danger">alert</option>
             <option color="table-danger">emergency</option>
         </row>
+        <row type="footer">
+            <group name="footer-actions" footer="specials-actions">
+                <button type="action" label="delete-selected-filters" color="info" action="delete-selected-filters" icon="fa-list-ol" />
+            </group>
+        </row>
     </rows>
 </view>

--- a/Core/XMLView/ListRoleAccess.xml
+++ b/Core/XMLView/ListRoleAccess.xml
@@ -51,7 +51,7 @@
         <group name="add-rol-access" icon="fa-user-plus">
             <column name="select-menu" title="menu">
                 <widget type="select" fieldname="menu">
-                    <values source="pages" fieldcode="menu" fieldtitle="menu" translate="true" translate="true"></values>
+                    <values source="pages" fieldcode="menu" fieldtitle="menu" translate="true"></values>
                 </widget>
             </column>
         </group>


### PR DESCRIPTION
- Added support to delete logs based on search filter and not restricted by page limit, use the same filters as on list page
- Minor fix with double translate tag on ListRoleAccess modal group

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [x] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->
