### PR TITLE
task#123: Modificado DocumentStitcher.php y DocumentStitcher,

### DIFF
--- a/Core/Controller/DocumentStitcher.php
+++ b/Core/Controller/DocumentStitcher.php
@@ -148,6 +148,11 @@ class DocumentStitcher extends Controller
         $this->modelName = $this->getModelName();
         $this->setDocuments();
 
+        //verify customer, supplier or currency in selected documents; 
+        if ($this->verifyDocuments() == false) {
+            $this->miniLog->alert($this->i18n->trans('error-verify-then-go-back'));
+        }
+
         // duplicated request?
         $token = $this->request->request->get('multireqtoken', '');
         if (!empty($token) && $this->multiRequestProtection->tokenExist($token)) {
@@ -289,5 +294,25 @@ class DocumentStitcher extends Controller
                 $this->documents[] = $doc;
             }
         }
+    }
+
+    /**
+     * Verify customer, supplier or currency in selected documents.
+     * 
+     * @return boolean
+     */
+    public function verifyDocuments()
+    {
+        $divisa = $this->documents[0]->coddivisa;
+        $customer = $this->documents[0]->codcliente;
+        $supplier = $this->documents[0]->codproveedor;
+        $verify = true;
+        foreach ($this->documents as $document) {
+            if ($divisa != $document->coddivisa || $customer != $document->codcliente || $supplier != $document->codproveedor) {
+                $verify = false;
+                break;
+            }
+        }
+        return $verify;
     }
 }

--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -48,9 +48,15 @@
                 </div>
                 <div class="col text-right">
                     <div class="dropdown">
-                        <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fas fa-magic fa-fw"></i> {{ i18n.trans('generate') }}
-                        </button>
+                        {% if fsc.verifyDocuments() == false %}
+                            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" disabled>
+                                <i class="fas fa-magic fa-fw"></i> {{ i18n.trans('generate') }}
+                            </button>
+                        {% else %}
+                            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="fas fa-magic fa-fw"></i> {{ i18n.trans('generate') }}
+                            </button>
+                        {% endif %}
                         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                             {% for status in fsc.getAvaliableStatus() %}
                                 <button type="button" onclick="sendFormData('{{ status.primaryColumnValue() }}');" class="dropdown-item">


### PR DESCRIPTION
para verificar que divisa, cliente o proveedores sean iguales en todos los documentos a agrupar.

Your PR description goes here.
SI los documentos seleccionados tienen diferente divisa, cliente o proveedor que el primero seleccionado, lanza un mensaje de error, y deshabilita el botón generar en la vista.
El mensaje invita a volver atrás y revisar su selección.

Mensaje 'error-verify-then-go-back' = 'No se pueden agrupar documentos que tengan distinto cliente, proveedor o divisa. Regrese atrás y revise su selección'

## How has this been tested?
- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->