### PR TITLE
Remove column codejercicio from documentos tables

### DIFF
--- a/Core/Table/albaranescli.xml
+++ b/Core/Table/albaranescli.xml
@@ -37,11 +37,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -200,10 +195,6 @@
     <constraint>
         <name>ca_albaranescli_series2</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_albaranescli_ejercicios2</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>uniq_codigo_albaranescli2</name>

--- a/Core/Table/albaranesprov.xml
+++ b/Core/Table/albaranesprov.xml
@@ -25,11 +25,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -151,10 +146,6 @@
     <constraint>
         <name>ca_albaranesprov_series2</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_albaranesprov_ejercicios2</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>uniq_codigo_albaranesprov2</name>

--- a/Core/Table/facturascli.xml
+++ b/Core/Table/facturascli.xml
@@ -43,11 +43,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -224,10 +219,6 @@
     <constraint>
         <name>ca_facturascli_series2</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_facturascli_ejercicios2</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>ca_facturascli_asiento2</name>

--- a/Core/Table/facturasprov.xml
+++ b/Core/Table/facturasprov.xml
@@ -31,11 +31,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -165,10 +160,6 @@
     <constraint>
         <name>ca_facturasprov_series2</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_facturasprov_ejercicios2</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>ca_facturasprov_asiento2</name>

--- a/Core/Table/pedidoscli.xml
+++ b/Core/Table/pedidoscli.xml
@@ -37,11 +37,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -195,10 +190,6 @@
     <constraint>
         <name>ca_pedidoscli_series</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_pedidoscli_ejercicios</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>uniq_codigo_pedidoscli2</name>

--- a/Core/Table/pedidosprov.xml
+++ b/Core/Table/pedidosprov.xml
@@ -25,11 +25,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -140,10 +135,6 @@
     <constraint>
         <name>ca_pedidosprov_series</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_pedidosprov_ejercicios</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>uniq_codigo_pedidosprov2</name>

--- a/Core/Table/presupuestoscli.xml
+++ b/Core/Table/presupuestoscli.xml
@@ -37,11 +37,6 @@
         <null>NO</null>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -195,10 +190,6 @@
     <constraint>
         <name>ca_presupuestoscli_series</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_presupuestoscli_ejercicios</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>uniq_codigo_presupuestoscli2</name>

--- a/Core/Table/presupuestosprov.xml
+++ b/Core/Table/presupuestosprov.xml
@@ -20,11 +20,6 @@
         <type>character varying(4)</type>
     </column>
     <column>
-        <name>codejercicio</name>
-        <type>character varying(4)</type>
-        <null>NO</null>
-    </column>
-    <column>
         <name>codigo</name>
         <type>character varying(20)</type>
         <null>NO</null>
@@ -140,10 +135,6 @@
     <constraint>
         <name>ca_presupuestosprov_series</name>
         <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
-        <name>ca_presupuestosprov_ejercicios</name>
-        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
         <name>uniq_codigo_presupuestosprov</name>


### PR DESCRIPTION
Remove column codejercicio from documentos tables and remove its foreign key that reference to ejercicios

Your PR description goes here.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [x] MySQL
- [ ] PostgreSQL
- [x] Clean database
- [x] Database with random data
<!---- [ ] If additional tests was realized, added here--->
