### PR TITLE
Add document totals in document grouping view

### DIFF
--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -253,6 +253,26 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <div class="card-footer">
+                <div class="row justify-content-between align-items-center mt-2">
+                  <div class="col-4">
+                    <h4>Totales</h4>
+                  </div>
+                  <div class="col-6">
+                    <div class="row">
+                        <div class="col">
+                            <h5>Neto: {{ doc.neto }}</h5>
+                        </div>
+                        <div class="col">
+                            <h5>Impuestos: {{ doc.totaliva }}</h5>
+                        </div>
+                        <div class="col">
+                            <h5>Total: {{ doc.total }}</h5>
+                        </div>
+                    </div>
+                  </div>
+                </div>
+            </div>
         </div>
     </div>
 {% endmacro %}


### PR DESCRIPTION
Add a footer to the document card with the document totals in the document grouping view.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
