### PR TITLE
Move ProductionErrorHandler.php from 'Core/Base/Debug' to 'Core/Lib' …

### DIFF
--- a/Core/Lib/ProductionErrorHandler.php
+++ b/Core/Lib/ProductionErrorHandler.php
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-namespace FacturaScripts\Core\Base\Debug;
+
+namespace FacturaScripts\Core\Lib;
 
 use FacturaScripts\Core\Base\PluginManager;
 
@@ -44,7 +45,7 @@ class ProductionErrorHandler
     }
 
     /**
-     * 
+     *
      * @param array $error
      *
      * @return string
@@ -56,7 +57,7 @@ class ProductionErrorHandler
     }
 
     /**
-     * 
+     *
      * @param array $error
      *
      * @return string
@@ -64,21 +65,25 @@ class ProductionErrorHandler
     private function render($error)
     {
         $title = "FATAL ERROR #" . $error["type"];
+        $file = str_replace(FS_FOLDER, '', $error['file']);
         return "<html>"
             . "<head>"
             . "<title>" . $title . "</title>"
             . "<style>"
             . "body {background-color: silver;}"
-            . ".container {padding: 20px 20px 40px 20px; max-width: 900px; margin-left: auto; margin-right: auto; border-radius: 10px; background-color: snow;}"
+            . '.container{display:flex;justify-content:center;align-items:center;height:100%}'
+            . ".message-container {padding: 20px 20px 40px 20px; max-width: 900px; background-color: snow;box-shadow: 1px 1px 1px 1px #00000070}"
             . ".text-center {text-align: center;}"
             . ".btn {padding: 10px; border-radius: 5px; background-color: orange; color: white; text-decoration: none; font-weight: bold;}"
+            . 'ul{list-style:none;}li{margin-bottom:5px}'
             . "</style>"
             . "</head>"
             . "<body>"
             . "<div class='container'>"
+            . '<div class="message-container">'
             . "<h1 class='text-center'>" . $title . "</h1>"
             . "<ul>"
-            . "<li><b>File:</b> " . $error["file"] . " (<b>Line " . $error["line"] . "</b>)</li>"
+            . "<li><b>File:</b> " . $file . " (<b>Line " . $error["line"] . "</b>)</li>"
             . "<li><b>Message:</b> " . $this->cleanMessage($error) . "</li>"
             . "<li><b>FacturaScripts:</b> " . PluginManager::CORE_VERSION . "</li>"
             . "<li><b>PHP:</b> " . PHP_VERSION . "</li>"
@@ -87,6 +92,7 @@ class ProductionErrorHandler
             . "<a href='https://facturascripts.com/contacto' target='_blank' class='btn'>REPORT / INFORMAR</a>"
             . "</div>"
             . "</div>"
+            . '</div>'
             . "</body>"
             . "</html>";
     }

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@ define('FS_FOLDER', __DIR__);
  * Preliminary checks
  */
 if (false === file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'config.php')) {
-    if ((int) substr(phpversion(), 0, 1) < 7) {
+    if ((int)substr(phpversion(), 0, 1) < 7) {
         die('You need PHP 7<br/>You have PHP ' . phpversion());
     } elseif (false === file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'vendor')) {
         die('<h1>COMPOSER ERROR</h1><p>You need to run: composer install</p><p>You should also run: npm install</p>');
@@ -55,7 +55,11 @@ if (FS_DEBUG) {
     $whoops->prependHandler(new \Whoops\Handler\PrettyPageHandler());
     $whoops->register();
 } else {
-    $errorHandler = new \FacturaScripts\Core\Base\Debug\ProductionErrorHandler();
+    if (class_exists('\FacturaScripts\Dinamic\Lib\ProductionErrorHandler')) {
+        new \FacturaScripts\Dinamic\Lib\ProductionErrorHandler();
+    } else {
+        new \FacturaScripts\Core\Lib\ProductionErrorHandler();
+    }
 }
 
 /**


### PR DESCRIPTION

The **ProductionErrorHandler.php** was moved from 'Core/Base/Debug' to 'Core/Lib' This allow improve the production error handler from plugins. 
#### Additionally
- Minimal styles improvements. 
- The FS_FOLDER string is removed from the file detail on the error to hide absolute path information for an attacker.

#### Changes

- The class ProductionHandler.php moved to the 'Core/Lib' directory.
- The index.php now load the class from the namespace 'Dinamic/Lib' instead of the previous 'Core/Base/Debug'
- If the class 'Dinamic/Lib/ProductionErrorHandler' doesn't exists the 'Core/Lib/ProductionErrorHandler' is loaded, this avoid dinamic updates errors.

## How has this been tested?

- [ x] MySQL
- [x ] Clean database
- [ x] Database with random data

- I created a TestPlugin and replace the file using a class insided of the Lib folder.