### PR TITLE
Fix getNewNumber for BusinessDocument below initial sequence number.

### DIFF
--- a/Core/Lib/BusinessDocumentCode.php
+++ b/Core/Lib/BusinessDocumentCode.php
@@ -95,6 +95,10 @@ class BusinessDocumentCode
             $preDate = $document->fecha;
             $preHour = $document->hora;
             foreach ($previous as $preDoc) {
+				if ( $expectedNumber < $sequence->inicio  ) {
+                    break;	// we are below the initial sequence number, so skip (no hole found)
+				}
+				
                 if ($expectedNumber != $preDoc->numero) {
                     /// hole found
                     $document->fecha = $preDate;


### PR DESCRIPTION
Fix getNewNumber for BusinessDocument below initial sequence number.

Using the "usarhuecos" option with document sequences, it can happen that the next assigned document number is below the defined initial number of that sequence. This fix provides a simple solution.

Background: This happened to me after changing a sequence from one fiscal year to another (which is allowed), using higher document numbers than before. Later, gaps were found below the new initial number.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->