### PR TITLE
Delete "apellidos" column from Agente Model

### DIFF
--- a/Core/Controller/ListAgente.php
+++ b/Core/Controller/ListAgente.php
@@ -51,10 +51,10 @@ class ListAgente extends ExtendedController\ListController
     protected function createViews()
     {
         $this->addView('ListAgente', 'Agente', 'agents', 'fas fa-id-badge');
-        $this->addSearchFields('ListAgente', ['nombre', 'apellidos', 'codagente', 'email']);
+        $this->addSearchFields('ListAgente', ['nombre', 'codagente', 'email']);
 
         $this->addOrderBy('ListAgente', ['codagente'], 'code');
-        $this->addOrderBy('ListAgente', ['concat(nombre,apellidos)'], 'name', 1);
+        $this->addOrderBy('ListAgente', ['nombre'], 'name', 1);
         $this->addOrderBy('ListAgente', ['provincia'], 'province');
 
         $selectValues = $this->codeModel->all('agentes', 'cargo', 'cargo');

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -34,13 +34,6 @@ class Agente extends Base\Contact
     use Base\ModelTrait;
 
     /**
-     * Last name of the agent or employee.
-     *
-     * @var string
-     */
-    public $apellidos;
-
-    /**
      * Bank account.
      *
      * @var string
@@ -161,16 +154,6 @@ class Agente extends Base\Contact
     }
 
     /**
-     * Returns name + agent's last name.
-     *
-     * @return string
-     */
-    public function primaryDescription()
-    {
-        return $this->nombre . ' ' . $this->apellidos;
-    }
-
-    /**
      * Returns the name of the table that uses this model.
      *
      * @return string
@@ -187,7 +170,6 @@ class Agente extends Base\Contact
      */
     public function test()
     {
-        $this->apellidos = Utils::noHtml($this->apellidos);
         $this->banco = Utils::noHtml($this->banco);
         $this->cargo = Utils::noHtml($this->cargo);
         $this->ciudad = Utils::noHtml($this->ciudad);

--- a/Core/Table/agentes.xml
+++ b/Core/Table/agentes.xml
@@ -7,10 +7,6 @@
 -->
 <table>
     <column>
-        <name>apellidos</name>
-        <type>character varying(150)</type>
-    </column>
-    <column>
         <name>ciudad</name>
         <type>character varying(100)</type>
     </column>

--- a/Core/XMLView/EditAgente.xml
+++ b/Core/XMLView/EditAgente.xml
@@ -29,11 +29,8 @@
             <column name="code" numcolumns="2" order="100">
                 <widget type="text" fieldname="codagente" icon="fas fa-hashtag" required="true" />
             </column>
-            <column name="name" numcolumns="4" order="110">
+            <column name="name" numcolumns="6" order="110">
                 <widget type="text" fieldname="nombre" required="true" />
-            </column>
-            <column name="surname" numcolumns="6" order="120">
-                <widget type="text" fieldname="apellidos" />
             </column>
             <column name="fiscal-number" numcolumns="4" order="130">
                 <widget type="text" fieldname="cifnif" icon="fas fa-id-card" />

--- a/Core/XMLView/EditCliente.xml
+++ b/Core/XMLView/EditCliente.xml
@@ -95,7 +95,7 @@
             </column>
             <column name="agent" numcolumns="3" titleurl="ListAgente" order="150">
                 <widget type="select" fieldname="codagente" onclick="EditAgente">
-                    <values source="agentes" fieldcode="codagente" fieldtitle="CONCAT(nombre,' ',apellidos)"></values>
+                    <values source="agentes" fieldcode="codagente" fieldtitle="nombre"></values>
                 </widget>
             </column>
             <column name="irpf" numcolumns="3" order="160">

--- a/Core/XMLView/ListAgente.xml
+++ b/Core/XMLView/ListAgente.xml
@@ -19,7 +19,7 @@
  *
  * Initial description for the controller ListAgente
  *
- * @author Artex Trading sa <jcuello@artextrading.com>  
+ * @author Artex Trading sa <jcuello@artextrading.com>
 -->
 
 <view>
@@ -29,9 +29,6 @@
         </column>
         <column name="name" order="110">
             <widget type="text" fieldname="nombre" />
-        </column>
-        <column name="surname" order="120">
-            <widget type="text" fieldname="apellidos" />
         </column>
         <column name="cifnif" order="125">
             <widget type="text" fieldname="cifnif" />


### PR DESCRIPTION
Delete "apellidos" columns and all references. Now use standard "nombre" column for determine description of record.

- [ ] MySQL
- [X] PostgreSQL
- [ ] Clean database
- [X] Database with random data
