### PR TITLE
Adding the missing translations for 'apache-module-not-found' used in the appinstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ package-lock.json
 .project
 .settings
 .buildpath
+
+# Vscode config files
+*.code-workspace

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -877,5 +877,6 @@
     "yearly": "Yearly",
     "yes": "Yes",
     "your": "Your",
-    "zip-code": "Zip code"
+    "zip-code": "Zip code",
+    "apache-module-not-found": "The '%module%' module wasn't found in the server."
 }

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -877,5 +877,6 @@
     "yearly": "Anual",
     "yes": "Si",
     "your": "Suyo",
-    "zip-code": "Código Postal"
+    "zip-code": "Código Postal",
+    "apache-module-not-found": "El Módulo de apache '%module%' no se encuentra activo en el servidor."
 }


### PR DESCRIPTION
Your PR description goes here.
Agregue una los strings para el tag 'apache-module-not found used in the AppInstaller.php
tambien agrego el ignore para que git no tome en cuenta los workspaces de vscode.

- [ X] MySQL
- [ ] PostgreSQL
- [ X] Clean database
- [ ] Database with random data
