### PR TITLE
Personalize numeration and code of sales documents

### DIFF
--- a/Core/Controller/EditSecuenciaDocumento.php
+++ b/Core/Controller/EditSecuenciaDocumento.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2019 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Lib\ExtendedController;
+
+/**
+ * Controller to edit a single item from the SecuenciaDocumento model.
+ *
+ * @author Carlos García Gómez  <carlos@facturascripts.com>
+ * @author Cristo M. Estévez Hernández <cristom.estevez@gmail.com>
+ */
+class EditSecuenciaDocumento extends ExtendedController\EditController
+{
+    
+    /**
+     * Returns the model name
+     */
+    public function getModelClassName()
+    {
+        return 'SecuenciaDocumento';
+    }
+
+    /**
+     * Returns basic page attributes
+     *
+     * @return array
+     */
+    public function getPageData()
+    {
+        $pagedata = parent::getPageData();
+        $pagedata['title'] = 'document-sequences';
+        $pagedata['menu'] = 'admin';
+        $pagedata['icon'] = 'fas fa-file-invoice';
+        $pagedata['showonmenu'] = false;
+
+        return $pagedata;
+    }
+}

--- a/Core/Controller/ListSecuenciaDocumento.php
+++ b/Core/Controller/ListSecuenciaDocumento.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Lib\ExtendedController;
+
+/**
+ * Controller to list the items in the SecuenciaDocumento model
+ *
+ * @author Carlos García Gómez <carlos@facturascripts.com>
+ * @author Cristo M. Estévez Hernández <cristom.estevez@gmail.com>
+ */
+class ListSecuenciaDocumento extends ExtendedController\ListController
+{
+
+    /**
+     * Returns basic page attributes
+     *
+     * @return array
+     */
+    public function getPageData()
+    {
+        $pagedata = parent::getPageData();
+        $pagedata['menu'] = 'admin';
+        $pagedata['title'] = 'document-sequences';
+        $pagedata['icon'] = 'fas fa-file-invoice';
+
+        return $pagedata;
+    }
+
+    /**
+     * Load views
+     */
+    protected function createViews()
+    {
+        $this->addView('ListSecuenciaDocumento', 'SecuenciaDocumento', 'document-sequences', 'fas fa-files-invoice');
+        $this->addSearchFields('ListSecuenciaDocumento', ['titulo', 'tipodoc']);
+        $this->addOrderBy('ListSecuenciaDocumento', ['codejercicio'], 'exercise');
+        $this->addOrderBy('ListSecuenciaDocumento', ['codserie'], 'serie');
+        $this->addOrderBy('ListSecuenciaDocumento', ['numero'], 'number');
+    }
+}

--- a/Core/Model/SecuenciaDocumento.php
+++ b/Core/Model/SecuenciaDocumento.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2013-2019 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace FacturaScripts\Core\Model;
+
+/**
+ * Personalize the numeration and code of sale and purchase documents.
+ *
+ * @author Carlos García Gómez <carlos@facturascripts.com>
+ * @author Cristo M. Estévez Hernández <cristom.estevez@gmail.com>
+ */
+class SecuenciaDocumento extends Base\ModelClass
+{
+
+    use Base\ModelTrait;
+
+    /**
+     *
+     * @var string
+     */
+    public $codejercicio;
+
+    /**
+     *
+     * @var string
+     */
+    public $codserie;
+
+    /**
+     *
+     * @var int
+     */
+    public $longnumero;
+
+    /**
+     * Primary key.
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     *
+     * @var int
+     */
+    public $numero;
+
+    /**
+     *
+     * @var string
+     */
+    public $patron;
+
+    /**
+     *
+     * @var bool
+     */
+    public $reutilizar;
+
+    /**
+     *
+     * @var string
+     */
+    public $titulo;
+
+    /**
+     *
+     * @var string
+     */
+    public $tipodoc;
+
+
+    /**
+     * Returns the name of the column that is the primary key of the model.
+     *
+     * @return string
+     */
+    public static function primaryColumn()
+    {
+        return 'id';
+    }
+
+    /**
+     * Returns the name of the table that uses this model.
+     *
+     * @return string
+     */
+    public static function tableName()
+    {
+        return 'secuenciasdocumentos';
+    }
+}

--- a/Core/Table/secuenciasdocumentos.xml
+++ b/Core/Table/secuenciasdocumentos.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Document   : secuenciasdocumento.xml
+    Author     : Carlos Garcia Gomez
+                 Cristo M. Estévez Hernández
+    Description:
+        Structure for the secuenciasdocumento table.
+-->
+<table>
+    <column>
+        <name>codejercicio</name>
+        <type>character varying(4)</type>
+    </column>
+    <column>
+        <name>codserie</name>
+        <type>character varying(4)</type>
+    </column>
+    <column>
+        <name>longnumero</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>id</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>numero</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>patron</name>
+        <type>varchar(20)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>reutilizar</name>
+        <type>boolean</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>titulo</name>
+        <type>varchar(50)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>tipodoc</name>
+        <type>varchar(30)</type>
+        <null>NO</null>
+    </column>
+    <constraint>
+        <name>secuenciasdocumento_pkey</name>
+        <type>PRIMARY KEY (id)</type>
+    </constraint>
+    <constraint>
+        <name>ca_secdocumentos_ejercicio</name>
+        <type>FOREIGN KEY (codejercicio) REFERENCES ejercicios (codejercicio) ON DELETE RESTRICT ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>ca_secdocumentos_serie</name>
+        <type>FOREIGN KEY (codserie) REFERENCES series (codserie) ON DELETE RESTRICT ON UPDATE CASCADE</type>
+    </constraint>
+</table>

--- a/Core/XMLView/EditSecuenciaDocumento.xml
+++ b/Core/XMLView/EditSecuenciaDocumento.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2019 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Initial description for the controller EditSecuenciaDocumento
+ *
+ * @author Carlos García Gómez  <carlos@facturascripts.com>
+ * @author Cristo M. Estévez Hernández <cristom.estevez@gmail.com>
+-->
+
+<view>
+    <columns>
+        <group name="data" numcolumns="12">
+            <column name="id" display="none" order="100">
+                <widget type="number" fieldname="id" />
+            </column>
+            <column name="code-exercise" order="110">
+                <widget type="select" fieldname="codejercicio" onclick="EditEjercicio">
+                    <values source="ejercicios" fieldcode="codejercicio" fieldtitle="nombre"></values>
+                </widget>
+            </column>
+            <column name="code-serie" numcolumns="4" order="120">
+                <widget type="select" fieldname="codserie" onclick="EditSerie">
+                    <values source="series" fieldcode="codserie" fieldtitle="descripcion"></values>
+                </widget>
+            </column>
+            <column name="longnumber" order="130">
+                <widget type="number" fieldname="longnumero" />
+            </column>
+            <column name="number" order="140">
+                <widget type="number" fieldname="numero" />
+            </column>
+            <column name="pattern" numcolumns="4" order="150">
+                <widget type="text" fieldname="patron" />
+            </column>
+            <column name="title" numcolumns="4" order="170">
+                <widget type="text" fieldname="titulo" />
+            </column>
+            <column name="type-document" order="180">
+                <widget type="select" fieldname="tipodoc" translate="true">
+                        <values title="customer-estimation">PresupuestoCliente</values>
+                        <values title="customer-order">PedidoCliente</values>
+                        <values title="customer-delivery-note">AlbaranCliente</values>
+                        <values title="customer-invoice">FacturaCliente</values>
+                        <values title="supplier-estimation">PresupuestoProveedor</values>
+                        <values title="supplier-order">PedidoProveedor</values>
+                        <values title="supplier-delivery-note">AlbaranProveedor</values>
+                        <values title="supplier-invoice">FacturaProveedor</values>
+                        <values title="service">Servicio</values>
+                    </widget>
+            </column>
+            <column name="reuse"  numcolumns="2" order="190">
+                <widget type="checkbox" fieldname="reutilizar" />
+            </column>
+        </group>
+    </columns>
+</view>

--- a/Core/XMLView/ListSecuenciaDocumento.xml
+++ b/Core/XMLView/ListSecuenciaDocumento.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2018 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Initial description for the controller ListSecuenciaDocumento
+ *
+ * @author Carlos García Gómez  <carlos@facturascripts.com>  
+ * @author Cristo M. Estévez Hernández <cristom.estevez@gmail.com>
+-->
+
+<view>
+    <columns>
+        <column name="code-exercise" order="100">
+            <widget type="text" fieldname="codejercicio" onclick="EditEjercicio" />
+        </column>
+        <column name="code-serie" order="110">
+            <widget type="select" fieldname="codserie" onclick="EditSerie">
+                <values source="series" fieldcode="codserie" fieldtitle="descripcion"></values>
+            </widget>
+        </column>
+        <column name="longnumber" display="center" order="120">
+            <widget type="integer" fieldname="longnumero" />
+        </column>
+        <column name="number" display="center" order="130">
+            <widget type="integer" fieldname="numero" />
+        </column>
+        <column name="pattern" display="center" order="140">
+            <widget type="text" fieldname="patron" />
+        </column>
+        <column name="title" display="center" order="150">
+            <widget type="text" fieldname="titulo" />
+        </column>
+        <column name="type-document" display="center" order="160">
+            <widget type="text" fieldname="tipodoc" />
+        </column>
+    </columns>
+</view>


### PR DESCRIPTION
Added functionallity to personalize the numeration and code of sales and purchase documents.

- Create model SecuenciaDocumento.
- Create ListSecuenciaDocumento to show all sencuences.
- Create EditSecuenciaDocument to modify all information of a document.
- Create secuenciasdocuments.xml to create the corresponding table of secuences.
- Create ListSecuenciaDocumento.xml and EditSecuenciaDocumento.xml

Your PR description goes here.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [x] MySQL
- [ ] PostgreSQL
- [x] Clean database
- [x] Database with random data
<!---- [ ] If additional tests was realized, added here--->