### PR TITLE
Fix Button Spinner view

### DIFF
--- a/Core/View/Master/btnLoading.html.twig
+++ b/Core/View/Master/btnLoading.html.twig
@@ -58,4 +58,8 @@
                 parseFloat(spinner.css('animation-duration')) * 1000)
         );
     }
+	
+    function existSpinner (btn) {
+        return btn.find('div.spinner').length !== 0;
+    }
 </script>

--- a/Core/View/Tab/AccountingEntry.html.twig
+++ b/Core/View/Tab/AccountingEntry.html.twig
@@ -25,7 +25,7 @@
     }
 
     function accEntryFormAction(action, selectedLine, btn = '') {
-        if (btn !== '') {
+        if (btn !== '' && !existSpinner(btn)) {
             animateSpinner(btn, 'add');
         }
 


### PR DESCRIPTION
View of the Spinner button fixed. When using a button with the Spinner, the accEntryFormAction function adds as many Spinners as queries to the model. With this modification the behaviour is fixed and only change the icon by the Spinner once.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
