### PR TITLE
made public 4 private methods

### DIFF
--- a/Core/Model/Base/JoinModel.php
+++ b/Core/Model/Base/JoinModel.php
@@ -308,7 +308,7 @@ abstract class JoinModel
      *
      * @return bool
      */
-    private function checkTables(): bool
+    public function checkTables(): bool
     {
         foreach ($this->getTables() as $tableName) {
             if (!self::$dataBase->tableExists($tableName)) {
@@ -324,7 +324,7 @@ abstract class JoinModel
      *
      * @return string
      */
-    private function fieldsList(): string
+    public function fieldsList(): string
     {
         $result = '';
         $comma = '';
@@ -340,7 +340,7 @@ abstract class JoinModel
      *
      * @return string
      */
-    private function getGroupBy(): string
+    public function getGroupBy(): string
     {
         $fields = $this->getGroupFields();
         return empty($fields) ? '' : ' GROUP BY ' . $fields;
@@ -363,7 +363,7 @@ abstract class JoinModel
      *
      * @return string
      */
-    private function getOrderBy(array $order): string
+    public function getOrderBy(array $order): string
     {
         $result = '';
         $coma = ' ORDER BY ';


### PR DESCRIPTION
Changed from private to public: checkTables, fieldsList, getGroupBy, getOrderBy

I suggest this change because to dramatically improve performance in one model using JoinModel I had to overwrite all() and count(), and for them to work this 4 methods should be public as well.



## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data