### PR TITLE
Fix documentReadOnly when dont exists editable field

### DIFF
--- a/Core/View/Master/GridView.html.twig
+++ b/Core/View/Master/GridView.html.twig
@@ -92,7 +92,7 @@
                                     {% endfor %}
                                 </div>
                             {% endblock %}
-                            {% if (currentView.model.editable is not null) and (currentView.model.editable == false) %}
+                            {% if currentView.model.editable is same as(false) %}
                                 <div class="row">
                                     <script type="text/javascript">
                                         documentReadOnly = true;

--- a/Core/View/Master/GridView.html.twig
+++ b/Core/View/Master/GridView.html.twig
@@ -92,7 +92,7 @@
                                     {% endfor %}
                                 </div>
                             {% endblock %}
-                            {% if currentView.model.editable == false %}
+                            {% if (currentView.model.editable is not null) and (currentView.model.editable == false) %}
                                 <div class="row">
                                     <script type="text/javascript">
                                         documentReadOnly = true;


### PR DESCRIPTION
When the master model don't have editable field the GridView set documentReadOnly on edit record.