### PR TITLE
Tarea #685 - Corregido bug que impedía guardar filtros con valor 0.

### DIFF
--- a/Core/Lib/ExtendedController/ListViewFiltersTrait.php
+++ b/Core/Lib/ExtendedController/ListViewFiltersTrait.php
@@ -199,12 +199,11 @@ trait ListViewFiltersTrait
     public function savePageFilter(Request $request, User $user): int
     {
         $pageFilter = new PageFilter();
-
         // Set values data filter
         foreach ($this->filters as $filter) {
             $name = $filter->name();
             $value = $request->request->get($name, null);
-            if (!empty($value)) {
+            if (!is_null($value)) {
                 $pageFilter->filters[$name] = $value;
             }
         }


### PR DESCRIPTION
Your PR description goes here.

Cuando se guarda un filtro si una de las opciones marcada para guardar su valor es 0 no se guardaba dicha opción, ahora con este cambio si se guarda.

[Tarea #685](https://facturascripts.com/roadmap/EditTask?code=685)

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->