### PR TITLE
Add greater visibility to filters

### DIFF
--- a/Core/Lib/ExtendedController/ListFilter.php
+++ b/Core/Lib/ExtendedController/ListFilter.php
@@ -211,7 +211,7 @@ class ListFilter
 
     /**
      * Creates and returns an autocomplete type filter.
-     * 
+     *
      * @param string $label
      * @param string $field
      * @param string $table
@@ -219,7 +219,7 @@ class ListFilter
      * @param string $fieldtitle
      * @param string $value
      * @param array  $where
-     * 
+     *
      * @return ListFilter
      */
     public static function newAutocompleteFilter($label, $field, $table, $fieldcode, $fieldtitle, $value, $where = []): ListFilter
@@ -263,12 +263,12 @@ class ListFilter
 
     /**
      * Creates and returns a select type filter.
-     * 
+     *
      * @param string $label
      * @param string $field
      * @param array  $values
      * @param string $value
-     * 
+     *
      * @return ListFilter
      */
     public static function newSelectFilter($label, $field, $values, $value): ListFilter
@@ -320,10 +320,10 @@ class ListFilter
      * Check if option value is not null or empty
      *
      * @param string $key
-     * 
+     *
      * @return bool
      */
-    private function hasValue($key = 'value'): bool
+    public function hasValue($key = 'value'): bool
     {
         $value = $this->options[$key];
         return (($value !== null) && ($value !== ''));

--- a/Core/Lib/ExtendedController/ListView.php
+++ b/Core/Lib/ExtendedController/ListView.php
@@ -260,6 +260,17 @@ class ListView extends BaseView implements DataViewInterface
     }
 
     /**
+     * Returns the filter identificate by key
+     *
+     * @param string $key
+     * @return ListFilter
+     */
+    public function getFilter($key)
+    {
+        return $this->filters[$key];
+    }
+
+    /**
      * Returns the list of defined Order By
      *
      * @return array


### PR DESCRIPTION
The hasValue method is raised to public for use from views and controllers.
The getFilter($key) method that allows us to obtain the filter identified by the key is added. This method complements the existing getFilters () that returns the list of available filters of a view.

## How has this been tested?
- [ ] MySQL
- [x] PostgreSQL
- [ ] Clean database
- [x] Database with random data
