### PR TITLE
Task #410: Add title option to row status

### DIFF
--- a/Core/Lib/Widget/RowStatus.php
+++ b/Core/Lib/Widget/RowStatus.php
@@ -69,4 +69,27 @@ class RowStatus extends VisualItem
 
         return '';
     }
+
+    /**
+     *
+     * @param object $model
+     * @return string
+     */
+    public function trTitle($model)
+    {
+        foreach ($this->options as $opt) {
+            $title = $opt['title'] ?? '';
+            if (empty($title)) {
+                continue;
+            }
+
+            $fieldname = isset($opt['fieldname']) ? $opt['fieldname'] : $this->fieldname;
+            $value = isset($model->{$fieldname}) ? $model->{$fieldname} : null;
+            if ($this->applyOperatorFromOption($opt, $value)) {
+                return static::$i18n->trans($title);
+            }
+        }
+
+        return '';
+    }
 }

--- a/Core/Lib/Widget/VisualItem.php
+++ b/Core/Lib/Widget/VisualItem.php
@@ -75,7 +75,7 @@ class VisualItem
     }
 
     /**
-     * 
+     *
      * @return int
      */
     public static function getLevel()
@@ -84,7 +84,7 @@ class VisualItem
     }
 
     /**
-     * 
+     *
      * @param int $new
      */
     public static function setLevel($new)
@@ -135,6 +135,19 @@ class VisualItem
      */
     public function getColorFromOption($option, $value, $prefix): string
     {
+        return $this->applyOperatorFromOption($option, $value)
+            ? $this->colorToClass($option['color'], $prefix)
+            : '';
+    }
+
+    /**
+     *
+     * @param string[] $option
+     * @param mixed    $value
+     * @return boolean
+     */
+    protected function applyOperatorFromOption($option, $value)
+    {
         $text = $option['text'] ?? '';
 
         $applyOperator = '';
@@ -147,48 +160,40 @@ class VisualItem
         }
 
         $matchValue = substr($text, strlen($applyOperator));
-        $apply = $matchValue == $value;
+        $apply = ($matchValue == $value);
 
         switch ($applyOperator) {
             case '>':
             case 'gt:':
-                $apply = (float) $value > (float) $matchValue;
-                break;
+                return (float) $value > (float) $matchValue;
 
             case 'gte:':
-                $apply = (float) $value >= (float) $matchValue;
-                break;
+                return (float) $value >= (float) $matchValue;
 
             case '<':
             case 'lt:':
-                $apply = (float) $value < (float) $matchValue;
-                break;
+                return (float) $value < (float) $matchValue;
 
             case 'lte:':
-                $apply = (float) $value <= (float) $matchValue;
-                break;
+                return (float) $value <= (float) $matchValue;
 
             case '!':
             case 'neq:':
-                $apply = $value != $matchValue;
-                break;
+                return $value != $matchValue;
 
             case 'like:':
-                $apply = false !== stripos($value, $matchValue);
-                break;
+                return false !== stripos($value, $matchValue);
 
             case 'null:':
-                $apply = null === $value;
-                break;
+                return null === $value;
 
             case 'notnull:':
-                $apply = null !== $value;
-                break;
+                return null !== $value;
         }
 
-        return $apply ? $this->colorToClass($option['color'], $prefix) : '';
+        return $apply;
     }
-
+    
     /**
      * Returns equivalent css class to $class. To extend in plugins.
      *

--- a/Core/View/Master/ListView.html.twig
+++ b/Core/View/Master/ListView.html.twig
@@ -110,16 +110,18 @@
                     </tr>
                 </thead>
                 <tbody>
+                    {% set rowStatus = currentView.getRow('status') %}
                     {% for model in currentView.cursor %}
-                        {% set trClass = currentView.getRow('status').trClass(model) %}
-                        <tr class="clickableRow {{ trClass }}" data-href="{{ model.url() }}">
-                            {% if currentView.settings.checkBoxes %}						
+                        {% set trClass = rowStatus.trClass(model) %}
+                        {% set trTitle = rowStatus.trTitle(model) %}
+                        <tr class="clickableRow {{ trClass }}" title="{{ trTitle }}" data-href="{{ model.url() }}">
+                            {% if currentView.settings.checkBoxes %}
                                 <td class="cancelClickable">
                                     <div class="form-check form-check-inline mb-2 mr-sm-2 mb-sm-0">
                                         <input class="form-check-input listAction" type="checkbox" name="code[]" value="{{ model.primaryColumnValue() }}" />
                                     </div>
                                 </td>
-                            {% endif %}							
+                            {% endif %}
                             {% for column in currentView.getColumns() %}
                                 {{ column.tableCell(model) | raw }}
                             {% endfor %}

--- a/Core/View/Master/ListViewMin.html.twig
+++ b/Core/View/Master/ListViewMin.html.twig
@@ -109,9 +109,11 @@
                 </tr>
             </thead>
             <tbody>
+                {% set rowStatus = currentView.getRow('status') %}
                 {% for model in currentView.cursor %}
-                    {% set trClass = currentView.getRow('status').trClass(model) %}
-                    <tr class="clickableRow {{ trClass }}" data-href="{{ model.url() }}">
+                    {% set trClass = rowStatus.trClass(model) %}
+                    {% set trTitle = rowStatus.trTitle(model) %}
+                    <tr class="clickableRow {{ trClass }}" title="{{ trTitle }}" data-href="{{ model.url() }}">
                         {% if currentView.settings.checkBoxes %}
                             <td class="cancelClickable">
                                 <div class="form-check form-check-inline mb-2 mr-sm-2 mb-sm-0">

--- a/Core/XMLView/ListAsiento.xml
+++ b/Core/XMLView/ListAsiento.xml
@@ -57,9 +57,9 @@
     </columns>
     <rows>
         <row type="status">
-            <option color="info" fieldname="editable">1</option>
-            <option color="warning" fieldname="operacion">notnull:</option>
-            <option color="success" fieldname="documento">neq:</option>
+            <option color="info" title="editable" fieldname="editable">1</option>
+            <option color="warning" title="special-accounting-entries" fieldname="operacion">notnull:</option>
+            <option color="success" title="document" fieldname="documento">neq:</option>
         </row>
     </rows>
     <modals>


### PR DESCRIPTION
Added the **title** attribute to the _options_ of the row status group.
Now, it's possible to indicate a text or translatable string into the user's language, an explanatory description of the reason why the row is colored.

### Example:
You can consult the Accounting entries option of the Accounting menu to see the result, or consult the ListAsiento.xml file to see an example of how to use it.

### How has this been tested?

- [X] MySQL
- [X] Database with random data
