### PR TITLE
Widget select

### DIFF
--- a/Core/Assets/JS/WidgetSelect.js
+++ b/Core/Assets/JS/WidgetSelect.js
@@ -1,0 +1,71 @@
+/*!
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2020 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ $(document).ready(function () {
+
+    $(".widget-action-select").each(function () {
+        let $select = $(this);
+
+        var data = {
+            action: $(this).attr("data-action"),
+            source: $(this).attr("data-source"),
+            filter: $(this).attr("data-filter"),
+            fieldcode: $(this).attr("data-fieldcode"),
+            fieldtitle: $(this).attr("data-fieldtitle"),
+        };
+
+        /**
+         * Para cada WidgetSelect con asyncsource, se asigna el evento onChange en el campo que filtra su orígen de datos
+         */
+
+        let $filter = $('[name="' + data.filter + '"]').on('change',function(){
+
+            data.value = $(this).val();
+
+            $.ajax({
+                method: "POST",
+                url: window.location.href,
+                data: data,
+                dataType: "json",
+                success: function (results) {
+                    $select.empty();
+                    if(!$select.is(':required')){
+                        $select.append($('<option>', {
+                            value: null,
+                            text: '------'
+                        }));
+                    }
+                    results.forEach(function (element) {
+                        $select.append($('<option>', {
+                            value: element[data.fieldcode],
+                            text: element[data.fieldtitle]
+                        }));
+                    });
+                },
+                error: function (msg) {
+                    alert(msg.status + " " + msg.responseText);
+                }
+            });
+        })
+
+        if(!$select.find('option').length){
+            $filter.change();
+        }
+    })
+
+});

--- a/Core/Controller/EditReport.php
+++ b/Core/Controller/EditReport.php
@@ -116,4 +116,43 @@ class EditReport extends EditController
             $ycolColumn->widget->setValuesFromArray($columns, false, true);
         }
     }
+
+    protected function getTableFieldsAction(){
+        $this->setTemplate(false);
+
+        $tableName = $this->request->request->get('value');
+        $fieldCode = $this->request->request->get('fieldcode');
+        $fieldtitle = $this->request->request->get('fieldtitle');
+
+        $columns = empty($tableName) || !$this->dataBase->tableExists($tableName) ? [] : array_keys($this->dataBase->getColumns($tableName));
+        sort($columns);
+        
+        $result=[];
+        foreach($columns as $v){
+            $result[]=[$fieldCode=>$v,$fieldtitle=>$v];
+        }
+
+        $this->response->setContent(\json_encode($result));
+
+    }
+
+     /**
+     * Run the actions that alter data before reading it.
+     *
+     * @param string $action
+     *
+     * @return bool
+     */
+    protected function execPreviousAction($action)
+    {
+        switch ($action) {
+            case 'get-table-fields':
+                 $this->getTableFieldsAction();
+                 return false;
+                break;
+         
+        }
+
+        return parent::execPreviousAction($action);
+    }
 }

--- a/Core/Lib/ExtendedController/BaseController.php
+++ b/Core/Lib/ExtendedController/BaseController.php
@@ -20,6 +20,7 @@ namespace FacturaScripts\Core\Lib\ExtendedController;
 
 use FacturaScripts\Core\Base\Controller;
 use FacturaScripts\Core\Base\ControllerPermissions;
+use FacturaScripts\Core\Base\DataBase;
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Dinamic\Lib\ExportManager;
 use FacturaScripts\Dinamic\Model\CodeModel;
@@ -253,6 +254,44 @@ abstract class BaseController extends Controller
 
         return $results;
     }
+
+     /**
+     * Run the autoselect action.
+     * Returns a JSON string for the searched values.
+     *
+     * @return array
+     */
+    protected function autoselectAction(): array
+    {
+        $data = $this->requestGet(['source', 'filter', 'fieldcode', 'fieldtitle','value']);
+
+        $filterVal = $this->request->request->get('value');
+        
+         $dataBase = new DataBase();
+
+         $wherevalue="{$data['value']}";
+
+         if(!is_numeric($data['value'])){
+            $wherevalue="'{$data['value']}'";
+         }
+
+         $sql="SELECT  {$data['fieldtitle']} as fieldtitle, {$data['fieldcode']} as fieldcode FROM {$data['source']} WHERE {$data['filter']} =  $wherevalue";
+
+         $result=$dataBase->select($sql);
+       
+         foreach ($result as $value) {
+              $results[] = [$data['fieldcode']=>$value['fieldcode'],$data['fieldtitle'] => $value['fieldtitle']];
+         }
+
+
+        if (empty($results)) {
+            $results[] = [];
+        }
+
+        return $results;
+    }
+
+
 
     /**
      * Action to delete data.

--- a/Core/Lib/ExtendedController/PanelController.php
+++ b/Core/Lib/ExtendedController/PanelController.php
@@ -304,6 +304,11 @@ abstract class PanelController extends BaseController
     protected function execPreviousAction($action)
     {
         switch ($action) {
+            case 'autoselect':
+                $this->setTemplate(false);
+                $results = $this->autoselectAction();
+                $this->response->setContent(json_encode($results));
+                return false;
             case 'autocomplete':
                 $this->setTemplate(false);
                 $results = $this->autocompleteAction();

--- a/Core/XMLView/EditDireccionContacto.xml
+++ b/Core/XMLView/EditDireccionContacto.xml
@@ -48,13 +48,15 @@
             </column>
             <column name="city" order="160">
                 <widget type="text" fieldname="ciudad" />
-            </column>
-            <column name="province" order="170">
-                <widget type="text" fieldname="provincia" />
-            </column>
-            <column name="country" titleurl="ListPais" order="180">
+            </column>          
+            <column name="country" titleurl="ListPais" order="170">
                 <widget type="select" fieldname="codpais" onclick="EditPais" required="true">
                     <values source="paises" fieldcode="codpais" fieldtitle="nombre" />
+                </widget>
+            </column>
+              <column name="province" order="180">
+                 <widget type="select" fieldname="provincia"  required="true">
+                    <values asyncsource="autoselect" source="provincias"  filter="codpais" fieldcode="provincia" fieldtitle="provincia" />
                 </widget>
             </column>
         </group>

--- a/Core/XMLView/EditReport.xml
+++ b/Core/XMLView/EditReport.xml
@@ -31,7 +31,9 @@
                 <widget type="select" fieldname="table" required="true" />
             </column>
             <column name="x-column" order="140">
-                <widget type="select" fieldname="xcolumn" />
+                <widget type="select" fieldname="xcolumn" required="true" >
+                    <values asyncsource="get-table-fields" filter="table" fieldcode="id" fieldtitle="name"/>
+                </widget>
             </column>
             <column name="x-operation" order="150">
                 <widget type="select" fieldname="xoperation" translate="true">
@@ -46,7 +48,9 @@
                 </widget>
             </column>
             <column name="y-column" order="160">
-                <widget type="select" fieldname="ycolumn" />
+                <widget type="select" fieldname="ycolumn">
+                      <values asyncsource="get-table-fields" filter="table" fieldcode="id" fieldtitle="name"/>
+                </widget>
             </column>
         </group>
         <group name="compare" numcolumns="12">


### PR DESCRIPTION
Modificaciones sobre el widget de select para soportar un orígen de datos asincrónico. TIene una funcionalidad por defecto que utiliza el source actual y se incorpora asyncsoruce que hace referencia a un action en execPreviosAction.
Se incluyen dos commits con ejemplos de cada caso.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [ ] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->