### PR TITLE
Verificar si la cantidad de línea supera al stock

### DIFF
--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -483,6 +483,10 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
         }
 
         $this->applyStockChanges($stock, $this->previousData['actualizastock'], $this->previousData['cantidad'] * -1, $this->previousData['servido'] * -1);
+        if ($stock->cantidad - $stock->reservada < $this->cantidad) {
+            $this->toolBox()->i18nLog()->warning('not-enough-stock', ['%reference%' => $this->referencia]);
+            return false;
+        }
         $this->applyStockChanges($stock, $this->actualizastock, $this->cantidad, $this->servido);
 
         /// enough stock?

--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -483,11 +483,10 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
         }
 
         $this->applyStockChanges($stock, $this->previousData['actualizastock'], $this->previousData['cantidad'] * -1, $this->previousData['servido'] * -1);
-        $available_stock = $stock->cantidad - $stock->reservada >= $this->cantidad;
         $this->applyStockChanges($stock, $this->actualizastock, $this->cantidad, $this->servido);
 
         /// enough stock?
-        if (false === $producto->ventasinstock && $this->actualizastock === -1 && (!$available_stock || $stock->cantidad < 0)) {
+        if (false === $producto->ventasinstock && $this->actualizastock === -1 && ($stock->disponible < $this->cantidad  || $stock->cantidad < 0)) {
             $this->toolBox()->i18nLog()->warning('not-enough-stock', ['%reference%' => $this->referencia]);
             return false;
         }

--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -483,14 +483,11 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
         }
 
         $this->applyStockChanges($stock, $this->previousData['actualizastock'], $this->previousData['cantidad'] * -1, $this->previousData['servido'] * -1);
-        if ($stock->cantidad - $stock->reservada < $this->cantidad) {
-            $this->toolBox()->i18nLog()->warning('not-enough-stock', ['%reference%' => $this->referencia]);
-            return false;
-        }
+        $available_stock = $stock->cantidad - $stock->reservada >= $this->cantidad;
         $this->applyStockChanges($stock, $this->actualizastock, $this->cantidad, $this->servido);
 
         /// enough stock?
-        if (false === $producto->ventasinstock && $this->actualizastock === -1 && $stock->cantidad < 0) {
+        if (false === $producto->ventasinstock && $this->actualizastock === -1 && (!$available_stock || $stock->cantidad < 0)) {
             $this->toolBox()->i18nLog()->warning('not-enough-stock', ['%reference%' => $this->referencia]);
             return false;
         }


### PR DESCRIPTION
No respeta el stock disponible (No se puede vender más de lo que tengo disponible).
Actualmente para el cálculo del stock se usa la cantidad, debería usar el disponible.

La línea 846 verifica si el stock disponible es menor que la cantidad de la línea para fallar.
