### PR TITLE
fix supplier receipt date

### DIFF
--- a/Core/Lib/ReceiptGenerator.php
+++ b/Core/Lib/ReceiptGenerator.php
@@ -236,6 +236,7 @@ class ReceiptGenerator
         $newReceipt->importe = $amount;
         $newReceipt->nick = $invoice->nick;
         $newReceipt->numero = $number;
+        $newReceipt->fecha = $invoice->fecha;
         $newReceipt->setPaymentMethod($invoice->codpago);
         $newReceipt->disableInvoiceUpdate(true);
         return $newReceipt->save();


### PR DESCRIPTION
This change fixes the supplier receipt date and now the receipt date is the same as the invoice date. This also fixes the expiration time that now is generated from the invoice date instead of from the date the receipt was created.


- [X] MySQL
- [ ] PostgreSQL
- [X] Clean database
- [X] Database with random data