### PR TITLE
Add column modal for name method

### DIFF
--- a/Core/Lib/ExtendedController/BaseView.php
+++ b/Core/Lib/ExtendedController/BaseView.php
@@ -208,6 +208,30 @@ abstract class BaseView
     }
 
     /**
+     * Gets the modal column by the column name
+     *
+     * @param string $columnName
+     *
+     * @return ColumnItem
+     */
+    public function columnModalForName(string $columnName)
+    {
+        return $this->getColumnForName($columnName, $this->modals);
+    }
+
+    /**
+     * Gets the column by the column name
+     *
+     * @param string $columnName
+     *
+     * @return ColumnItem
+     */
+    public function columnForName(string $columnName)
+    {
+        return $this->getColumnForName($columnName, $this->columns);
+    }
+
+    /**
      * Gets the column by the given field name
      *
      * @param string $fieldName
@@ -228,26 +252,6 @@ abstract class BaseView
     }
 
     /**
-     * Gets the column by the column name
-     *
-     * @param string $columnName
-     *
-     * @return ColumnItem
-     */
-    public function columnForName(string $columnName)
-    {
-        foreach ($this->columns as $group) {
-            foreach ($group->columns as $key => $column) {
-                if ($key === $columnName) {
-                    return $column;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Establishes the column's edit state
      *
      * @param string $columnName
@@ -259,6 +263,27 @@ abstract class BaseView
         if (!empty($column)) {
             $column->display = $disabled ? 'none' : 'left';
         }
+    }
+
+    /**
+     * Gets the column by the column name from source group
+     *
+     * @param string $columnName
+     * @param array  $source
+     *
+     * @return ColumnItem
+     */
+    public function getColumnForName(string $columnName, &$source)
+    {
+        foreach ($source as $group) {
+            foreach ($group->columns as $key => $column) {
+                if ($key === $columnName) {
+                    return $column;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Restructure columnForName and add columnModalForName.
This is necessary to be able to access the columns of the modal forms, for example to be able to load special values to select widgets.