### PR TITLE
Evitar juntar documentos con el descuento general diferente.

### DIFF
--- a/Core/Controller/DocumentStitcher.php
+++ b/Core/Controller/DocumentStitcher.php
@@ -160,6 +160,8 @@ class DocumentStitcher extends Controller
             if ($doc->codalmacen != $newDoc->codalmacen ||
                 $doc->coddivisa != $newDoc->coddivisa ||
                 $doc->idempresa != $newDoc->idempresa ||
+                $doc->dtopor1 != $newDoc->dtopor1 ||
+                $doc->dtopor2 != $newDoc->dtopor2 ||
                 $doc->subjectColumnValue() != $newDoc->subjectColumnValue()) {
                 $this->toolBox()->i18nLog()->warning('incompatible-document', ['%code%' => $newDoc->codigo]);
                 return false;


### PR DESCRIPTION
Your PR description goes here.

Evitar juntar documentos cuanto el dtopor1 o el dtopor2 son diferentes. Se debe actualizar también la traducción "incompatible-document" una vez aprobado el pr.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->