### PR TITLE
Permite usar parámetros en el onclick de los widget.

### DIFF
--- a/Core/Lib/Widget/BaseWidget.php
+++ b/Core/Lib/Widget/BaseWidget.php
@@ -263,7 +263,8 @@ class BaseWidget extends VisualItem
             return empty($titleurl) ? $inside : '<a href="' . $titleurl . '">' . $inside . '</a>';
         }
 
-        return '<a href="' . FS_ROUTE . '/' . $this->onclick . '?code=' . rawurlencode($this->value)
+        $params = strpos($this->onclick, '?') !== false ? '&' : '?';
+        return '<a href="' . FS_ROUTE . '/' . $this->onclick . $params . 'code=' . rawurlencode($this->value)
             . '" class="cancelClickable">' . $inside . '</a>';
     }
 


### PR DESCRIPTION
Your PR description goes here.

Permite usar parámetros adiciones en el onclick de los widget. Por ejemplo si queremos que al pinchar vaya a otro controlador pero dentro de una pestaña, pondriamos esto: onclick="EditCliente?activetab=direcciones". De este modo detecta que se esta usando el carácter '?' y en vez de ponerlo 2 veces como hace ahora lo pondría una vez, y el code iría separado con '&'.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->