### PR TITLE
Contact method test fails before creating a new client

### DIFF
--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -262,6 +262,7 @@ class Cliente extends Base\ComercialContact
             $contact->fax = $this->fax;
             $contact->nombre = $parts[0];
             $contact->personafisica = $this->personafisica;
+            $contact->tipoidfiscal = $this->tipoidfiscal;
             $contact->telefono1 = $this->telefono1;
             $contact->telefono2 = $this->telefono2;
             if ($contact->save()) {


### PR DESCRIPTION
Cuando se hace la verificación del  documento de identidad en el método test() del Contacto falla por que llega el tipo de documento por defecto, mas no el que se seleccionó en la creación del cliente.
