### PR TITLE
Now when installing FS the Translation folder is created inside the M…

### DIFF
--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -117,7 +117,7 @@ final class AppInstaller
     private function createFolders()
     {
         // Check each needed folder to deploy
-        foreach (['Plugins', 'Dinamic', 'MyFiles'] as $folder) {
+        foreach (['Plugins', 'Dinamic', 'MyFiles', 'MyFiles\\Translation'] as $folder) {
             if (false === ToolBox::files()->createFolder($folder)) {
                 ToolBox::i18nLog()->critical('cant-create-folders', ['%folder%' => $folder]);
                 return false;

--- a/Core/App/AppInstaller.php
+++ b/Core/App/AppInstaller.php
@@ -117,7 +117,7 @@ final class AppInstaller
     private function createFolders()
     {
         // Check each needed folder to deploy
-        foreach (['Plugins', 'Dinamic', 'MyFiles', 'MyFiles\\Translation'] as $folder) {
+        foreach (['Plugins', 'Dinamic', 'MyFiles'] as $folder) {
             if (false === ToolBox::files()->createFolder($folder)) {
                 ToolBox::i18nLog()->critical('cant-create-folders', ['%folder%' => $folder]);
                 return false;

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -274,9 +274,9 @@ class Translator
     {
         self::$languages[] = $langCode;
 
-        $file = \FS_FOLDER . '/Core/Translation/' . $langCode . '.json';
-        if (file_exists($file)) {
-            self::$translator->addResource('json', $file, $langCode);
+        $coreFile = \FS_FOLDER . '/Core/Translation/' . $langCode . '.json';
+        if (file_exists($coreFile)) {
+            self::$translator->addResource('json', $coreFile, $langCode);
         }
 
         $pluginManager = new PluginManager();
@@ -285,6 +285,11 @@ class Translator
             if (file_exists($file2)) {
                 self::$translator->addResource('json', $file2, $langCode);
             }
+        }
+
+        $myFile = \FS_FOLDER . '/MyFiles/Translation/' . $langCode . '.json';
+        if (file_exists($myFile)) {
+            self::$translator->addResource('json', $myFile, $langCode);
         }
     }
 }

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -287,9 +287,12 @@ class Translator
             }
         }
 
-        $myFile = \FS_FOLDER . '/MyFiles/Translation/' . $langCode . '.json';
+        $myFile = \FS_FOLDER . '/MyFiles/Translation';
         if (file_exists($myFile)) {
-            self::$translator->addResource('json', $myFile, $langCode);
+            $myFile = $myFile . '/' . $langCode . '.json';
+            if (file_exists($myFile)) {
+                self::$translator->addResource('json', $myFile, $langCode);
+            }
         }
     }
 }


### PR DESCRIPTION
Your PR description goes here.

Now when installing FS the Translation folder is created inside the MyFiles folder. And the translation system takes into account this folder to translate strings, before the plugins and the core.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [X] Clean database
- [ ] Database with random data
<!---- [ ] If additional tests was realized, added here--->