### PR TITLE
Añadido método unistall para poder ejecutar código después de desinta…

### DIFF
--- a/Core/Base/InitClass.php
+++ b/Core/Base/InitClass.php
@@ -39,6 +39,11 @@ abstract class InitClass
     abstract public function update();
 
     /**
+     * Code that is executed when uninstalling a plugin.
+     */
+    public function unistall(){}
+
+    /**
      * 
      * @return string
      */

--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -119,6 +119,15 @@ final class PluginManager
             $this->disableByDependency($pluginName);
             $this->save();
             $this->deploy(true, true);
+
+            $pluginClass = "FacturaScripts\\Plugins\\$pluginName\\Init";
+            if (class_exists($pluginClass)) {
+                $initObject = new $pluginClass();
+                if (method_exists($initObject, 'unistall')) {
+                    $initObject->unistall();
+                }
+            }
+
             ToolBox::i18nLog()->notice('plugin-disabled', ['%pluginName%' => $pluginName]);
             return true;
         }


### PR DESCRIPTION
…lar un plugin.

Añade la opción de poder definir un método unistall en el init del plugin que se ejecutará después de desinstalar el plugin.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->