### PR TITLE
Set focus to query search

### DIFF
--- a/Core/View/Master/ListController.html.twig
+++ b/Core/View/Master/ListController.html.twig
@@ -128,6 +128,11 @@
                 window.location.hash = this.hash;
                 $('html,body').scrollTop(scrollmem);
             });
+            $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+                if (window.innerWidth > 1023) {
+                    $("input[name='query']:visible").focus();
+                }
+            });
         });
     </script>
 {% endblock %}

--- a/Core/View/Master/ListController.html.twig
+++ b/Core/View/Master/ListController.html.twig
@@ -133,6 +133,9 @@
                     $("input[name='query']:visible").focus();
                 }
             });
+            if (window.innerWidth > 1023) {
+                $("input[name='query']:visible").focus();
+            }
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
If the window width is 1024 or larger, the focus is automatically placed on the search input of the active tab.

## How has this been tested?

- [X] Chrome
- [X] Safari
- [ ] Firefox
- [ ] Edge
