### PR TITLE
Required email user wizard

### DIFF
--- a/Core/Controller/Wizard.php
+++ b/Core/Controller/Wizard.php
@@ -50,6 +50,13 @@ class Wizard extends Controller
     public $showChangePasswd = false;
 
     /**
+     * Check if the user must introduce the email.
+     *
+     * @var boolean
+     */
+    public $showIntroduceEmail = true;
+
+    /**
      * Returns basic page attributes
      *
      * @return array
@@ -102,12 +109,16 @@ class Wizard extends Controller
             $this->showChangePasswd = true;
         }
 
+        if ($this->user->email !== '') {
+            $this->showIntroduceEmail = false;
+        }
+
         $pass = $this->request->request->get('password', '');
         if ('' !== $pass && !$this->saveNewPassword($pass)) {
             return;
         }
-
-        if (!$this->saveEmail()) {
+        $email = $this->request->request->get('email', '');
+        if ('' !== $email && !$this->saveEmail()) {
             return;
         }
 

--- a/Core/Controller/Wizard.php
+++ b/Core/Controller/Wizard.php
@@ -107,6 +107,10 @@ class Wizard extends Controller
             return;
         }
 
+        if (!$this->saveEmail()) {
+            return;
+        }
+
         $codpais = $this->request->request->get('codpais', '');
         if ('' !== $codpais) {
             $this->saveStep1($codpais);
@@ -239,6 +243,12 @@ class Wizard extends Controller
             $this->appSettings->save();
             break;
         }
+    }
+
+    private function saveEmail() : bool
+    {
+        $this->user->email = $this->request->request->get('email', '');
+        return $this->user->save();
     }
 
     /**

--- a/Core/View/Wizard.html.twig
+++ b/Core/View/Wizard.html.twig
@@ -40,6 +40,7 @@
                     </div>
                 </div>
             {% endif %}
+            {% if fsc.showIntroduceEmail %}
             <div class="row bg-warning">
                 <div class="col-sm-12">
                     <div class="form-group">
@@ -47,6 +48,7 @@
                     </div>
                 </div>
             </div>
+            {% endif %}
             <div class="row">
                 <div class="col-sm-4">
                     <div class="form-group">

--- a/Core/View/Wizard.html.twig
+++ b/Core/View/Wizard.html.twig
@@ -40,6 +40,13 @@
                     </div>
                 </div>
             {% endif %}
+            <div class="row bg-warning">
+                <div class="col-sm-12">
+                    <div class="form-group">
+                        {{ forms.simpleInput('email', 'email', '', 'email', i18n.trans('specify-email'), 'fa-at', 'required') }}
+                    </div>
+                </div>
+            </div>
             <div class="row">
                 <div class="col-sm-4">
                     <div class="form-group">


### PR DESCRIPTION
 Required introduce email on Wizard with HTML and added function on Wizard controller to get and save the email. If the user has email, the view doesn´t show the input for the new password.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [x] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->
