### PR TITLE
facturascripts: task_55_add_supplier_budgets_to_DocumentReports_controller

### DIFF
--- a/Core/Controller/DocumentReports.php
+++ b/Core/Controller/DocumentReports.php
@@ -124,6 +124,7 @@ class DocumentReports extends Controller
             'customer-orders' => $this->i18n->trans('customer-orders'),
             'customer-delivery-notes' => $this->i18n->trans('customer-delivery-notes'),
             'customer-invoices' => $this->i18n->trans('customer-invoices'),
+            'supplier-estimations' => $this->i18n->trans('supplier-estimations'),
             'supplier-orders' => $this->i18n->trans('supplier-orders'),
             'supplier-delivery-notes' => $this->i18n->trans('supplier-delivery-notes'),
             'supplier-invoices' => $this->i18n->trans('supplier-invoices'),

--- a/Core/Lib/DocumentReportsBase/DocumentReportsSource.php
+++ b/Core/Lib/DocumentReportsBase/DocumentReportsSource.php
@@ -68,7 +68,7 @@ class DocumentReportsSource
     {
         $this->source = $source;
         $this->color = $color;
-        $this->dateFrom = new \DateTime(date('01-m-Y'));
+        $this->dateFrom = new \DateTime(date('01-01-Y'));
         $this->dateTo = new \DateTime(date('t-m-Y'));
     }
 
@@ -91,6 +91,9 @@ class DocumentReportsSource
 
             case 'customer-invoices':
                 return Model\FacturaCliente::tableName();
+                
+            case 'supplier-estimations':
+                return Model\PresupuestoProveedor::tableName();
 
             case 'supplier-orders':
                 return Model\PedidoProveedor::tableName();


### PR DESCRIPTION
He añadido la  opción de presupuestos de proveedor en el informe de documentos (controlador DocumentReports), y he puesto la fecha de inicio por defecto  a principio de año, en lugar de principio de mes. 

## How has this been tested?
- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->