### PR TITLE
#215 - Add primary column value test

### DIFF
--- a/Test/Core/CustomTest.php
+++ b/Test/Core/CustomTest.php
@@ -19,6 +19,7 @@
 namespace FacturaScripts\Test\Core;
 
 use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Model\Base\ModelClass;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,6 +30,10 @@ use PHPUnit\Framework\TestCase;
 class CustomTest extends TestCase
 {
 
+    /**
+     *
+     * @var ModelClass
+     */
     public $model;
 
     public function testInit()

--- a/Test/Core/Model/AgenciaTransporteTest.php
+++ b/Test/Core/Model/AgenciaTransporteTest.php
@@ -32,4 +32,10 @@ final class AgenciaTransporteTest extends CustomTest
     {
         $this->model = new AgenciaTransporte();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/AgenteTest.php
+++ b/Test/Core/Model/AgenteTest.php
@@ -32,4 +32,10 @@ final class AgenteTest extends CustomTest
     {
         $this->model = new Agente();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/AlmacenTest.php
+++ b/Test/Core/Model/AlmacenTest.php
@@ -32,4 +32,10 @@ final class AlmacenTest extends CustomTest
     {
         $this->model = new Almacen();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/AtributoTest.php
+++ b/Test/Core/Model/AtributoTest.php
@@ -34,4 +34,10 @@ final class AtributoTest extends CustomTest
     {
         $this->model = new Atributo();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/ClienteTest.php
+++ b/Test/Core/Model/ClienteTest.php
@@ -34,4 +34,12 @@ final class ClienteTest extends CustomTest
     {
         $this->model = new Cliente();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->nombre = 'test description';
+        
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/FabricanteTest.php
+++ b/Test/Core/Model/FabricanteTest.php
@@ -34,4 +34,12 @@ final class FabricanteTest extends CustomTest
     {
         $this->model = new Fabricante();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->nombre = 'test descripciont';
+
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/FamiliaTest.php
+++ b/Test/Core/Model/FamiliaTest.php
@@ -34,4 +34,12 @@ final class FamiliaTest extends CustomTest
     {
         $this->model = new Familia();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->descripcion = 'test description';
+        
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/FormaPagoTest.php
+++ b/Test/Core/Model/FormaPagoTest.php
@@ -34,4 +34,12 @@ final class FormaPagoTest extends CustomTest
     {
         $this->model = new FormaPago();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->plazovencimiento = 0;
+        
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/ImpuestoTest.php
+++ b/Test/Core/Model/ImpuestoTest.php
@@ -34,4 +34,10 @@ final class ImpuestoTest extends CustomTest
     {
         $this->model = new Impuesto();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/ProveedorTest.php
+++ b/Test/Core/Model/ProveedorTest.php
@@ -34,4 +34,10 @@ final class ProveedorTest extends CustomTest
     {
         $this->model = new Proveedor();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/RoleTest.php
+++ b/Test/Core/Model/RoleTest.php
@@ -34,4 +34,10 @@ final class RoleTest extends CustomTest
     {
         $this->model = new Role();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/SerieTest.php
+++ b/Test/Core/Model/SerieTest.php
@@ -34,4 +34,10 @@ final class SerieTest extends CustomTest
     {
         $this->model = new Serie();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/TarifaTest.php
+++ b/Test/Core/Model/TarifaTest.php
@@ -34,4 +34,10 @@ final class TarifaTest extends CustomTest
     {
         $this->model = new Tarifa();
     }
+
+    public function testPrimaryColumnValue()
+    {
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }    
 }

--- a/Test/Core/Model/UserTest.php
+++ b/Test/Core/Model/UserTest.php
@@ -34,4 +34,12 @@ final class UserTest extends CustomTest
     {
         $this->model = new User();
     }
+    
+    public function testPrimaryColumnValue()
+    {
+        $this->model->email = 'test@test.com';
+        
+        $this->model->{$this->model->primaryColumn()} = 'n"l123';
+        $this->assertFalse($this->model->test());
+    }
 }


### PR DESCRIPTION
Add primary column value test for invalid characters in models:
- Agenciatransporte
- Agente
- Almacen
- Atributo
- Cliente
- Fabricante
- Familia
- Formapago
- Impuesto
- Proveedor
- Role
- Serie
- Tarifa
- User

## How has this been tested?

Console command:

`phpunit.phar phpunit.xml`

- [X] MySQL
- [X] Database with random data
