### PR TITLE
fix error when the files don't have a file extension.

### DIFF
--- a/Core/Base/PluginDeploy.php
+++ b/Core/Base/PluginDeploy.php
@@ -183,16 +183,17 @@ class PluginDeploy
                 continue;
             }
 
-            $infoFile = pathinfo($fileName);
+            $fileInfo = pathinfo($fileName);
             if (is_dir($path . DIRECTORY_SEPARATOR . $fileName)) {
                 $this->createFolder(\FS_FOLDER . DIRECTORY_SEPARATOR . 'Dinamic' . DIRECTORY_SEPARATOR . $folder . DIRECTORY_SEPARATOR . $fileName);
                 continue;
-            } elseif ($infoFile['filename'] === '' || !is_file($path . DIRECTORY_SEPARATOR . $fileName)) {
+            } elseif ($fileInfo['filename'] === '' || !is_file($path . DIRECTORY_SEPARATOR . $fileName)) {
                 continue;
             }
 
             $filePath = $path . DIRECTORY_SEPARATOR . $fileName;
-            switch ($infoFile['extension']) {
+            $extension = $fileInfo["extension"] ?? '';
+            switch ($extension) {
                 case 'php':
                     $this->linkPHPFile($fileName, $folder, $place, $pluginName);
                     break;


### PR DESCRIPTION
Soluciono un error silencioso en el método **linkFiles** de la clase **PluginDeploy**.
El método fallaba de manera silenciosa cuando se intentaba copiar un archivo que no poseía extension, por ejemplo los archivos LICENSE y changelog, esto debido a que la función **pathinfo** no retorna ninguna extensión para esos archivos.

También cambio el nombre de la variable local **$infoFile** a **$fileInfo** el nuevo nombre es mas preciso.

## How has this been tested?

- [x] MySQL
- [x] PostgreSQL
- [x] Clean database
- [x] Database with random data