### PR TITLE
Remove raw array conversion on APIModel routines.

### DIFF
--- a/Core/Lib/API/APIModel.php
+++ b/Core/Lib/API/APIModel.php
@@ -53,7 +53,7 @@ class APIModel extends APIResourceClass
         }
 
         if ($this->model->delete()) {
-            $this->setOk($this->toolBox()->i18n()->trans('record-deleted-correctly'), (array)$this->model);
+            $this->setOk($this->toolBox()->i18n()->trans('record-deleted-correctly'), $this->model->getFieldsValues());
             return true;
         }
 
@@ -93,7 +93,7 @@ class APIModel extends APIResourceClass
             return false;
         }
 
-        $this->returnResult((array)$this->model);
+        $this->returnResult($this->model->getFieldsValues());
         return true;
     }
 
@@ -110,7 +110,9 @@ class APIModel extends APIResourceClass
         $param0 = empty($this->params) ? '' : $this->params[0];
         $code = $values[$field] ?? $param0;
         if ($this->model->loadFromCode($code)) {
-            $this->setError($this->toolBox()->i18n()->trans('duplicate-record'), (array)$this->model);
+            $this->setError(
+                $this->toolBox()->i18n()->trans('duplicate-record'),
+                $this->model->getFieldsValues());
             return false;
         }
 

--- a/Core/Lib/API/APIModel.php
+++ b/Core/Lib/API/APIModel.php
@@ -53,7 +53,7 @@ class APIModel extends APIResourceClass
         }
 
         if ($this->model->delete()) {
-            $this->setOk($this->toolBox()->i18n()->trans('record-deleted-correctly'), (array) $this->model);
+            $this->setOk($this->toolBox()->i18n()->trans('record-deleted-correctly'), (array)$this->model);
             return true;
         }
 
@@ -93,7 +93,7 @@ class APIModel extends APIResourceClass
             return false;
         }
 
-        $this->returnResult((array) $this->model);
+        $this->returnResult((array)$this->model);
         return true;
     }
 
@@ -110,7 +110,7 @@ class APIModel extends APIResourceClass
         $param0 = empty($this->params) ? '' : $this->params[0];
         $code = $values[$field] ?? $param0;
         if ($this->model->loadFromCode($code)) {
-            $this->setError($this->toolBox()->i18n()->trans('duplicate-record'), (array) $this->model);
+            $this->setError($this->toolBox()->i18n()->trans('duplicate-record'), (array)$this->model);
             return false;
         }
 
@@ -215,8 +215,8 @@ class APIModel extends APIResourceClass
     /**
      * Returns the where clauses.
      *
-     * @param array  $filter
-     * @param array  $operation
+     * @param array $filter
+     * @param array $operation
      * @param string $defaultOperation
      *
      * @return DataBaseWhere[]
@@ -265,7 +265,7 @@ class APIModel extends APIResourceClass
             if (substr($key, -5) == '_like') {
                 $field = substr($key, 0, -5);
                 $operator = 'LIKE';
-            } elseif (substr($key, -6) == '_isnot') {
+            } else if (substr($key, -6) == '_isnot') {
                 $field = substr($key, 0, -6);
                 $operator = 'IS NOT';
             }
@@ -281,14 +281,14 @@ class APIModel extends APIResourceClass
     }
 
     /**
-     * 
+     *
      * @return bool
      */
     protected function listAll(): bool
     {
         $filter = $this->getRequestArray('filter');
-        $limit = (int) $this->request->get('limit', 50);
-        $offset = (int) $this->request->get('offset', 0);
+        $limit = (int)$this->request->get('limit', 50);
+        $offset = (int)$this->request->get('offset', 0);
         $operation = $this->getRequestArray('operation');
         $order = $this->getRequestArray('sort');
 
@@ -325,13 +325,16 @@ class APIModel extends APIResourceClass
     }
 
     /**
-     * 
+     *
      * @return bool
      */
     private function saveResource(): bool
     {
         if ($this->model->save()) {
-            $this->setOk($this->toolBox()->i18n()->trans('record-updated-correctly'), (array) $this->model);
+            $this->setOk(
+                $this->toolBox()->i18n()->trans('record-updated-correctly'),
+                $this->model->getFieldsValues()
+            );
             return true;
         }
 
@@ -340,7 +343,7 @@ class APIModel extends APIResourceClass
             $message .= ' - ' . $log['message'];
         }
 
-        $this->setError($message, (array) $this->model);
+        $this->setError($message, $this->model->getFieldsValues());
         return false;
     }
 }

--- a/Core/Model/Base/ModelCore.php
+++ b/Core/Model/Base/ModelCore.php
@@ -52,7 +52,7 @@ abstract class ModelCore
 
     /**
      * Adds an extension to this model.
-     * 
+     *
      * @param mixed $extension
      */
     abstract public static function addExtension($extension);
@@ -68,7 +68,7 @@ abstract class ModelCore
      * Loads table fields if is necessary.
      *
      * @param DataBase $dataBase
-     * @param string   $tableName
+     * @param string $tableName
      */
     abstract protected function loadModelFields(DataBase &$dataBase, string $tableName);
 
@@ -88,9 +88,9 @@ abstract class ModelCore
 
     /**
      * Executes all $name methods added from the extensions.
-     * 
+     *
      * @param string $name
-     * @param array  $arguments
+     * @param array $arguments
      *
      * @return mixed
      */
@@ -199,7 +199,7 @@ abstract class ModelCore
         foreach ($data as $key => $value) {
             if (in_array($key, $exclude)) {
                 continue;
-            } elseif (!isset($fields[$key])) {
+            } else if (!isset($fields[$key])) {
                 $this->{$key} = $value;
                 continue;
             }
@@ -287,7 +287,7 @@ abstract class ModelCore
     /**
      * Returns the boolean value for the field.
      *
-     * @param array  $field
+     * @param array $field
      * @param string $value
      *
      * @return bool|null
@@ -296,7 +296,7 @@ abstract class ModelCore
     {
         if (in_array(strtolower($value), ['true', 't', '1'], false)) {
             return true;
-        } elseif (in_array(strtolower($value), ['false', 'f', '0'], false)) {
+        } else if (in_array(strtolower($value), ['false', 'f', '0'], false)) {
             return false;
         }
 
@@ -306,7 +306,7 @@ abstract class ModelCore
     /**
      * Returns the float value for the field.
      *
-     * @param array  $field
+     * @param array $field
      * @param string $value
      *
      * @return float|null
@@ -314,7 +314,7 @@ abstract class ModelCore
     private function getFloatValueForField($field, $value)
     {
         if (is_numeric($value)) {
-            return (float) $value;
+            return (float)$value;
         }
 
         return $field['is_nullable'] === 'NO' ? 0.0 : null;
@@ -323,7 +323,7 @@ abstract class ModelCore
     /**
      * Returns the integer value by controlling special cases for the PK and FK.
      *
-     * @param array  $field
+     * @param array $field
      * @param string $value
      *
      * @return int|null
@@ -331,7 +331,7 @@ abstract class ModelCore
     private function getIntergerValueForField($field, $value)
     {
         if (is_numeric($value)) {
-            return (int) $value;
+            return (int)$value;
         }
 
         if ($field['name'] === static::primaryColumn()) {
@@ -342,11 +342,25 @@ abstract class ModelCore
     }
 
     /**
-     * 
+     *
      * @return ToolBox
      */
     protected static function toolBox()
     {
         return new ToolBox();
+    }
+
+    /**
+     * Return an array with the model fields values.
+     * @return array
+     */
+    public function getFieldsValues()
+    {
+        $data = [];
+        foreach ($this->getModelFields() as $field) {
+            $name = $field["name"];
+            $data[$name] = $this->{$name};
+        }
+        return $data;
     }
 }


### PR DESCRIPTION
Cree un nuevo **getFieldsValues** en el ModelCore, este método retorna un array con los valores del modelo según los campos retornados por el **getModelFields**, la motivación para la creación de este método es que en la clase **APIModel** existe un error dado que en varios métodos y respuestas se realiza una conversión cruda de los modelos a arreglos de la forma `(array)$object` esto causa comportamiento inesperados para modelos que extienden otras clases o implementan traits.

Ahora el método **getFieldsValues** permitiría que nosotros podamos sobre escribirlo en los modelos para cambiar la data que se responde en el API si es necesario.

De igual forma es bastante útil y común poder acceder de forma directa a estos valores en facturascripts fuera del entorno del API, este método seria útil en controladores y otras clases.

## How has this been tested?

- [x] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [x] Database with random data