### PR TITLE
Añadido soporte de extensión al método test del ModelClass.php

### DIFF
--- a/Core/Model/Base/ModelClass.php
+++ b/Core/Model/Base/ModelClass.php
@@ -276,6 +276,10 @@ abstract class ModelClass extends ModelCore
      */
     public function test()
     {
+        if ($this->pipe('testBefore') === false) {
+            return false;
+        }
+
         $fields = $this->getModelFields();
         if (empty($fields)) {
             return false;
@@ -291,6 +295,7 @@ abstract class ModelClass extends ModelCore
             }
         }
 
+        $this->pipe('test');
         return $return;
     }
 


### PR DESCRIPTION
Your PR description goes here.

Añadido soporte de extensiones al método test de los modelos, se puede introducir un testBefore para ejecutar el código antes del test del modelo y otro al final del mismo método.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->