### PR TITLE
Tarea #517 - Renombrar método getAvaliableStatus() a getAvailableStatus()

### DIFF
--- a/Core/Controller/EditFacturaCliente.php
+++ b/Core/Controller/EditFacturaCliente.php
@@ -277,7 +277,7 @@ class EditFacturaCliente extends SalesDocumentController
         $this->dataBase->beginTransaction();
 
         if ($invoice->editable) {
-            foreach ($invoice->getAvaliableStatus() as $status) {
+            foreach ($invoice->getAvailableStatus() as $status) {
                 if ($status->editable) {
                     continue;
                 }

--- a/Core/Controller/EditFacturaProveedor.php
+++ b/Core/Controller/EditFacturaProveedor.php
@@ -277,7 +277,7 @@ class EditFacturaProveedor extends PurchaseDocumentController
         $this->dataBase->beginTransaction();
 
         if ($invoice->editable) {
-            foreach ($invoice->getAvaliableStatus() as $status) {
+            foreach ($invoice->getAvailableStatus() as $status) {
                 if ($status->editable) {
                     continue;
                 }

--- a/Core/Controller/ListPresupuestoCliente.php
+++ b/Core/Controller/ListPresupuestoCliente.php
@@ -86,7 +86,7 @@ class ListPresupuestoCliente extends ListBusinessDocument
 
         // select the available expired status
         $expiredStatus = null;
-        foreach ($model->getAvaliableStatus() as $status) {
+        foreach ($model->getAvailableStatus() as $status) {
             if ($status->idestado == 23 && !$status->editable && empty($status->generadoc)) {
                 $expiredStatus = $status->idestado;
                 break;

--- a/Core/Lib/Accounting/ClosingToAcounting.php
+++ b/Core/Lib/Accounting/ClosingToAcounting.php
@@ -200,7 +200,7 @@ class ClosingToAcounting
     {
         /// apply to customer invoices
         $customerInvoice = new FacturaCliente();
-        $status1 = $customerInvoice->getAvaliableStatus();
+        $status1 = $customerInvoice->getAvailableStatus();
         $where = [
             new DataBaseWhere('editable', true),
             new DataBaseWhere('codejercicio', $this->exercise->codejercicio)
@@ -221,7 +221,7 @@ class ClosingToAcounting
 
         /// apply to supplier invoices
         $supplierInvoice = new FacturaProveedor();
-        $status2 = $supplierInvoice->getAvaliableStatus();
+        $status2 = $supplierInvoice->getAvailableStatus();
         foreach ($status2 as $stat) {
             if ($stat->editable || $stat->generadoc) {
                 continue;

--- a/Core/Lib/ExtendedController/BusinessDocumentView.php
+++ b/Core/Lib/ExtendedController/BusinessDocumentView.php
@@ -69,7 +69,7 @@ class BusinessDocumentView extends BaseView
     public function __construct(string $name, string $title, string $modelName, string $icon = 'fas fa-file')
     {
         parent::__construct($name, $title, $modelName, $icon);
-        $this->documentStatus = $this->model->getAvaliableStatus();
+        $this->documentStatus = $this->model->getAvailableStatus();
     }
 
     /**

--- a/Core/Lib/ExtendedController/ListBusinessActionTrait.php
+++ b/Core/Lib/ExtendedController/ListBusinessActionTrait.php
@@ -131,7 +131,7 @@ trait ListBusinessActionTrait
                 continue;
             }
 
-            foreach ($model->getAvaliableStatus() as $status) {
+            foreach ($model->getAvailableStatus() as $status) {
                 if (empty($status->generadoc)) {
                     continue;
                 }
@@ -201,7 +201,7 @@ trait ListBusinessActionTrait
                 continue;
             }
 
-            foreach ($model->getAvaliableStatus() as $status) {
+            foreach ($model->getAvailableStatus() as $status) {
                 if ($status->editable) {
                     continue;
                 }

--- a/Core/Model/Base/TransformerDocument.php
+++ b/Core/Model/Base/TransformerDocument.php
@@ -103,7 +103,7 @@ abstract class TransformerDocument extends BusinessDocument
         $this->editable = true;
 
         // select default status
-        foreach ($this->getAvaliableStatus() as $status) {
+        foreach ($this->getAvailableStatus() as $status) {
             if ($status->predeterminado) {
                 $this->idestado = $status->idestado;
                 $this->editable = $status->editable;
@@ -153,7 +153,7 @@ abstract class TransformerDocument extends BusinessDocument
 
         // change parent doc status
         foreach ($parents as $parent) {
-            foreach ($parent->getAvaliableStatus() as $status) {
+            foreach ($parent->getAvailableStatus() as $status) {
                 if ($status->predeterminado) {
                     $parent->idestado = $status->idestado;
                     $parent->save();
@@ -183,7 +183,7 @@ abstract class TransformerDocument extends BusinessDocument
      *
      * @return EstadoDocumento[]
      */
-    public function getAvaliableStatus()
+    public function getAvailableStatus()
     {
         if (null === self::$estados) {
             $statusModel = new EstadoDocumento();


### PR DESCRIPTION
Your PR description goes here.

Renombrar método getAvaliableStatus() a getAvailableStatus() tanto en la clase TransformerDocument como en todas las llamadas a este método.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->