### PR TITLE
Only owner data

### DIFF
--- a/Core/Base/ControllerPermissions.php
+++ b/Core/Base/ControllerPermissions.php
@@ -57,6 +57,13 @@ class ControllerPermissions
     public $allowUpdate = false;
 
     /**
+     * Permission for show all or only owner data.
+     *
+     * @var bool
+     */
+    public $onlyOwnerData = false;
+
+    /**
      * ControllerPermissions constructor.
      *
      * @param User|false  $user
@@ -72,28 +79,32 @@ class ControllerPermissions
             $this->allowAccess = true;
             $this->allowDelete = true;
             $this->allowUpdate = true;
+            $this->onlyOwnerData = false;
         } else {
             /// normal user
             foreach (RoleAccess::allFromUser($user->nick, $pageName) as $access) {
                 $this->allowAccess = true;
                 $this->allowDelete = $access->allowdelete ? true : $this->allowDelete;
                 $this->allowUpdate = $access->allowupdate ? true : $this->allowUpdate;
+                $this->onlyOwnerData = $access->ownerdata ? true : $this->onlyOwnerData;
             }
         }
     }
 
     /**
-     * 
+     *
      * @param bool $access
      * @param int  $accessMode
      * @param bool $delete
      * @param bool $update
+     * @param bool $owner
      */
-    public function set(bool $access, int $accessMode, bool $delete, bool $update)
+    public function set(bool $access, int $accessMode, bool $delete, bool $update, bool $owner)
     {
         $this->accessMode = $accessMode;
         $this->allowAccess = $access;
         $this->allowDelete = $delete;
         $this->allowUpdate = $update;
+        $this->onlyOwnerData = $owner;
     }
 }

--- a/Core/Lib/ExtendedController/BaseController.php
+++ b/Core/Lib/ExtendedController/BaseController.php
@@ -255,6 +255,25 @@ abstract class BaseController extends Controller
     }
 
     /**
+     * Check if the active user has permission to view the information
+     * of the active record in the informed model.
+     * 
+     * @param ModelClass|JoinModel $model
+     * @return bool
+     */
+    protected function checkOwnerData($model):bool
+    {
+        if ($this->permissions->onlyOwnerData &&
+            isset($model->nick) &&
+            $model->nick !== $this->user->nick)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Action to delete data.
      *
      * @return bool
@@ -347,6 +366,25 @@ abstract class BaseController extends Controller
             }
         }
         return $result;
+    }
+
+    /**
+     * Returns the where filter to apply to obtain the data
+     * created by the active user.
+     *
+     * @param ModelClass|JoinModel $model
+     * @return DataBaseWhere[]
+     */
+    protected function getOwnerFilter($model)
+    {
+        $fields = $model->getModelFields();
+        if (isset($fields['nick'])) {
+            return [
+                new DataBaseWhere($fields['nick']['name'], $this->user->nick),
+                new DataBaseWhere($fields['nick']['name'], null, 'IS', 'OR'),
+            ];
+        }
+        return [];
     }
 
     /**

--- a/Core/Lib/ExtendedController/BusinessDocumentController.php
+++ b/Core/Lib/ExtendedController/BusinessDocumentController.php
@@ -152,7 +152,7 @@ abstract class BusinessDocumentController extends PanelController
     }
 
     /**
-     * 
+     *
      * @return array
      */
     protected function getBusinessFormData()
@@ -215,6 +215,13 @@ abstract class BusinessDocumentController extends PanelController
 
                 /// data not found?
                 $view->loadData($code);
+
+                /// User can access to data?
+                if (!$this->checkOwnerData($view->model)) {
+                    $this->setTemplate('Error/AccessDenied');
+                    return;
+                }
+
                 $action = $this->request->request->get('action', '');
                 if ('' === $action && false === $view->model->exists()) {
                     $this->toolBox()->i18nLog()->warning('record-not-found');
@@ -292,7 +299,7 @@ abstract class BusinessDocumentController extends PanelController
     }
 
     /**
-     * 
+     *
      * @param string $message
      *
      * @return string
@@ -310,7 +317,7 @@ abstract class BusinessDocumentController extends PanelController
     }
 
     /**
-     * 
+     *
      * @param BusinessDocumentView $view
      * @param array                $data
      *
@@ -393,7 +400,7 @@ abstract class BusinessDocumentController extends PanelController
     }
 
     /**
-     * 
+     *
      * @return bool
      */
     protected function subjectChangedAction()

--- a/Core/Lib/ExtendedController/EditController.php
+++ b/Core/Lib/ExtendedController/EditController.php
@@ -22,7 +22,7 @@ namespace FacturaScripts\Core\Lib\ExtendedController;
  * Controller to manage the data editing
  *
  * @author Carlos García Gómez  <carlos@facturascripts.com>
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  */
 abstract class EditController extends PanelController
 {
@@ -87,6 +87,15 @@ abstract class EditController extends PanelController
                 $primaryKey = $this->request->request->get($view->model->primaryColumn());
                 $code = $this->request->query->get('code', $primaryKey);
                 $view->loadData($code);
+
+                /// User can access to data?
+                if ($this->permissions->onlyOwnerData &&
+                    isset($view->model->nick) &&
+                    $view->model->nick !== $this->user->nick)
+                {
+                    $this->setTemplate('Error/AccessDenied');
+                    return;
+                }
 
                 /// Data not found?
                 $action = $this->request->request->get('action', '');

--- a/Core/Lib/ExtendedController/EditController.php
+++ b/Core/Lib/ExtendedController/EditController.php
@@ -89,10 +89,7 @@ abstract class EditController extends PanelController
                 $view->loadData($code);
 
                 /// User can access to data?
-                if ($this->permissions->onlyOwnerData &&
-                    isset($view->model->nick) &&
-                    $view->model->nick !== $this->user->nick)
-                {
+                if (!$this->checkOwnerData($view->model)) {
                     $this->setTemplate('Error/AccessDenied');
                     return;
                 }

--- a/Core/Lib/ExtendedController/ListController.php
+++ b/Core/Lib/ExtendedController/ListController.php
@@ -313,13 +313,10 @@ abstract class ListController extends BaseController
      */
     protected function loadData($viewName, $view)
     {
-        $where = [];
-        if ($this->permissions->onlyOwnerData) {
-            $fields = $view->model->getModelFields();
-            if (isset($fields['nick'])) {
-                $where[] = new DataBaseWhere($fields['nick']['name'], $this->user->nick);
-            }
-        }
+        $where = ($this->permissions->onlyOwnerData)
+            ? $this->getOwnerFilter($view->model)
+            : [];
+
         $view->loadData('', $where);
     }
 

--- a/Core/Lib/ExtendedController/ListController.php
+++ b/Core/Lib/ExtendedController/ListController.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Controller that lists the data in table mode
  *
  * @author Carlos García Gómez          <carlos@facturascripts.com>
- * @author Artex Trading sa             <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
  * @author Cristo M. Estévez Hernández  <cristom.estevez@gmail.com>
  */
 abstract class ListController extends BaseController
@@ -313,7 +313,14 @@ abstract class ListController extends BaseController
      */
     protected function loadData($viewName, $view)
     {
-        $view->loadData();
+        $where = [];
+        if ($this->permissions->onlyOwnerData) {
+            $fields = $view->model->getModelFields();
+            if (isset($fields['nick'])) {
+                $where[] = new DataBaseWhere($fields['nick']['name'], $this->user->nick);
+            }
+        }
+        $view->loadData('', $where);
     }
 
     /**

--- a/Core/Model/RoleAccess.php
+++ b/Core/Model/RoleAccess.php
@@ -64,6 +64,13 @@ class RoleAccess extends Base\ModelClass
     public $id;
 
     /**
+     * Permision for show all or owner data.
+     *
+     * @var bool
+     */
+    public $ownerdata;
+
+    /**
      * Name of the page.
      *
      * @var string
@@ -94,6 +101,7 @@ class RoleAccess extends Base\ModelClass
             $roleAccess->pagename = $page->name;
             $roleAccess->allowdelete = true;
             $roleAccess->allowupdate = true;
+            $roleAccess->ownerdata = false;
             if (false === $roleAccess->save()) {
                 return false;
             }
@@ -103,7 +111,7 @@ class RoleAccess extends Base\ModelClass
     }
 
     /**
-     * 
+     *
      * @param string $nick
      * @param string $pageName
      *
@@ -121,7 +129,7 @@ class RoleAccess extends Base\ModelClass
     }
 
     /**
-     * 
+     *
      * @return Page
      */
     public function getPage()
@@ -132,7 +140,7 @@ class RoleAccess extends Base\ModelClass
     }
 
     /**
-     * 
+     *
      * @return string
      */
     public function install()

--- a/Core/Table/roles_access.xml
+++ b/Core/Table/roles_access.xml
@@ -29,6 +29,12 @@
         <null>NO</null>
     </column>
     <column>
+        <name>ownerdata</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>false</default>
+    </column>
+    <column>
         <name>pagename</name>
         <type>character varying(40)</type>
         <null>NO</null>

--- a/Core/XMLView/EditRoleAccess.xml
+++ b/Core/XMLView/EditRoleAccess.xml
@@ -40,6 +40,9 @@
             <column name="allow-delete" order="140">
                 <widget type="checkbox" fieldname="allowdelete" />
             </column>
+            <column name="only-owner-data" order="150">
+                <widget type="checkbox" fieldname="ownerdata" />
+            </column>
         </group>
     </columns>
     <rows>

--- a/Core/XMLView/ListPageRule.xml
+++ b/Core/XMLView/ListPageRule.xml
@@ -19,7 +19,7 @@
  *
  * Initial description for the controller ListPageRule
  *
- * @author Artex Trading sa <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello Principal <yopli2000@gmail.com>
 -->
 
 
@@ -39,6 +39,9 @@
         </column>
         <column name="allow-delete" order="110">
             <widget type="checkbox" fieldname="allowdelete" />
+        </column>
+        <column name="only-owner-data" order="120">
+            <widget type="checkbox" fieldname="ownerdata" />
         </column>
     </columns>
 </view>


### PR DESCRIPTION
Added filter and access control to information whose owner is the active user or user who has made the login.

The control has been added at the group level, creating a new attribute that allows the administrator to indicate if a controller allows to see all the information or only the proprietary information of the active user.

The controllers now have two methods to filter and / or control access to information.
- **checkOwnerData**: Indicates if the model data record is accessible by the active user.
- **getOwnerFilter**: Returns the condition in the form of DataBaseWhere to add to the call to obtain the information if you want to use the proprietary data control.

**These controls have been included** in the extended controllers: **ListController**, **EditController**, and **BusinessDocumentController**.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
