### PR TITLE
Task427

### DIFF
--- a/Core/Controller/SendMail.php
+++ b/Core/Controller/SendMail.php
@@ -84,7 +84,7 @@ class SendMail extends Controller
         $this->newMail = new NewMail();
 
         /// Check if the email is configurate
-        if ($this->newMail->canSendMail()) {
+        if (!$this->newMail->canSendMail()) {
             $this->toolBox()->i18nLog()->warning('email-not-configured');
         }
 
@@ -234,7 +234,9 @@ class SendMail extends Controller
         $this->newMail->fromNick = $this->user->nick;
         $this->newMail->title = $this->request->request->get('subject', '');
         $this->newMail->text = $this->request->request->get('body', '');
-
+        
+        $this->newMail->setMailbox($this->request->request->get('email-from', ''));
+        
         foreach ($this->getEmails('email') as $email) {
             $this->newMail->addAddress($email);
         }

--- a/Core/Controller/SendMail.php
+++ b/Core/Controller/SendMail.php
@@ -84,7 +84,7 @@ class SendMail extends Controller
         $this->newMail = new NewMail();
 
         /// Check if the email is configurate
-        if ($this->toolBox()->appSettings()->get('email', 'host', '') == "") {
+        if ($this->newMail->canSendMail()) {
             $this->toolBox()->i18nLog()->warning('email-not-configured');
         }
 

--- a/Core/Lib/Email/NewMail.php
+++ b/Core/Lib/Email/NewMail.php
@@ -271,6 +271,20 @@ class NewMail
         $this->toolBox()->i18nLog()->error('error', ['%error%' => $this->mail->ErrorInfo]);
         return false;
     }
+    
+    /**
+     * Check if the email is configured
+     * 
+     * @return bool
+     */
+    public function canSendMail()
+    {
+        if ($this->toolBox()->appSettings()->get('email', 'host', '') == "") {
+            return false;
+        } else {
+            return true;
+        }
+    }
 
     /**
      * Test the PHPMailer connection. Return the result of the connection.

--- a/Core/Lib/Email/NewMail.php
+++ b/Core/Lib/Email/NewMail.php
@@ -285,6 +285,32 @@ class NewMail
             return true;
         }
     }
+    
+    /**
+     * Returns an array with available email trays
+     * 
+     * @return array
+     */
+    public function getAvailableMailboxes()
+    {
+        $results = [];
+    
+        $emailSend = $this->toolBox()->appSettings()->get('email', 'email', '');
+        if ($emailSend != "") {
+            $results = [$emailSend];
+        }
+        
+        return $results;
+    }
+    
+    /**
+     * 
+     * @param type $emailFrom
+     */
+    public function setMailbox($emailFrom)
+    {
+        $this->mail->Email = $emailFrom;
+    }
 
     /**
      * Test the PHPMailer connection. Return the result of the connection.

--- a/Core/View/SendMail.html.twig
+++ b/Core/View/SendMail.html.twig
@@ -33,6 +33,19 @@
                             <div class="form-group">
                                 <div class="input-group">
                                     <div class="input-group-prepend">
+                                        <span class="input-group-text">{{ i18n.trans('from') }}</span>
+                                    </div>
+                                    <select class="custom-select" name="email-from">
+                                        {% for emailFrom in fsc.newMail.getAvailableMailboxes() %}
+                                            <option value="{{ emailFrom }}">{{ emailFrom }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            
+                            <div class="form-group">
+                                <div class="input-group">
+                                    <div class="input-group-prepend">
                                         <span class="input-group-text">{{ i18n.trans('to') }}</span>
                                     </div>
                                     {% set emails = fsc.newMail.getToAddresses() is empty ? '' : fsc.newMail.getToAddresses() | join(',') ~ ', ' %}


### PR DESCRIPTION
Methods to display shipping emails are added

----------------

Se añaden los metodos para mostrar los email de envío. 

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [x] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [x] Database with random data
<!---- [ ] If additional tests was realized, added here--->