### PR TITLE
[FIX] Error en traducción en documentos PDF

### DIFF
--- a/Core/Lib/Export/PDFExport.php
+++ b/Core/Lib/Export/PDFExport.php
@@ -225,6 +225,7 @@ class PDFExport extends PDFDocument
      */
     public function newDoc(string $title, int $idformat, string $langcode)
     {
+        $this->lineHeadersTranslate($langcode);
         $this->setFileName($title);
 
         if (!empty($idformat)) {

--- a/Core/Lib/Export/PDFExport.php
+++ b/Core/Lib/Export/PDFExport.php
@@ -225,7 +225,7 @@ class PDFExport extends PDFDocument
      */
     public function newDoc(string $title, int $idformat, string $langcode)
     {
-        $this->lineHeadersTranslate($langcode);
+        
         $this->setFileName($title);
 
         if (!empty($idformat)) {
@@ -236,6 +236,7 @@ class PDFExport extends PDFDocument
         if (!empty($langcode)) {
             $this->i18n->setLang($langcode);
         }
+        $this->lineHeadersTranslate();
     }
 
     /**

--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -629,10 +629,7 @@ abstract class PDFDocument extends PDFCore
         }
     }
     
-    protected function lineHeadersTranslate (string $code="") {
-        if(!empty($code)) {
-            $this->i18n->setLang($code);
-        }
+    protected function lineHeadersTranslate () {    
         $this->lineHeaders = [
             'referencia' => ['type' => 'text', 'title' => $this->i18n->trans('reference') . ' - ' . $this->i18n->trans('description')],
             'cantidad' => ['type' => 'number', 'title' => $this->i18n->trans('quantity')],

--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -63,17 +63,7 @@ abstract class PDFDocument extends PDFCore
     public function __construct()
     {
         parent::__construct();
-        $this->lineHeaders = [
-            'referencia' => ['type' => 'text', 'title' => $this->i18n->trans('reference') . ' - ' . $this->i18n->trans('description')],
-            'cantidad' => ['type' => 'number', 'title' => $this->i18n->trans('quantity')],
-            'pvpunitario' => ['type' => 'number', 'title' => $this->i18n->trans('price')],
-            'dtopor' => ['type' => 'percentage', 'title' => $this->i18n->trans('dto')],
-            'dtopor2' => ['type' => 'percentage', 'title' => $this->i18n->trans('dto-2')],
-            'pvptotal' => ['type' => 'number', 'title' => $this->i18n->trans('net')],
-            'iva' => ['type' => 'percentage', 'title' => $this->i18n->trans('tax')],
-            'recargo' => ['type' => 'percentage', 'title' => $this->i18n->trans('re')],
-            'irpf' => ['type' => 'percentage', 'title' => $this->i18n->trans('irpf')]
-        ];
+        $this->lineHeadersTranslate();
     }
 
     /**
@@ -637,5 +627,22 @@ abstract class PDFDocument extends PDFCore
             $this->pdf->ezText("\n");
             $this->pdf->ezTable($rows, $headers, '', $tableOptions);
         }
+    }
+    
+    protected function lineHeadersTranslate (string $code="") {
+        if(!empty($code)) {
+            $this->i18n->setLang($code);
+        }
+        $this->lineHeaders = [
+            'referencia' => ['type' => 'text', 'title' => $this->i18n->trans('reference') . ' - ' . $this->i18n->trans('description')],
+            'cantidad' => ['type' => 'number', 'title' => $this->i18n->trans('quantity')],
+            'pvpunitario' => ['type' => 'number', 'title' => $this->i18n->trans('price')],
+            'dtopor' => ['type' => 'percentage', 'title' => $this->i18n->trans('dto')],
+            'dtopor2' => ['type' => 'percentage', 'title' => $this->i18n->trans('dto-2')],
+            'pvptotal' => ['type' => 'number', 'title' => $this->i18n->trans('net')],
+            'iva' => ['type' => 'percentage', 'title' => $this->i18n->trans('tax')],
+            'recargo' => ['type' => 'percentage', 'title' => $this->i18n->trans('re')],
+            'irpf' => ['type' => 'percentage', 'title' => $this->i18n->trans('irpf')]
+        ];
     }
 }


### PR DESCRIPTION
Cuando exportas un documento (factura, albarán,etc.) y eliges un idioma al que traducir el documento PDF, la cabecera de la tabla con las líneas de productos no es traducida. Esta cabecera siempre es traducida con el idioma del usuario que está imprimiendo el documento.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [ ] Database with random data
