### PR TITLE
Fix ListCliente controller

### DIFF
--- a/Core/Controller/ListCliente.php
+++ b/Core/Controller/ListCliente.php
@@ -98,6 +98,15 @@ class ListCliente extends ListController
         $this->addOrderBy($viewName, ['fechaalta'], 'creation-date', 2);
 
         // filters
+        $values = [
+            [
+                'label' => $this->toolBox()->i18n()->trans('client'),
+                'where' => [new DataBaseWhere('codcliente', null, 'IS NOT')]
+            ]
+        ];
+        $this->addFilterSelectWhere($viewName, 'type', $values);
+		
+		// filters
         $this->addFilterSelect($viewName, 'codpais', 'country', 'codpais', Paises::codeModel());
 
         $provinces = $this->codeModel->all('contactos', 'provincia', 'provincia');


### PR DESCRIPTION
Fix filter select where in ListCliente. Error identified in Cuestion #4837.

When you go to the list of contact addresses in clients it shows you a complete list of addresses, both clients and suppliers. A filter is added to show only the list of customer addresses.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data