### PR TITLE
Fix loadPageOption for selected user

### DIFF
--- a/Core/Model/PageOption.php
+++ b/Core/Model/PageOption.php
@@ -22,7 +22,7 @@ namespace FacturaScripts\Core\Model;
  * Visual configuration of the FacturaScripts views,
  * each PageOption corresponds to a view or tab.
  *
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello  <yopli2000@gmail.com>
  * @author Carlos García Gómez  <carlos@facturascripts.com>
  */
 class PageOption extends Base\ModelClass


### PR DESCRIPTION
Fixed problem loading display options.
The correct operation is:
- If a user is selected, its configuration is loaded, the configuration common to all users or if none of the above cases exist, the xml view is loaded.

- If all users are selected, the configuration common to all users is loaded or if it does not exist, the xml view is loaded.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
