### PR TITLE
Added automatic description

### DIFF
--- a/Core/Lib/Accounting/AccountingCreateTools.php
+++ b/Core/Lib/Accounting/AccountingCreateTools.php
@@ -108,7 +108,7 @@ class AccountingCreateTools
      * @param String $description    The description of the subaccount
      * @return Subcuenta
      */
-    public function createFromAccount($account, $code, $description)
+    public function createFromAccount($account, $code, $description = '')
     {
         if (!$account->exists() || !$this->checkExercise($account->codejercicio)) {
             return new Subcuenta();
@@ -118,7 +118,7 @@ class AccountingCreateTools
         $subaccount->codcuenta = $account->codcuenta;
         $subaccount->codejercicio = $account->codejercicio;
         $subaccount->codsubcuenta = $code;
-        $subaccount->descripcion = $description;
+        $subaccount->descripcion = empty($description) ? $account->descripcion : $description;
         $subaccount->idcuenta = $account->idcuenta;
         $subaccount->save();
         return $subaccount;


### PR DESCRIPTION
When creating a subaccount if the description is not reported, the description of the parent account is used.