### PR TITLE
Update BusinessDocumentView.js

### DIFF
--- a/Core/Assets/JS/BusinessDocumentView.js
+++ b/Core/Assets/JS/BusinessDocumentView.js
@@ -24,7 +24,7 @@ var hsTable = null;
 
 function beforeChange(changes, source) {
     // Check if the value has changed. Not Multiselection
-    if (changes !== null && changes[0][2] !== changes[0][3]) {
+    if (changes !== null && changes[0][2] != changes[0][3]) {
         for (var i = 0; i < businessDocViewAutocompleteColumns.length; i++) {
             if (changes[0][1] === businessDocViewAutocompleteColumns[i]) {
                 // apply for autocomplete columns


### PR DESCRIPTION
Issue: When autocomplete dropdown from the grid is visible, if focus is lost (by clicking in any element out of the grid) appears an error in the console "Uncaught TypeError: Cannot read property '0' of undefined"
Solution: don't use strict comparison here (null !== empty string is true. null != empty string is false)


## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->