### PR TITLE
Update BaseWidget.php

### DIFF
--- a/Core/Lib/Widget/BaseWidget.php
+++ b/Core/Lib/Widget/BaseWidget.php
@@ -87,7 +87,11 @@ class BaseWidget extends VisualItem
         $this->icon = $data['icon'] ?? '';
         $this->onclick = $data['onclick'] ?? '';
         $this->readonly = $data['readonly'] ?? 'false';
-        $this->required = isset($data['required']);
+        if (isset($data['required'])){
+            $this->required = (strtolower($data['required']) == 'false') ? false : true;
+        }else{
+            $this->required = false;
+        }
         $this->type = $data['type'];
         $this->loadOptions($data['children']);
         $this->assets();


### PR DESCRIPTION
En XMLView/EditLoquesea.xml para los widget tipo select tanto `required="true"` como `required="false"` provocan que no se añada el primer option con "------" al desplegable.
Entiendo que cuando `required="false"` sí debería añadirse.

El mismo fix en una línea (aunque más lioso):
```php
$this->required = isset($data['required']) ? ((strtolower($data['required']) == 'false') ? false : true) : false;
```

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data