### PR TITLE
task#23 Added method to change status to expired to PresupuestoCliente

### DIFF
--- a/Core/Data/Lang/ES/estados_documentos.csv
+++ b/Core/Data/Lang/ES/estados_documentos.csv
@@ -21,3 +21,4 @@ idestado;tipodoc;nombre;predeterminado;bloquear;editable;actualizastock;generado
 20;AlbaranProveedor;Devuelto;false;true;false;0;
 21;FacturaProveedor;Nueva;true;true;true;1;
 22;FacturaProveedor;Completada;false;true;false;1;
+23;PresupuestoCliente;Caducado;false;true;false;0;

--- a/Core/XMLView/EditPresupuestoCliente.xml
+++ b/Core/XMLView/EditPresupuestoCliente.xml
@@ -39,6 +39,9 @@
             <column name="number2" order="140">
                 <widget type="text" fieldname="numero2" icon="fas fa-hashtag" />
             </column>
+            <column name="expiration" order="150">
+                <widget type="date" fieldname="finoferta" />
+            </column>
             <column name="email-sent" order="150">
                 <widget type="date" fieldname="femail" />
             </column>

--- a/Core/XMLView/ListPresupuestoCliente.xml
+++ b/Core/XMLView/ListPresupuestoCliente.xml
@@ -92,6 +92,9 @@
         <column name="date" display="right" order="290">
             <widget type="date" fieldname="fecha" />
         </column>
+        <column name="expiration" display="right" order="300">
+            <widget type="date" fieldname="finoferta" />
+        </column>
     </columns>
     <rows>
         <row type="status">


### PR DESCRIPTION
Método para revisar y  cambiar a estado caducado todos aquellos presupuestos de venta cuya fecha fin haya expirado, cada vez que accedemos al ListPresupuestoCliente .

## How has this been tested?
- [ X] MySQL
- [ X] Database with random data
<!---- [ ] If additional tests was realized, added here--->
Para poder probar, he creado primero el estado caducado en mi instalación de pruebas.