### PR TITLE
Load first default settings

### DIFF
--- a/Core/Controller/EditSettings.php
+++ b/Core/Controller/EditSettings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2021 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2022 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -30,7 +30,7 @@ use FacturaScripts\Dinamic\Model\Impuesto;
 /**
  * Controller to edit main settings
  *
- * @author Artex Trading sa     <jcuello@artextrading.com>
+ * @author Jose Antonio Cuello  <yopli2000@gmail.com>
  * @author Carlos Garcia Gomez  <carlos@facturascripts.com>
  */
 class EditSettings extends PanelController
@@ -50,23 +50,6 @@ class EditSettings extends PanelController
         $data['title'] = 'control-panel';
         $data['icon'] = 'fas fa-tools';
         return $data;
-    }
-
-    /**
-     * Return a list of all XML settings files on XMLView folder.
-     *
-     * @return array
-     */
-    private function allSettingsXMLViews()
-    {
-        $names = [];
-        foreach ($this->toolBox()->files()->scanFolder(\FS_FOLDER . '/Dinamic/XMLView') as $fileName) {
-            if (0 === \strpos($fileName, self::KEY_SETTINGS)) {
-                $names[] = \substr($fileName, 0, -4);
-            }
-        }
-
-        return $names;
     }
 
     /**
@@ -171,6 +154,9 @@ class EditSettings extends PanelController
 
     /**
      * Load views
+     *
+     * Put the Default first in the list.
+     * Then we process all the views that start with Settings.
      */
     protected function createViews()
     {
@@ -178,24 +164,17 @@ class EditSettings extends PanelController
 
         $modelName = 'Settings';
         $icon = $this->getPageData()['icon'];
+
+        $this->createViewsSettings('SettingsDefault', $modelName, $icon);
+
         foreach ($this->allSettingsXMLViews() as $name) {
-            $title = $this->getKeyFromViewName($name);
-            $this->addEditView($name, $modelName, $title, $icon);
-
-            // change icon
-            $groups = $this->views[$name]->getColumns();
-            foreach ($groups as $group) {
-                if (!empty($group->icon)) {
-                    $this->views[$name]->icon = $group->icon;
-                    break;
-                }
+            if ($name === 'SettingsDefault') {
+                continue;
             }
-
-            // disable buttons
-            $this->setSettings($name, 'btnDelete', false);
-            $this->setSettings($name, 'btnNew', false);
+            $this->createViewsSettings($name, $modelName, $icon);
         }
 
+        /// Others configuration views.
         $this->createViewsApiKeys();
         $this->createViewsIdFiscal();
         $this->createViewSequences();
@@ -238,6 +217,32 @@ class EditSettings extends PanelController
         $this->createDocTypeFilter($viewName);
         $this->views[$viewName]->addFilterSelect('idempresa', 'company', 'idempresa', Empresas::codeModel());
         $this->views[$viewName]->addFilterSelect('codserie', 'serie', 'codserie', Series::codeModel());
+    }
+
+    /**
+     * Add a view settings.
+     * 
+     * @param type $name
+     * @param type $model
+     * @param type $icon
+     */
+    protected function createViewsSettings($name, $model, $icon)
+    {
+        $title = $this->getKeyFromViewName($name);
+        $this->addEditView($name, $model, $title, $icon);
+
+        /// change icon
+        $groups = $this->views[$name]->getColumns();
+        foreach ($groups as $group) {
+            if (!empty($group->icon)) {
+                $this->views[$name]->icon = $group->icon;
+                break;
+            }
+        }
+
+        /// disable buttons
+        $this->setSettings($name, 'btnDelete', false);
+        $this->setSettings($name, 'btnNew', false);
     }
 
     /**
@@ -331,18 +336,6 @@ class EditSettings extends PanelController
     }
 
     /**
-     * Returns the view id for a specified $viewName
-     *
-     * @param string $viewName
-     *
-     * @return string
-     */
-    private function getKeyFromViewName($viewName)
-    {
-        return \strtolower(\substr($viewName, \strlen(self::KEY_SETTINGS)));
-    }
-
-    /**
      * Load view data
      *
      * @param string $viewName
@@ -410,5 +403,34 @@ class EditSettings extends PanelController
         if ($columnWarehouse && $columnWarehouse->widget->getType() === 'select') {
             $columnWarehouse->widget->setValuesFromCodeModel($almacenes);
         }
+    }
+
+    /**
+     * Return a list of all XML settings files on XMLView folder.
+     *
+     * @return array
+     */
+    private function allSettingsXMLViews()
+    {
+        $names = [];
+        foreach ($this->toolBox()->files()->scanFolder(\FS_FOLDER . '/Dinamic/XMLView') as $fileName) {
+            if (0 === \strpos($fileName, self::KEY_SETTINGS)) {
+                $names[] = \substr($fileName, 0, -4);
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Returns the view id for a specified $viewName
+     *
+     * @param string $viewName
+     *
+     * @return string
+     */
+    private function getKeyFromViewName($viewName)
+    {
+        return \strtolower(\substr($viewName, \strlen(self::KEY_SETTINGS)));
     }
 }


### PR DESCRIPTION
Refactored controller so that it loads the defaults view first and then the list of views for plugin configuration.
Additionally, the private methods have been moved to the end of the file, just after the protected methods.

## How has this been tested?

- [x] MySQL
- [x] Database with random data
