### PR TITLE
Fixed filtering of subaccounts

### DIFF
--- a/Core/Controller/EditReportAmount.php
+++ b/Core/Controller/EditReportAmount.php
@@ -27,7 +27,7 @@ use FacturaScripts\Dinamic\Model\ReportAmount;
  * Description of EditReportAmount
  *
  * @author Carlos Garcia Gomez  <carlos@facturascripts.com>
- * @author Jose Antonio Cuello  <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello  <yopli2000@gmail.com>
  */
 class EditReportAmount extends EditReportAccounting
 {

--- a/Core/Lib/Accounting/BalanceAmounts.php
+++ b/Core/Lib/Accounting/BalanceAmounts.php
@@ -68,12 +68,11 @@ class BalanceAmounts extends AccountingBase
 
         /// get accounts
         $cuenta = new Cuenta();
-        $where = [new DataBaseWhere('codejercicio', $this->exercise->codejercicio)];
-        $accounts = $cuenta->all($where, ['codcuenta' => 'ASC'], 0, 0);
+        $accounts = $cuenta->all($this->getAccountWhere($params), ['codcuenta' => 'ASC'], 0, 0);
 
         /// get subaccounts
         $subcuenta = new Subcuenta();
-        $subaccounts = $subcuenta->all($where, [], 0, 0);
+        $subaccounts = $subcuenta->all($this->getSubAccountWhere($params), [], 0, 0);
 
         /// get amounts
         $amounts = $this->getData($params);
@@ -214,6 +213,26 @@ class BalanceAmounts extends AccountingBase
     }
 
     /**
+     *
+     * @param array $params
+     * @return DataBaseWhere
+     */
+    protected function getAccountWhere(array $params = []) {
+        $where = [ new DataBaseWhere('codejercicio', $this->exercise->codejercicio) ];
+
+        $subaccountFrom = $params['subaccount-from'] ?? '';
+        if (!empty($subaccountFrom)) {
+            $where[] = new DataBaseWhere('codcuenta', substr($subaccountFrom, 0, 1), '>=');
+        }
+
+        $subaccountTo = $params['subaccount-to'] ?? '';
+        if (!empty($subaccountTo)) {
+            $where[] = new DataBaseWhere('codcuenta', substr($subaccountTo, 0, 4), '<=');
+        }
+        return $where;
+    }
+
+    /**
      * @param array $params
      *
      * @return string
@@ -242,12 +261,35 @@ class BalanceAmounts extends AccountingBase
         }
 
         $subaccountFrom = $params['subaccount-from'] ?? '';
-        $subaccountTo = $params['subaccount-to'] ?? $subaccountFrom;
-        if (!empty($subaccountFrom) || !empty($subaccountTo)) {
-            $where .= ' AND partidas.codsubcuenta BETWEEN ' . $this->dataBase->var2str($subaccountFrom)
-                . ' AND ' . $this->dataBase->var2str($subaccountTo);
+        if (!empty($subaccountFrom)) {
+            $where .= ' AND partidas.codsubcuenta >= ' . $this->dataBase->var2str($subaccountFrom);
         }
 
+        $subaccountTo = $params['subaccount-to'] ?? $subaccountFrom;
+        if (!empty($subaccountTo)) {
+            $where .= ' AND partidas.codsubcuenta <= ' . $this->dataBase->var2str($subaccountTo);
+        }
+
+        return $where;
+    }
+
+    /**
+     *
+     * @param array $params
+     * @return DataBaseWhere
+     */
+    protected function getSubAccountWhere(array $params = []) {
+        $where = [ new DataBaseWhere('codejercicio', $this->exercise->codejercicio) ];
+
+        $subaccountFrom = $params['subaccount-from'] ?? '';
+        if (!empty($subaccountFrom)) {
+            $where[] = new DataBaseWhere('codsubcuenta', $subaccountFrom, '>=');
+        }
+
+        $subaccountTo = $params['subaccount-to'] ?? '';
+        if (!empty($subaccountTo)) {
+            $where[] = new DataBaseWhere('codsubcuenta', $subaccountTo, '<=');
+        }
         return $where;
     }
 

--- a/Core/Lib/ExtendedController/EditReportAccounting.php
+++ b/Core/Lib/ExtendedController/EditReportAccounting.php
@@ -22,7 +22,7 @@ namespace FacturaScripts\Core\Lib\ExtendedController;
  * Class base for accounting reports
  *
  * @author Carlos Garcia Gomez <carlos@facturascripts.com>
- * @author Jose Antonio Cuello <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello <yopli2000@gmail.com>
  */
 abstract class EditReportAccounting extends EditController
 {
@@ -41,7 +41,7 @@ abstract class EditReportAccounting extends EditController
             $this->toolBox()->i18nLog()->warning('no-data');
             return;
         }
-        
+
         $title = $model->name;
         $this->setTemplate(false);
         $this->exportData($pages, $title, $format);


### PR DESCRIPTION
Fixed error when a subaccount was reported from or to but its complementary (from / to) was not reported.

Fixed the calculation so that it does not calculate accounts and subaccounts that are not in the range of the filter applied by the user.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
