### PR TITLE
Update AssetManager.php avoinding warning when the included file does…

### DIFF
--- a/Core/Lib/AssetManager.php
+++ b/Core/Lib/AssetManager.php
@@ -78,16 +78,17 @@ class AssetManager
     public static function combine(string $type): string
     {
         $txt = '';
-        foreach (static::get($type) as $file) {
-            $filePath = $file;
-            if (\FS_ROUTE == substr($file, 0, strlen(\FS_ROUTE))) {
-                $filePath = substr($file, strlen(\FS_ROUTE) + 1);
+        $fsRouteLength = strlen(\FS_ROUTE);
+        foreach (static::get($type) as $path) {
+            if (\FS_ROUTE == substr($path, 0, $fsRouteLength)) {
+                $path = substr($path, $fsRouteLength + 1);
             }
-
-            $content = file_get_contents(\FS_FOLDER . DIRECTORY_SEPARATOR . $filePath) . "\n";
-            $txt .= static::fixCombineContent($content, \FS_ROUTE . DIRECTORY_SEPARATOR . $filePath);
+            $path = \FS_FOLDER . DIRECTORY_SEPARATOR . $path;
+            if (is_file($path)) {
+                $content = file_get_contents($path) . "\n";
+                $txt .= static::fixCombineContent($content, $path);
+            }
         }
-
         return $txt;
     }
 


### PR DESCRIPTION
Eliminé un error que ocasionaba un php warning, esto debido a que en algunas ocasiones se intenta obtener el contenido de una archivo que no existe. también se mejora el nombre de la variable local **$filePath** al nombre simple $**path** en el contexto utilizado no hay diferencia. Otro cambio es que se evita calcular el tamaño del **FS_ROUTE** en cada iteración. 
