### PR TITLE
Allow multiple cells bidimensional render (DebugBar)

### DIFF
--- a/Core/Base/Debug/DebugBar.php
+++ b/Core/Base/Debug/DebugBar.php
@@ -301,7 +301,9 @@ class DebugBar extends DumbBar
             $html .= '<tr><td>#' . $count . '</td>';
             foreach ($row as $cell) {
                 if (is_array($cell)) {
-                    $html .= '<td>[' . implode(', ', $cell) . ']</td>';
+                    foreach($cell as $cell_data){
+                        $html .= '<td>[' . implode(', ', $cell_data) . ']</td>';
+                    }
                     continue;
                 }
 

--- a/Core/Base/Debug/DebugBar.php
+++ b/Core/Base/Debug/DebugBar.php
@@ -301,12 +301,10 @@ class DebugBar extends DumbBar
             $html .= '<tr><td>#' . $count . '</td>';
             foreach ($row as $cell) {
                 if (is_array($cell)) {
-                    foreach($cell as $cell_data){
-                        $html .= '<td>[' . implode(', ', $cell_data) . ']</td>';
-                    }
+                    $html .= '<td>[' . var_export($cell, true) . ']</td>';
                     continue;
                 }
-
+                
                 $html .= '<td>' . $cell . '</td>';
             }
             $html .= '</tr>';


### PR DESCRIPTION
See details image: https://prnt.sc/w0pql5

En el caso de hacer un post con datos en array similares a:
``` <input type="text" name="properties[]" /> ```
Donde se envían muchas datos `clave -> valor` el render del debug bar falla.