### PR TITLE
Partial fix for "ordernum doesn't work for ordering submenus"

### DIFF
--- a/Core/Base/MenuManager.php
+++ b/Core/Base/MenuManager.php
@@ -319,12 +319,12 @@ class MenuManager
             return \strcasecmp($menu1->title, $menu2->title);
         });
 
-        /// sort submenus
-        foreach ($result as $key => $value) {
-            if (!empty($value->menu)) {
-                $result[$key]->menu = $this->sortMenu($value->menu);
-            }
-        }
+        // /// sort submenus
+        // foreach ($result as $key => $value) {
+        //     if (!empty($value->menu)) {
+        //         $result[$key]->menu = $this->sortMenu($value->menu);
+        //     }
+        // }
 
         return $result;
     }


### PR DESCRIPTION
Partial fix for "ordernum doesn't work for ordering submenus", according to chat on 5th nov.

I commented "sort submenus" because submenus arrive here already in the right order (see loadPages())

I say "partial fix" because with this ordernum works if present but still needs to be properly saved in the DB (eg Controller/ListSomething.php -> getPageData() ... $data['ordernum'] = 80; ...)

At the moment I handle this manually setting the order for all the submenus in my plugin via Init.php -> update() with sql queries.

Your PR description goes here.

<!---Please make a clear summary of the changes.--->
<!---Do not include different functionalities in the same PR.--->
<!---If the modifications are about sending emails, do not also include changes to the API, or file management. Do not force us to decide between all or nothing.--->
<!---You can remove these lines.--->

<!---Por favor, haz un resumen claro de los cambios.--->
<!---No incluyas funcionalidades distintas en el mismo PR.--->
<!---Si las modificaciones son sobre el envío de emails, no incluyas también cambios en la API o en la gestión de archivos. No nos obligues a decidir entre todo o nada.--->
<!---Puedes eliminar estas líneas.--->

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [x] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->