### PR TITLE
Tarea #783 - cambio diseño de los formularios de compras y ventas

### DIFF
--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -27,8 +27,8 @@ trait CommonLineHTML
         $attributes = $model->editable && false === $line->suplido ?
             'name="iva_' . $idlinea . '" onchange="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"' :
             'disabled=""';
-        return '<div class="col-sm-2 col-lg-1 px-0 order-6">'
-            . '<div class="mb-1 small">' . $i18n->trans('tax')
+        return '<div class="col-sm col-md col-lg-1 px-0 order-6">'
+            . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('tax') . '</span>'
             . '<select ' . $attributes . ' class="form-control form-control-sm rounded-0">' . implode('', $options) . '</select>'
             . '</div>'
             . '</div>';
@@ -43,6 +43,16 @@ trait CommonLineHTML
             $rows += mb_strlen($desLine) < 140 ? 1 : ceil(mb_strlen($desLine) / 140);
         }
 
+        $columnMd = empty($line->referencia) ? 12 : 10;
+        return '<div class="col-sm-8 col-md-' . $columnMd . ' col-lg px-0 order-1">'
+            . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('description') . '</span>'
+            . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
+            . '</div>'
+            . '</div>';
+    }
+
+    protected static function referencia(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string
+    {
         $sortable = $model->editable ?
             '<input type="hidden" name="orden_' . $idlinea . '" value="' . $line->orden . '"/>' :
             '';
@@ -50,18 +60,15 @@ trait CommonLineHTML
         $variante = new Variante();
         $where = [new DataBaseWhere('referencia', $line->referencia)];
         if (empty($line->referencia) || false === $variante->loadFromCode('', $where)) {
-            return '<div class="col-sm-4 col-lg px-0 order-1">'
-                . '<div class="mb-1 small">' . $sortable . $i18n->trans('description')
-                . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
-                . '</div>'
+            return '<div class="col-sm-2 col-md-2 col-lg-1 px-0 order-1">'
+                . $sortable
                 . '</div>';
         }
 
-        return '<div class="col-sm-4 col-lg px-0 order-1">'
-            . '<div class="mb-1 small">'
+        return '<div class="col-sm-2 col-md-2 col-lg-1 pl-0 text-break align-self-start order-1">'
+            . '<div class="mb-1 small"><div class="d-lg-none text-truncate">' . $i18n->trans('reference') . '</div>'
             . $sortable . '<a href="' . $variante->url() . '">' . $line->referencia . '</a>'
             . '<input type="hidden" name="referencia_' . $idlinea . '" value="' . $line->referencia . '"/>'
-            . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
             . '</div>'
             . '</div>';
     }
@@ -71,8 +78,8 @@ trait CommonLineHTML
         $attributes = $model->editable ?
             'name="dtopor_' . $idlinea . '" min="0" max="100" step="1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"' :
             'disabled=""';
-        return '<div class="col-sm-2 col-xl-1 px-0 order-5">'
-            . '<div class="mb-1 small">' . $i18n->trans('percentage-discount')
+        return '<div class="col-sm col-md col-lg-1 px-0 order-5">'
+            . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('percentage-discount') . '</span>'
             . '<input type="number" ' . $attributes . ' value="' . $line->dtopor . '" class="form-control form-control-sm rounded-0"/>'
             . '</div>'
             . '</div>';
@@ -116,8 +123,8 @@ trait CommonLineHTML
     protected static function lineTotal(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string
     {
         $total = $line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100;
-        return '<div class="col-sm-2 col-xl-1 px-0 order-7">'
-            . '<div class="mb-1 small">' . $i18n->trans('subtotal')
+        return '<div class="col-sm col-md col-lg-1 px-0 order-7">'
+            . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('subtotal') . '</span>'
             . '<input type="number" name="linetotal_' . $idlinea . '"  value="' . $total . '" class="form-control form-control-sm rounded-0" readonly/>'
             . '</div>'
             . '</div>';
@@ -145,7 +152,7 @@ trait CommonLineHTML
             return '';
         }
 
-        return '<div class="col-sm-auto px-0 order-8">'
+        return '<div class="col-auto col-sm-auto px-0 order-8">'
             . '<button class="btn btn-outline-secondary btn-sm rounded-0 mb-1" type="button"'
             . ' onclick="' . $jsName . '(\'' . $idlinea . '\')"><i class="fas fa-calculator"></i></button>'
             . '</div>';
@@ -154,7 +161,7 @@ trait CommonLineHTML
     protected static function renderExpandButton(Translator $i18n, string $idlinea, TransformerDocument $model, string $jsName): string
     {
         if ($model->editable) {
-            return '<div class="col-sm-auto px-0 order-9">'
+            return '<div class="col-auto col-sm-auto px-0 order-9">'
                 . '<button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-sm btn-outline-secondary rounded-0 mb-1" title="'
                 . $i18n->trans('more') . '"><i class="fas fa-ellipsis-h"></i></button>'
                 . '<button class="btn btn-sm btn-outline-danger btn-spin-action rounded-0 mb-1" type="button" title="' . $i18n->trans('delete') . '"'
@@ -163,7 +170,7 @@ trait CommonLineHTML
                 . '</div>';
         }
 
-        return '<div class="col-sm-auto px-0 order-9"><button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-sm btn-outline-secondary rounded-0 mb-1" title="'
+        return '<div class="col-auto col-sm-auto px-0 order-9"><button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-sm btn-outline-secondary rounded-0 mb-1" title="'
             . $i18n->trans('more') . '"><i class="fas fa-ellipsis-h"></i></button></div>';
     }
 

--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -43,7 +43,7 @@ trait CommonLineHTML
             $rows += mb_strlen($desLine) < 140 ? 1 : ceil(mb_strlen($desLine) / 140);
         }
 
-        $columnMd = empty($line->referencia) ? 12 : 10;
+        $columnMd = empty($line->referencia) ? 12 : 8;
         $columnSm = empty($line->referencia) ? 10 : 8;
         return '<div class="col-sm-' . $columnSm . ' col-md-' . $columnMd . ' col-lg px-0 order-2">'
             . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('description') . '</span>'
@@ -61,7 +61,9 @@ trait CommonLineHTML
         $variante = new Variante();
         $where = [new DataBaseWhere('referencia', $line->referencia)];
         if (empty($line->referencia) || false === $variante->loadFromCode('', $where)) {
-            return '<div>' . $sortable . '</div>';
+            return '<div class="d-none d-lg-block col-sm-2 col-md-2 col-lg-1 px-0 order-1">'
+                . $sortable
+                . '</div>';
         }
 
         return '<div class="col-sm-2 col-md-2 col-lg-1 pl-0 text-break align-self-start order-1">'

--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -27,9 +27,9 @@ trait CommonLineHTML
         $attributes = $model->editable && false === $line->suplido ?
             'name="iva_' . $idlinea . '" onchange="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"' :
             'disabled=""';
-        return '<div class="col-sm-2 col-lg-1 order-6">'
+        return '<div class="col-sm-2 col-lg-1 px-0 order-6">'
             . '<div class="mb-1 small">' . $i18n->trans('tax')
-            . '<select ' . $attributes . ' class="form-control">' . implode('', $options) . '</select>'
+            . '<select ' . $attributes . ' class="form-control form-control-sm rounded-0">' . implode('', $options) . '</select>'
             . '</div>'
             . '</div>';
     }
@@ -50,18 +50,18 @@ trait CommonLineHTML
         $variante = new Variante();
         $where = [new DataBaseWhere('referencia', $line->referencia)];
         if (empty($line->referencia) || false === $variante->loadFromCode('', $where)) {
-            return '<div class="col-sm-4 col-lg order-1">'
+            return '<div class="col-sm-4 col-lg px-0 order-1">'
                 . '<div class="mb-1 small">' . $sortable . $i18n->trans('description')
-                . '<textarea ' . $attributes . ' class="form-control doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
+                . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
                 . '</div>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-4 col-lg order-1">'
+        return '<div class="col-sm-4 col-lg px-0 order-1">'
             . '<div class="mb-1 small">'
             . $sortable . '<a href="' . $variante->url() . '">' . $line->referencia . '</a>'
             . '<input type="hidden" name="referencia_' . $idlinea . '" value="' . $line->referencia . '"/>'
-            . '<textarea ' . $attributes . ' class="form-control doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
+            . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
             . '</div>'
             . '</div>';
     }
@@ -71,9 +71,9 @@ trait CommonLineHTML
         $attributes = $model->editable ?
             'name="dtopor_' . $idlinea . '" min="0" max="100" step="1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"' :
             'disabled=""';
-        return '<div class="col-sm-2 col-xl-1 order-5">'
+        return '<div class="col-sm-2 col-xl-1 px-0 order-5">'
             . '<div class="mb-1 small">' . $i18n->trans('percentage-discount')
-            . '<input type="number" ' . $attributes . ' value="' . $line->dtopor . '" class="form-control"/>'
+            . '<input type="number" ' . $attributes . ' value="' . $line->dtopor . '" class="form-control form-control-sm rounded-0"/>'
             . '</div>'
             . '</div>';
     }
@@ -116,9 +116,9 @@ trait CommonLineHTML
     protected static function lineTotal(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string
     {
         $total = $line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100;
-        return '<div class="col-sm-2 col-xl-1 order-7">'
+        return '<div class="col-sm-2 col-xl-1 px-0 order-7">'
             . '<div class="mb-1 small">' . $i18n->trans('subtotal')
-            . '<input type="number" name="linetotal_' . $idlinea . '"  value="' . $total . '" class="form-control" readonly/>'
+            . '<input type="number" name="linetotal_' . $idlinea . '"  value="' . $total . '" class="form-control form-control-sm rounded-0" readonly/>'
             . '</div>'
             . '</div>';
     }
@@ -145,8 +145,8 @@ trait CommonLineHTML
             return '';
         }
 
-        return '<div class="col-sm-auto order-8">'
-            . '<button class="btn btn-outline-secondary mb-1" type="button"'
+        return '<div class="col-sm-auto px-0 order-8">'
+            . '<button class="btn btn-outline-secondary btn-sm rounded-0 mb-1" type="button"'
             . ' onclick="' . $jsName . '(\'' . $idlinea . '\')"><i class="fas fa-calculator"></i></button>'
             . '</div>';
     }
@@ -154,16 +154,16 @@ trait CommonLineHTML
     protected static function renderExpandButton(Translator $i18n, string $idlinea, TransformerDocument $model, string $jsName): string
     {
         if ($model->editable) {
-            return '<div class="col-sm-auto order-9">'
-                . '<button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-outline-secondary mb-1" title="'
+            return '<div class="col-sm-auto px-0 order-9">'
+                . '<button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-sm btn-outline-secondary rounded-0 mb-1" title="'
                 . $i18n->trans('more') . '"><i class="fas fa-ellipsis-h"></i></button>'
-                . '<button class="btn btn-outline-danger btn-spin-action ml-2 mb-1" type="button" title="' . $i18n->trans('delete') . '"'
+                . '<button class="btn btn-sm btn-outline-danger btn-spin-action rounded-0 mb-1" type="button" title="' . $i18n->trans('delete') . '"'
                 . ' onclick="return ' . $jsName . '(\'rm-line\', \'' . $idlinea . '\');">'
                 . '<i class="fas fa-trash-alt"></i></button>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-auto order-9"><button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-outline-secondary mb-1" title="'
+        return '<div class="col-sm-auto px-0 order-9"><button type="button" data-toggle="modal" data-target="#lineModal-' . $idlinea . '" class="btn btn-sm btn-outline-secondary rounded-0 mb-1" title="'
             . $i18n->trans('more') . '"><i class="fas fa-ellipsis-h"></i></button></div>';
     }
 

--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -44,7 +44,7 @@ trait CommonLineHTML
         }
 
         $columnMd = empty($line->referencia) ? 12 : 10;
-        return '<div class="col-sm-8 col-md-' . $columnMd . ' col-lg px-0 order-1">'
+        return '<div class="col-sm-8 col-md-' . $columnMd . ' col-lg px-0 order-2">'
             . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('description') . '</span>'
             . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
             . '</div>'

--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -44,7 +44,8 @@ trait CommonLineHTML
         }
 
         $columnMd = empty($line->referencia) ? 12 : 10;
-        return '<div class="col-sm-8 col-md-' . $columnMd . ' col-lg px-0 order-2">'
+        $columnSm = empty($line->referencia) ? 10 : 8;
+        return '<div class="col-sm-' . $columnSm . ' col-md-' . $columnMd . ' col-lg px-0 order-2">'
             . '<div class="mb-1 small"><span class="d-lg-none">' . $i18n->trans('description') . '</span>'
             . '<textarea ' . $attributes . ' class="form-control form-control-sm rounded-0 doc-line-desc" rows="' . $rows . '">' . $line->descripcion . '</textarea>'
             . '</div>'
@@ -60,9 +61,7 @@ trait CommonLineHTML
         $variante = new Variante();
         $where = [new DataBaseWhere('referencia', $line->referencia)];
         if (empty($line->referencia) || false === $variante->loadFromCode('', $where)) {
-            return '<div class="col-sm-2 col-md-2 col-lg-1 px-0 order-1">'
-                . $sortable
-                . '</div>';
+            return '<div>' . $sortable . '</div>';
         }
 
         return '<div class="col-sm-2 col-md-2 col-lg-1 pl-0 text-break align-self-start order-1">'

--- a/Core/Base/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Base/AjaxForms/CommonSalesPurchases.php
@@ -206,7 +206,7 @@ trait CommonSalesPurchases
             . '<div class="input-group mb-3">'
             . '<div class="input-group-prepend"><span class="input-group-text"><i class="fas fa-barcode"></i></span></div>'
             . '<input type="text" name="fastli" class="form-control" placeholder="' . $i18n->trans('barcode')
-            . ' / ' . $i18n->trans('reference') . '" onkeyup="' . $jsName . '(event)"/>'
+            . '" onkeyup="' . $jsName . '(event)"/>'
             . '</div></div>' : '<div class="col-sm"></div>';
     }
 
@@ -452,11 +452,14 @@ trait CommonSalesPurchases
 
     protected static function productBtn(Translator $i18n, BusinessDocument $model): string
     {
-        return $model->editable ? '<div class="col-sm-6 col-md-auto">'
-            . '<a href="#" class="btn btn-info mb-3" onclick="$(\'#findProductModal\').modal(); $(\'#findProductInput\').focus(); return false;">'
-            . '<i class="fas fa-search fa-fw"></i> ' . $i18n->trans('products')
-            . '</a>'
-            . '</div>' : '';
+        return $model->editable ? '<div class="col-sm-6 col-md-3">'
+            . '<div class="input-group mb-3">'
+            . '<div class="input-group-prepend">'
+            . '<button class="btn btn-info" type="button" onclick="$(\'#findProductModal\').modal(); $(\'#findProductInput\').focus(); return false;"><i class="fas fa-search fa-fw"></i></button>'
+            . '</div>'
+            . '<input type="text" id="findProductInput" class="form-control" placeholder="' . $i18n->trans('reference') . '" />'
+            . '</div>'
+            . '</div>': '';
     }
 
     protected static function saveBtn(Translator $i18n, BusinessDocument $model, string $jsName): string

--- a/Core/Base/AjaxForms/PurchasesController.php
+++ b/Core/Base/AjaxForms/PurchasesController.php
@@ -15,6 +15,7 @@ use FacturaScripts\Core\Model\Base\PurchaseDocument;
 use FacturaScripts\Core\Model\Base\PurchaseDocumentLine;
 use FacturaScripts\Dinamic\Lib\AssetManager;
 use FacturaScripts\Dinamic\Model\Proveedor;
+use FacturaScripts\Dinamic\Model\Variante;
 
 /**
  * Description of PurchasesController
@@ -76,6 +77,28 @@ abstract class PurchasesController extends PanelController
         return Series::all();
     }
 
+    protected function autocompleteProductAction(): bool
+    {
+        $this->setTemplate(false);
+
+        $list = [];
+        $variante = new Variante();
+        $query = $this->request->get('term');
+        foreach ($variante->codeModelSearch($query, 'referencia') as $value) {
+            $list[] = [
+                'key' => $this->toolBox()->utils()->fixHtml($value->code),
+                'value' => $this->toolBox()->utils()->fixHtml($value->description)
+            ];
+        }
+
+        if (empty($list)) {
+            $list[] = ['key' => null, 'value' => $this->toolBox()->i18n()->trans('no-data')];
+        }
+
+        $this->response->setContent(\json_encode($list));
+        return false;
+    }
+
     protected function createViews()
     {
         $this->setTabsPosition('top');
@@ -118,8 +141,12 @@ abstract class PurchasesController extends PanelController
             case 'add-file':
                 return $this->addFileAction();
 
+            case 'autocomplete-product':
+                return $this->autocompleteProductAction();
+
             case 'add-product':
             case 'fast-line':
+            case 'fast-product':
             case 'new-line':
             case 'recalculate':
             case 'rm-line':

--- a/Core/Base/AjaxForms/PurchasesHeaderHTML.php
+++ b/Core/Base/AjaxForms/PurchasesHeaderHTML.php
@@ -102,7 +102,7 @@ class PurchasesHeaderHTML
             return '<div class="col-sm-3">'
                 . '<div class="form-group">' . $i18n->trans('supplier')
                 . '<input type="hidden" name="codproveedor" />'
-                . '<a href="#" class="btn btn-block btn-primary" onclick="$(\'#findSupplierModal\').modal();'
+                . '<a href="#" id="btnFindSupplierModal" class="btn btn-block btn-primary" onclick="$(\'#findSupplierModal\').modal();'
                 . ' $(\'#findSupplierInput\').focus(); return false;"><i class="fas fa-users fa-fw"></i> '
                 . $i18n->trans('select') . '</a>'
                 . '</div>'

--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -67,7 +67,7 @@ class PurchasesLineHTML
         }
 
         // add new line
-        if ($formData['action'] === 'add-product') {
+        if ($formData['action'] === 'add-product' || $formData['action'] === 'fast-product') {
             $lines[] = $model->getNewProductLine($formData['selectedLine']);
         } elseif ($formData['action'] === 'fast-line') {
             $newLine = static::getFastLine($model, $formData);
@@ -120,7 +120,7 @@ class PurchasesLineHTML
      */
     public static function render(array $lines, PurchaseDocument $model): string
     {
-        $html = '';
+        $html = self::renderTitles($model);
         foreach ($lines as $line) {
             $html .= self::renderLine($line, $model);
         }
@@ -138,6 +138,7 @@ class PurchasesLineHTML
         $cssClass = static::$num % 2 == 0 ? 'bg-white border-top' : 'bg-light border-top';
         return '<div class="' . $cssClass . ' line pl-2 pr-2">'
             . '<div class="form-row align-items-end">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'referencia')
             . self::renderField($i18n, $idlinea, $line, $model, 'descripcion')
             . self::renderField($i18n, $idlinea, $line, $model, 'cantidad')
             . self::renderNewFields($i18n, $idlinea, $line, $model)
@@ -149,45 +150,6 @@ class PurchasesLineHTML
             . self::renderExpandButton($i18n, $idlinea, $model, 'purchasesFormAction')
             . '</div>'
             . self::renderLineModal($i18n, $line, $idlinea, $model)
-            . '</div>';
-    }
-
-    private static function renderLineModal(Translator $i18n, PurchaseDocumentLine $line, string $idlinea, PurchaseDocument $model): string
-    {
-        return '<div class="modal fade" id="lineModal-' . $idlinea . '" tabindex="-1" aria-labelledby="lineModal-' . $idlinea . 'Label" aria-hidden="true">'
-            . '<div class="modal-dialog modal-dialog-centered">'
-            . '<div class="modal-content">'
-            . '<div class="modal-header">'
-            . '<h5 class="modal-title">'
-            . $line->referencia
-            . '</h5>'
-            . '<button type="button" class="close" data-dismiss="modal" aria-label="Close">'
-            . '<span aria-hidden="true">&times;</span>'
-            . '</button>'
-            . '</div>'
-            . '<div class="modal-body">'
-            . '<div class="form-row">'
-            . self::renderField($i18n, $idlinea, $line, $model, 'recargo')
-            . self::renderField($i18n, $idlinea, $line, $model, 'irpf')
-            . '</div>'
-            . '<div class="form-row">'
-            . self::renderField($i18n, $idlinea, $line, $model, 'suplido')
-            . self::renderField($i18n, $idlinea, $line, $model, 'dtopor2')
-            . '</div>'
-            . '<div class="form-row">'
-            . self::renderNewModalFields($i18n, $idlinea, $line, $model)
-            . '</div>'
-            . '</div>'
-            . '<div class="modal-footer">'
-            . '<button type="button" class="btn btn-secondary" data-dismiss="modal">'
-            . $i18n->trans('close')
-            . '</button>'
-            . '<button type="button" class="btn btn-primary" data-dismiss="modal">'
-            . $i18n->trans('accept')
-            . '</button>'
-            . '</div>'
-            . '</div>'
-            . '</div>'
             . '</div>';
     }
 
@@ -213,12 +175,14 @@ class PurchasesLineHTML
     protected static function cantidad(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 small px-0 order-2">' . $i18n->trans('quantity')
+            return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
+                . '<span class="d-lg-none">' . $i18n->trans('quantity') . '</span>'
                 . '<input type="number" class="form-control form-control-sm rounded-0 mb-1" value="' . $line->cantidad . '" disabled=""/>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-2 col-xl-1 small px-0 order-2">' . $i18n->trans('quantity')
+        return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
+            . '<span class="d-lg-none">' . $i18n->trans('quantity') . '</span>'
             . '<input type="number" name="cantidad_' . $idlinea . '" value="' . $line->cantidad
             . '" class="form-control form-control-sm rounded-0 mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
             . '</div>';
@@ -248,17 +212,19 @@ class PurchasesLineHTML
     protected static function precio(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
-                . '<div class="mb-1 small">' . $i18n->trans('price')
-                . '<input type="number" value="' . $line->pvpunitario . '" class="form-control  form-control-sm rounded-0" disabled=""/>'
+            return '<div class="col-sm col-md col-lg-1 px-0 order-4">'
+                . '<div class="mb-1 small">'
+                . '<span class="d-lg-none">' . $i18n->trans('price') . '</span>'
+                . '<input type="number" value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0" disabled=""/>'
                 . '</div>'
                 . '</div>';
         }
 
         $attributes = 'name="pvpunitario_' . $idlinea . '" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"';
-        return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
-            . '<div class="mb-1 small">' . $i18n->trans('price')
-            . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control  form-control-sm rounded-0"/>'
+        return '<div class="col-sm col-md col-lg-1 px-0 order-4">'
+            . '<div class="mb-1 small">'
+            . '<span class="d-lg-none">' . $i18n->trans('price') . '</span>'
+            . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0"/>'
             . '</div>'
             . '</div>';
     }
@@ -300,11 +266,79 @@ class PurchasesLineHTML
             case 'recargo':
                 return self::recargo($i18n, $idlinea, $line, $model, 'purchasesFormActionWait');
 
+            case 'referencia':
+                return self::referencia($i18n, $idlinea, $line, $model);
+
             case 'suplido':
                 return self::suplido($i18n, $idlinea, $line, $model, 'purchasesFormAction');
         }
 
         return null;
+    }
+
+    private static function renderLineModal(Translator $i18n, PurchaseDocumentLine $line, string $idlinea, PurchaseDocument $model): string
+    {
+        return '<div class="modal fade" id="lineModal-' . $idlinea . '" tabindex="-1" aria-labelledby="lineModal-' . $idlinea . 'Label" aria-hidden="true">'
+            . '<div class="modal-dialog modal-dialog-centered">'
+            . '<div class="modal-content">'
+            . '<div class="modal-header">'
+            . '<h5 class="modal-title">'
+            . $line->referencia
+            . '</h5>'
+            . '<button type="button" class="close" data-dismiss="modal" aria-label="Close">'
+            . '<span aria-hidden="true">&times;</span>'
+            . '</button>'
+            . '</div>'
+            . '<div class="modal-body">'
+            . '<div class="form-row">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'recargo')
+            . self::renderField($i18n, $idlinea, $line, $model, 'irpf')
+            . '</div>'
+            . '<div class="form-row">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'suplido')
+            . self::renderField($i18n, $idlinea, $line, $model, 'dtopor2')
+            . '</div>'
+            . '<div class="form-row">'
+            . self::renderNewModalFields($i18n, $idlinea, $line, $model)
+            . '</div>'
+            . '</div>'
+            . '<div class="modal-footer">'
+            . '<button type="button" class="btn btn-secondary" data-dismiss="modal">'
+            . $i18n->trans('close')
+            . '</button>'
+            . '<button type="button" class="btn btn-primary" data-dismiss="modal">'
+            . $i18n->trans('accept')
+            . '</button>'
+            . '</div>'
+            . '</div>'
+            . '</div>'
+            . '</div>';
+    }
+
+    private static function renderNewFields(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model): string
+    {
+        // cargamos los nuevos campos
+        $newFields = [];
+        foreach (self::$mods as $mod) {
+            foreach ($mod->newFields() as $field) {
+                if (false === in_array($field, $newFields)) {
+                    $newFields[] = $field;
+                }
+            }
+        }
+
+        // renderizamos los campos
+        $html = '';
+        foreach ($newFields as $field) {
+            foreach (self::$mods as $mod) {
+                $fieldHtml = $mod->renderField($i18n, $idlinea, $line, $model, $field);
+                if ($fieldHtml !== null) {
+                    $html .= $fieldHtml;
+                    break;
+                }
+            }
+        }
+        return $html;
     }
 
     private static function renderNewModalFields(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model): string
@@ -333,12 +367,12 @@ class PurchasesLineHTML
         return $html;
     }
 
-    private static function renderNewFields(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model): string
+    private static function renderNewTitles(Translator $i18n, PurchaseDocument $model): string
     {
         // cargamos los nuevos campos
         $newFields = [];
         foreach (self::$mods as $mod) {
-            foreach ($mod->newFields() as $field) {
+            foreach ($mod->newTitles() as $field) {
                 if (false === in_array($field, $newFields)) {
                     $newFields[] = $field;
                 }
@@ -349,7 +383,7 @@ class PurchasesLineHTML
         $html = '';
         foreach ($newFields as $field) {
             foreach (self::$mods as $mod) {
-                $fieldHtml = $mod->renderField($i18n, $idlinea, $line, $model, $field);
+                $fieldHtml = $mod->renderTitle($i18n, $model, $field);
                 if ($fieldHtml !== null) {
                     $html .= $fieldHtml;
                     break;
@@ -357,5 +391,119 @@ class PurchasesLineHTML
             }
         }
         return $html;
+    }
+
+    private static function renderTitle(Translator $i18n, PurchaseDocument $model, string $field): ?string
+    {
+        foreach (self::$mods as $mod) {
+            $html = $mod->renderTitle($i18n, $model, $field);
+            if ($html !== null) {
+                return $html;
+            }
+        }
+
+        switch ($field) {
+            case '_actionsButton':
+                return self::titleActionsButton($i18n, $model);
+
+            case '_total':
+                return self::titleTotal($i18n);
+
+            case 'cantidad':
+                return self::titleCantidad($i18n);
+
+            case 'codimpuesto':
+                return self::titleCodimpuesto($i18n);
+
+            case 'descripcion':
+                return self::titleDescripcion($i18n);
+
+            case 'dtopor':
+                return self::titleDtopor($i18n);
+
+            case 'pvpunitario':
+                return self::titlePrecio($i18n);
+
+            case 'referencia':
+                return self::titleReferencia($i18n);
+        }
+
+        return null;
+    }
+
+    private static function renderTitles(PurchaseDocument $model): string
+    {
+        $i18n = new Translator();
+        return '<div class="titles d-none d-lg-block">'
+            . '<div class="form-row pl-2 pr-2">'
+            . self::renderTitle($i18n, $model, 'referencia')
+            . self::renderTitle($i18n, $model, 'descripcion')
+            . self::renderTitle($i18n, $model, 'cantidad')
+            . self::renderNewTitles($i18n, $model)
+            . self::renderTitle($i18n, $model, 'pvpunitario')
+            . self::renderTitle($i18n, $model, 'dtopor')
+            . self::renderTitle($i18n, $model, 'codimpuesto')
+            . self::renderTitle($i18n, $model, '_total')
+            . self::renderTitle($i18n, $model, '_actionsButton')
+            . '</div>'
+            . '</div>';
+    }
+
+    private static function titleActionsButton(Translator $i18n, PurchaseDocument $model): string
+    {
+        $text = $model->editable ? $i18n->trans('actions') : '';
+        $width = $model->editable ? 90 : 30;
+        return '<div class="col-lg-auto px-0 text-center small order-8" style="width: ' . $width . 'px;">'
+            . $text
+            . '</div>';
+    }
+
+    private static function titleCantidad(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-3">'
+            . $i18n->trans('quantity')
+            . '</div>';
+    }
+
+    private static function titleCodimpuesto(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-6">'
+            . $i18n->trans('tax')
+            . '</div>';
+    }
+
+    private static function titleDescripcion(Translator $i18n): string
+    {
+        return '<div class="col-lg px-0 small order-2">'
+            . $i18n->trans('description')
+            . '</div>';
+    }
+
+    private static function titleDtopor(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-5">'
+            . $i18n->trans('percentage-discount')
+            . '</div>';
+    }
+
+    private static function titlePrecio(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-4">'
+            . $i18n->trans('price')
+            . '</div>';
+    }
+
+    private static function titleReferencia(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-1">'
+            . $i18n->trans('reference')
+            . '</div>';
+    }
+
+    private static function titleTotal(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-7">'
+            . $i18n->trans('subtotal')
+            . '</div>';
     }
 }

--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -175,13 +175,13 @@ class PurchasesLineHTML
     protected static function cantidad(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
+            return '<div class="col-sm-2 col-md-2 col-lg-1 small px-0 order-3">'
                 . '<span class="d-lg-none">' . $i18n->trans('quantity') . '</span>'
                 . '<input type="number" class="form-control form-control-sm rounded-0 mb-1" value="' . $line->cantidad . '" disabled=""/>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
+        return '<div class="col-sm-2 col-md-2 col-lg-1 small px-0 order-3">'
             . '<span class="d-lg-none">' . $i18n->trans('quantity') . '</span>'
             . '<input type="number" name="cantidad_' . $idlinea . '" value="' . $line->cantidad
             . '" class="form-control form-control-sm rounded-0 mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'

--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -433,6 +433,10 @@ class PurchasesLineHTML
 
     private static function renderTitles(PurchaseDocument $model): string
     {
+        if (empty($model->codigo)) {
+            return '';
+        }
+
         $i18n = new Translator();
         return '<div class="titles d-none d-lg-block">'
             . '<div class="form-row pl-2 pr-2">'

--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -213,14 +213,14 @@ class PurchasesLineHTML
     protected static function cantidad(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 small order-2">' . $i18n->trans('quantity')
-                . '<input type="number" class="form-control mb-1" value="' . $line->cantidad . '" disabled=""/>'
+            return '<div class="col-sm-2 col-xl-1 small px-0 order-2">' . $i18n->trans('quantity')
+                . '<input type="number" class="form-control form-control-sm rounded-0 mb-1" value="' . $line->cantidad . '" disabled=""/>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-2 col-xl-1 small order-2">' . $i18n->trans('quantity')
+        return '<div class="col-sm-2 col-xl-1 small px-0 order-2">' . $i18n->trans('quantity')
             . '<input type="number" name="cantidad_' . $idlinea . '" value="' . $line->cantidad
-            . '" class="form-control mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
+            . '" class="form-control form-control-sm rounded-0 mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
             . '</div>';
     }
 
@@ -248,17 +248,17 @@ class PurchasesLineHTML
     protected static function precio(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 order-3">'
+            return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
                 . '<div class="mb-1 small">' . $i18n->trans('price')
-                . '<input type="number" value="' . $line->pvpunitario . '" class="form-control" disabled=""/>'
+                . '<input type="number" value="' . $line->pvpunitario . '" class="form-control  form-control-sm rounded-0" disabled=""/>'
                 . '</div>'
                 . '</div>';
         }
 
         $attributes = 'name="pvpunitario_' . $idlinea . '" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"';
-        return '<div class="col-sm-2 col-xl-1 order-3">'
+        return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
             . '<div class="mb-1 small">' . $i18n->trans('price')
-            . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control"/>'
+            . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control  form-control-sm rounded-0"/>'
             . '</div>'
             . '</div>';
     }

--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -15,6 +15,7 @@ use FacturaScripts\Core\Model\Base\SalesDocument;
 use FacturaScripts\Core\Model\Base\SalesDocumentLine;
 use FacturaScripts\Dinamic\Lib\AssetManager;
 use FacturaScripts\Dinamic\Model\Cliente;
+use FacturaScripts\Dinamic\Model\Variante;
 
 /**
  * Description of SalesController
@@ -78,6 +79,28 @@ abstract class SalesController extends PanelController
         return Series::all();
     }
 
+    protected function autocompleteProductAction(): bool
+    {
+        $this->setTemplate(false);
+
+        $list = [];
+        $variante = new Variante();
+        $query = $this->request->get('term');
+        foreach ($variante->codeModelSearch($query, 'referencia') as $value) {
+            $list[] = [
+                'key' => $this->toolBox()->utils()->fixHtml($value->code),
+                'value' => $this->toolBox()->utils()->fixHtml($value->description)
+            ];
+        }
+
+        if (empty($list)) {
+            $list[] = ['key' => null, 'value' => $this->toolBox()->i18n()->trans('no-data')];
+        }
+
+        $this->response->setContent(\json_encode($list));
+        return false;
+    }
+
     protected function createViews()
     {
         $this->setTabsPosition('top');
@@ -122,8 +145,12 @@ abstract class SalesController extends PanelController
             case 'add-file':
                 return $this->addFileAction();
 
+            case 'autocomplete-product':
+                return $this->autocompleteProductAction();
+
             case 'add-product':
             case 'fast-line':
+            case 'fast-product':
             case 'new-line':
             case 'recalculate':
             case 'rm-line':

--- a/Core/Base/AjaxForms/SalesHeaderHTML.php
+++ b/Core/Base/AjaxForms/SalesHeaderHTML.php
@@ -160,7 +160,7 @@ class SalesHeaderHTML
             return '<div class="col-sm-3">'
                 . '<div class="form-group">' . $i18n->trans('customer')
                 . '<input type="hidden" name="codcliente"/>'
-                . '<a href="#" class="btn btn-block btn-primary" onclick="$(\'#findCustomerModal\').modal();'
+                . '<a href="#" id="btnFindCustomerModal" class="btn btn-block btn-primary" onclick="$(\'#findCustomerModal\').modal();'
                 . ' $(\'#findCustomerInput\').focus(); return false;"><i class="fas fa-users fa-fw"></i> '
                 . $i18n->trans('select') . '</a>'
                 . '</div>'

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -177,7 +177,7 @@ class SalesLineHTML
     private static function cantidad(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-2">'
+            return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
                 . '<span class="d-lg-none">' . self::cantidadLabel($i18n, $line, $model) . '</span>'
                 . '<div class="input-group input-group-sm mb-1">'
                 . self::cantidadServido($i18n, $line, $model)
@@ -187,7 +187,7 @@ class SalesLineHTML
                 . '</div>';
         }
 
-        return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-2">'
+        return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
             . '<span class="d-lg-none">'. self::cantidadLabel($i18n, $line, $model) . '</span>'
             . '<div class="input-group input-group-sm mb-1">'
             . self::cantidadServido($i18n, $line, $model)
@@ -318,7 +318,7 @@ class SalesLineHTML
     private static function precio(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm col-md col-lg-1 px-0 order-3">'
+            return '<div class="col-sm col-md col-lg-1 px-0 order-4">'
                 . '<div class="mb-1 small"><span class=" d-lg-none">' . $i18n->trans('price') . '</span>'
                 . '<input type="number" value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0" disabled/>'
                 . '</div>'
@@ -326,7 +326,7 @@ class SalesLineHTML
         }
 
         $attributes = 'name="pvpunitario_' . $idlinea . '" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"';
-        return '<div class="col-sm col-md col-lg-1 px-0 order-3">'
+        return '<div class="col-sm col-md col-lg-1 px-0 order-4">'
             . '<div class="mb-1 small"><span class=" d-lg-none">' . $i18n->trans('price') . '</span>'
             . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0"/>'
             . '</div>'
@@ -564,7 +564,7 @@ class SalesLineHTML
 
     private static function titleCantidad(Translator $i18n): string
     {
-        return '<div class="col-lg-1 px-0 small order-2">'
+        return '<div class="col-lg-1 px-0 small order-3">'
             . $i18n->trans('quantity')
             . '</div>';
     }
@@ -578,7 +578,7 @@ class SalesLineHTML
 
     private static function titleDescripcion(Translator $i18n): string
     {
-        return '<div class="col-lg px-0 small order-1">'
+        return '<div class="col-lg px-0 small order-2">'
             . $i18n->trans('description')
             . '</div>';
     }
@@ -592,7 +592,7 @@ class SalesLineHTML
 
     private static function titlePrecio(Translator $i18n): string
     {
-        return '<div class="col-lg-1 px-0 small order-3">'
+        return '<div class="col-lg-1 px-0 small order-4">'
             . $i18n->trans('price')
             . '</div>';
     }

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -537,6 +537,10 @@ class SalesLineHTML
 
     private static function renderTitles(SalesDocument $model): string
     {
+        if (empty($model->codigo)) {
+            return '';
+        }
+
         $i18n = new Translator();
         return '<div class="titles d-none d-lg-block">'
             . '<div class="form-row pl-2 pr-2">'

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -215,14 +215,14 @@ class SalesLineHTML
     private static function cantidad(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 small order-2">' . self::cantidadLabel($i18n, $line, $model)
-                . '<input type="number" class="form-control mb-1" value="' . $line->cantidad . '" disabled=""/>'
+            return '<div class="col-sm-2 col-xl-1 small px-0 order-2">' . self::cantidadLabel($i18n, $line, $model)
+                . '<input type="number" class="form-control form-control-sm rounded-0 mb-1" value="' . $line->cantidad . '" disabled=""/>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-3 col-xl-1 small order-2">' . self::cantidadLabel($i18n, $line, $model)
+        return '<div class="col-sm-3 col-xl-1 small px-0 order-2">' . self::cantidadLabel($i18n, $line, $model)
             . '<input type="number" name="cantidad_' . $idlinea . '" value="' . $line->cantidad
-            . '" class="form-control mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
+            . '" class="form-control form-control-sm rounded-0 mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
             . '</div>';
     }
 
@@ -290,17 +290,17 @@ class SalesLineHTML
     private static function precio(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 order-3">'
+            return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
                 . '<div class="mb-1 small">' . $i18n->trans('price')
-                . '<input type="number" value="' . $line->pvpunitario . '" class="form-control" disabled/>'
+                . '<input type="number" value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0" disabled/>'
                 . '</div>'
                 . '</div>';
         }
 
         $attributes = 'name="pvpunitario_' . $idlinea . '" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"';
-        return '<div class="col-sm-2 col-xl-1 order-3">'
+        return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
             . '<div class="mb-1 small">' . $i18n->trans('price')
-            . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control"/>'
+            . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0"/>'
             . '</div>'
             . '</div>';
     }

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -227,7 +227,7 @@ class SalesLineHTML
         switch ($line->actualizastock) {
             case -1:
             case -2:
-                $available = $stock->disponible > 0 ? '(' . $stock->disponible . '+)' : '';
+                $available = $stock->disponible > 0 ? '(' . $stock->disponible . ')' : '';
                 return '<span class="text-success">' . $i18n->trans('quantity') . '</span> ' . $available;
 
             default:
@@ -279,7 +279,7 @@ class SalesLineHTML
             case -1:
             case -2:
             $html = $stock->disponible > 0 ?
-                    '<span class="input-group-text text-success rounded-0">' . $stock->disponible . '+</span>' :
+                    '<span class="input-group-text text-success rounded-0">' . $stock->disponible . '</span>' :
                     '<span class="input-group-text text-danger rounded-0">' . $stock->disponible . '</span>';
                 break;
 

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -69,7 +69,7 @@ class SalesLineHTML
         }
 
         // add new line
-        if ($formData['action'] === 'add-product') {
+        if ($formData['action'] === 'add-product' || $formData['action'] === 'fast-product') {
             $lines[] = $model->getNewProductLine($formData['selectedLine']);
         } elseif ($formData['action'] === 'fast-line') {
             $newLine = self::getFastLine($model, $formData);
@@ -122,7 +122,7 @@ class SalesLineHTML
      */
     public static function render(array $lines, SalesDocument $model): string
     {
-        $html = '';
+        $html = self::renderTitles($model);
         foreach ($lines as $line) {
             $html .= self::renderLine($line, $model);
         }
@@ -140,6 +140,7 @@ class SalesLineHTML
         $cssClass = self::$num % 2 == 0 ? 'bg-white border-top' : 'bg-light border-top';
         return '<div class="' . $cssClass . ' line pl-2 pr-2">'
             . '<div class="form-row align-items-end">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'referencia')
             . self::renderField($i18n, $idlinea, $line, $model, 'descripcion')
             . self::renderField($i18n, $idlinea, $line, $model, 'cantidad')
             . self::renderNewFields($i18n, $idlinea, $line, $model)
@@ -151,45 +152,6 @@ class SalesLineHTML
             . self::renderExpandButton($i18n, $idlinea, $model, 'salesFormAction')
             . '</div>'
             . self::renderLineModal($i18n, $line, $idlinea, $model)
-            . '</div>';
-    }
-
-    private static function renderLineModal(Translator $i18n, SalesDocumentLine $line, string $idlinea, SalesDocument $model): string
-    {
-        return '<div class="modal fade" id="lineModal-' . $idlinea . '" tabindex="-1" aria-labelledby="lineModal-' . $idlinea . 'Label" aria-hidden="true">'
-            . '<div class="modal-dialog modal-dialog-centered">'
-            . '<div class="modal-content">'
-            . '<div class="modal-header">'
-            . '<h5 class="modal-title">'
-            . $line->referencia
-            . '</h5>'
-            . '<button type="button" class="close" data-dismiss="modal" aria-label="Close">'
-            . '<span aria-hidden="true">&times;</span>'
-            . '</button>'
-            . '</div>'
-            . '<div class="modal-body">'
-            . '<div class="form-row">'
-            . self::renderField($i18n, $idlinea, $line, $model, 'recargo')
-            . self::renderField($i18n, $idlinea, $line, $model, 'irpf')
-            . '</div>'
-            . '<div class="form-row">'
-            . self::renderField($i18n, $idlinea, $line, $model, 'suplido')
-            . self::renderField($i18n, $idlinea, $line, $model, 'dtopor2')
-            . '</div>'
-            . '<div class="form-row">'
-            . self::renderNewModalFields($i18n, $idlinea, $line, $model)
-            . '</div>'
-            . '</div>'
-            . '<div class="modal-footer">'
-            . '<button type="button" class="btn btn-secondary" data-dismiss="modal">'
-            . $i18n->trans('close')
-            . '</button>'
-            . '<button type="button" class="btn btn-primary" data-dismiss="modal">'
-            . $i18n->trans('accept')
-            . '</button>'
-            . '</div>'
-            . '</div>'
-            . '</div>'
             . '</div>';
     }
 
@@ -215,14 +177,24 @@ class SalesLineHTML
     private static function cantidad(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 small px-0 order-2">' . self::cantidadLabel($i18n, $line, $model)
-                . '<input type="number" class="form-control form-control-sm rounded-0 mb-1" value="' . $line->cantidad . '" disabled=""/>'
+            return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-2">'
+                . '<span class="d-lg-none">' . self::cantidadLabel($i18n, $line, $model) . '</span>'
+                . '<div class="input-group input-group-sm mb-1">'
+                . self::cantidadServido($i18n, $line, $model)
+                . '<input type="number" class="form-control rounded-0" value="' . $line->cantidad . '" disabled=""/>'
+                . self::cantidadStock($i18n, $line, $model)
+                . '</div>'
                 . '</div>';
         }
 
-        return '<div class="col-sm-3 col-xl-1 small px-0 order-2">' . self::cantidadLabel($i18n, $line, $model)
+        return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-2">'
+            . '<span class="d-lg-none">'. self::cantidadLabel($i18n, $line, $model) . '</span>'
+            . '<div class="input-group input-group-sm mb-1">'
+            . self::cantidadServido($i18n, $line, $model)
             . '<input type="number" name="cantidad_' . $idlinea . '" value="' . $line->cantidad
-            . '" class="form-control form-control-sm rounded-0 mb-1" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
+            . '" class="form-control rounded-0" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"/>'
+            . self::cantidadStock($i18n, $line, $model)
+            . '</div>'
             . '</div>';
     }
 
@@ -266,6 +238,67 @@ class SalesLineHTML
         }
     }
 
+    private static function cantidadServido(Translator $i18n, SalesDocumentLine $line, SalesDocument $model): string
+    {
+        $html = '';
+        if (empty($line->referencia) || $line->modelClassName() === 'LineaFacturaCliente') {
+            return $html;
+        }
+
+        if (false === $model->editable) {
+            $html .= '<div class="input-group-prepend" title="' . $i18n->trans('quantity-served') . '">';
+            $html .= $line->servido == $line->cantidad ?
+                '<span class="input-group-text text-success rounded-0">' . $line->servido . '</span>' :
+                '<span class="input-group-text text-warning rounded-0">' . $line->servido . '</span>';
+            $html .= '</div>';
+        }
+        return $html;
+    }
+
+    private static function cantidadStock(Translator $i18n, SalesDocumentLine $line, SalesDocument $model): string
+    {
+        $html = '';
+        if (empty($line->referencia) || $line->modelClassName() === 'LineaFacturaCliente' || false === $model->editable) {
+            return $html;
+        }
+
+        $product = $line->getProducto();
+        if ($product->nostock || $product->ventasinstock) {
+            return $html;
+        }
+
+        // buscamos el stock de este producto en este almacén
+        $stock = new Stock();
+        $where = [
+            new DataBaseWhere('codalmacen', $model->codalmacen),
+            new DataBaseWhere('referencia', $line->referencia)
+        ];
+        $stock->loadFromCode('', $where);
+
+        switch ($line->actualizastock) {
+            case -1:
+            case -2:
+            $html = $stock->disponible > 0 ?
+                    '<span class="input-group-text text-success rounded-0">' . $stock->disponible . '+</span>' :
+                    '<span class="input-group-text text-danger rounded-0">' . $stock->disponible . '</span>';
+                break;
+
+            default:
+                $html = $line->cantidad <= $stock->cantidad ?
+                    '<span class="input-group-text text-success rounded-0">' . $stock->cantidad . '</span>' :
+                    '<span class="input-group-text text-danger rounded-0">' . $stock->cantidad . '</span>';
+                break;
+        }
+
+        if (empty($html)) {
+            return $html;
+        }
+
+        return '<div class="input-group-prepend" title="' . $i18n->trans('stock') . '">'
+            . $html
+            . '</div>';
+    }
+
     private static function getFastLine(SalesDocument $model, array $formData): ?SalesDocumentLine
     {
         if (empty($formData['fastli'])) {
@@ -278,11 +311,6 @@ class SalesLineHTML
             return $model->getNewProductLine($variante->referencia);
         }
 
-        $whereRef = [new DataBaseWhere('referencia', $formData['fastli'])];
-        foreach ($variantModel->all($whereRef) as $variante) {
-            return $model->getNewProductLine($variante->referencia);
-        }
-
         ToolBox::i18nLog()->warning('product-not-found', ['%ref%' => $formData['fastli']]);
         return null;
     }
@@ -290,16 +318,16 @@ class SalesLineHTML
     private static function precio(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
-                . '<div class="mb-1 small">' . $i18n->trans('price')
+            return '<div class="col-sm col-md col-lg-1 px-0 order-3">'
+                . '<div class="mb-1 small"><span class=" d-lg-none">' . $i18n->trans('price') . '</span>'
                 . '<input type="number" value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0" disabled/>'
                 . '</div>'
                 . '</div>';
         }
 
         $attributes = 'name="pvpunitario_' . $idlinea . '" onkeyup="return ' . $jsFunc . '(\'recalculate-line\', \'0\');"';
-        return '<div class="col-sm-2 col-xl-1 px-0 order-3">'
-            . '<div class="mb-1 small">' . $i18n->trans('price')
+        return '<div class="col-sm col-md col-lg-1 px-0 order-3">'
+            . '<div class="mb-1 small"><span class=" d-lg-none">' . $i18n->trans('price') . '</span>'
             . '<input type="number" ' . $attributes . ' value="' . $line->pvpunitario . '" class="form-control form-control-sm rounded-0"/>'
             . '</div>'
             . '</div>';
@@ -342,11 +370,79 @@ class SalesLineHTML
             case 'recargo':
                 return self::recargo($i18n, $idlinea, $line, $model, 'salesFormActionWait');
 
+            case 'referencia':
+                return self::referencia($i18n, $idlinea, $line, $model);
+
             case 'suplido':
                 return self::suplido($i18n, $idlinea, $line, $model, 'salesFormAction');
         }
 
         return null;
+    }
+
+    private static function renderLineModal(Translator $i18n, SalesDocumentLine $line, string $idlinea, SalesDocument $model): string
+    {
+        return '<div class="modal fade" id="lineModal-' . $idlinea . '" tabindex="-1" aria-labelledby="lineModal-' . $idlinea . 'Label" aria-hidden="true">'
+            . '<div class="modal-dialog modal-dialog-centered">'
+            . '<div class="modal-content">'
+            . '<div class="modal-header">'
+            . '<h5 class="modal-title">'
+            . $line->referencia
+            . '</h5>'
+            . '<button type="button" class="close" data-dismiss="modal" aria-label="Close">'
+            . '<span aria-hidden="true">&times;</span>'
+            . '</button>'
+            . '</div>'
+            . '<div class="modal-body">'
+            . '<div class="form-row">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'recargo')
+            . self::renderField($i18n, $idlinea, $line, $model, 'irpf')
+            . '</div>'
+            . '<div class="form-row">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'suplido')
+            . self::renderField($i18n, $idlinea, $line, $model, 'dtopor2')
+            . '</div>'
+            . '<div class="form-row">'
+            . self::renderNewModalFields($i18n, $idlinea, $line, $model)
+            . '</div>'
+            . '</div>'
+            . '<div class="modal-footer">'
+            . '<button type="button" class="btn btn-secondary" data-dismiss="modal">'
+            . $i18n->trans('close')
+            . '</button>'
+            . '<button type="button" class="btn btn-primary" data-dismiss="modal">'
+            . $i18n->trans('accept')
+            . '</button>'
+            . '</div>'
+            . '</div>'
+            . '</div>'
+            . '</div>';
+    }
+
+    private static function renderNewFields(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model): string
+    {
+        // cargamos los nuevos campos
+        $newFields = [];
+        foreach (self::$mods as $mod) {
+            foreach ($mod->newFields() as $field) {
+                if (false === in_array($field, $newFields)) {
+                    $newFields[] = $field;
+                }
+            }
+        }
+
+        // renderizamos los campos
+        $html = '';
+        foreach ($newFields as $field) {
+            foreach (self::$mods as $mod) {
+                $fieldHtml = $mod->renderField($i18n, $idlinea, $line, $model, $field);
+                if ($fieldHtml !== null) {
+                    $html .= $fieldHtml;
+                    break;
+                }
+            }
+        }
+        return $html;
     }
 
     private static function renderNewModalFields(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model): string
@@ -375,12 +471,12 @@ class SalesLineHTML
         return $html;
     }
 
-    private static function renderNewFields(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model): string
+    private static function renderNewTitles(Translator $i18n, SalesDocument $model): string
     {
         // cargamos los nuevos campos
         $newFields = [];
         foreach (self::$mods as $mod) {
-            foreach ($mod->newFields() as $field) {
+            foreach ($mod->newTitles() as $field) {
                 if (false === in_array($field, $newFields)) {
                     $newFields[] = $field;
                 }
@@ -391,7 +487,7 @@ class SalesLineHTML
         $html = '';
         foreach ($newFields as $field) {
             foreach (self::$mods as $mod) {
-                $fieldHtml = $mod->renderField($i18n, $idlinea, $line, $model, $field);
+                $fieldHtml = $mod->renderTitle($i18n, $model, $field);
                 if ($fieldHtml !== null) {
                     $html .= $fieldHtml;
                     break;
@@ -399,5 +495,119 @@ class SalesLineHTML
             }
         }
         return $html;
+    }
+
+    private static function renderTitle(Translator $i18n, SalesDocument $model, string $field): ?string
+    {
+        foreach (self::$mods as $mod) {
+            $html = $mod->renderTitle($i18n, $model, $field);
+            if ($html !== null) {
+                return $html;
+            }
+        }
+
+        switch ($field) {
+            case '_actionsButton':
+                return self::titleActionsButton($i18n, $model);
+
+            case '_total':
+                return self::titleTotal($i18n);
+
+            case 'cantidad':
+                return self::titleCantidad($i18n);
+
+            case 'codimpuesto':
+                return self::titleCodimpuesto($i18n);
+
+            case 'descripcion':
+                return self::titleDescripcion($i18n);
+
+            case 'dtopor':
+                return self::titleDtopor($i18n);
+
+            case 'pvpunitario':
+                return self::titlePrecio($i18n);
+
+            case 'referencia':
+                return self::titleReferencia($i18n);
+        }
+
+        return null;
+    }
+
+    private static function renderTitles(SalesDocument $model): string
+    {
+        $i18n = new Translator();
+        return '<div class="titles d-none d-lg-block">'
+            . '<div class="form-row pl-2 pr-2">'
+            . self::renderTitle($i18n, $model, 'referencia')
+            . self::renderTitle($i18n, $model, 'descripcion')
+            . self::renderTitle($i18n, $model, 'cantidad')
+            . self::renderNewTitles($i18n, $model)
+            . self::renderTitle($i18n, $model, 'pvpunitario')
+            . self::renderTitle($i18n, $model, 'dtopor')
+            . self::renderTitle($i18n, $model, 'codimpuesto')
+            . self::renderTitle($i18n, $model, '_total')
+            . self::renderTitle($i18n, $model, '_actionsButton')
+            . '</div>'
+            . '</div>';
+    }
+
+    private static function titleActionsButton(Translator $i18n, SalesDocument $model): string
+    {
+        $text = $model->editable ? $i18n->trans('actions') : '';
+        $width = $model->editable ? 90 : 30;
+        return '<div class="col-lg-auto px-0 text-center small order-8" style="width: ' . $width . 'px;">'
+            . $text
+            . '</div>';
+    }
+
+    private static function titleCantidad(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-2">'
+            . $i18n->trans('quantity')
+            . '</div>';
+    }
+
+    private static function titleCodimpuesto(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-6">'
+            . $i18n->trans('tax')
+            . '</div>';
+    }
+
+    private static function titleDescripcion(Translator $i18n): string
+    {
+        return '<div class="col-lg px-0 small order-1">'
+            . $i18n->trans('description')
+            . '</div>';
+    }
+
+    private static function titleDtopor(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-5">'
+            . $i18n->trans('percentage-discount')
+            . '</div>';
+    }
+
+    private static function titlePrecio(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-3">'
+            . $i18n->trans('price')
+            . '</div>';
+    }
+
+    private static function titleReferencia(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-1">'
+            . $i18n->trans('reference')
+            . '</div>';
+    }
+
+    private static function titleTotal(Translator $i18n): string
+    {
+        return '<div class="col-lg-1 px-0 small order-7">'
+            . $i18n->trans('subtotal')
+            . '</div>';
     }
 }

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -177,7 +177,7 @@ class SalesLineHTML
     private static function cantidad(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $jsFunc): string
     {
         if (false === $model->editable) {
-            return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
+            return '<div class="col-sm-2 col-md-2 col-lg-1 small px-0 order-3">'
                 . '<span class="d-lg-none">' . self::cantidadLabel($i18n, $line, $model) . '</span>'
                 . '<div class="input-group input-group-sm mb-1">'
                 . self::cantidadServido($i18n, $line, $model)
@@ -187,7 +187,7 @@ class SalesLineHTML
                 . '</div>';
         }
 
-        return '<div class="col-sm-2 col-md col-lg-1 small px-0 order-3">'
+        return '<div class="col-sm-2 col-md-2 col-lg-1 small px-0 order-3">'
             . '<span class="d-lg-none">'. self::cantidadLabel($i18n, $line, $model) . '</span>'
             . '<div class="input-group input-group-sm mb-1">'
             . self::cantidadServido($i18n, $line, $model)

--- a/Core/Base/Contract/PurchasesLineModInterface.php
+++ b/Core/Base/Contract/PurchasesLineModInterface.php
@@ -19,5 +19,9 @@ interface PurchasesLineModInterface
 
     public function newFields(): array;
 
+    public function newTitles(): array;
+
     public function renderField(Translator $i18n, string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $field): ?string;
+
+    public function renderTitle(Translator $i18n, PurchaseDocument $model, string $field): ?string;
 }

--- a/Core/Base/Contract/SalesLineModInterface.php
+++ b/Core/Base/Contract/SalesLineModInterface.php
@@ -19,5 +19,9 @@ interface SalesLineModInterface
 
     public function newFields(): array;
 
+    public function newTitles(): array;
+
     public function renderField(Translator $i18n, string $idlinea, SalesDocumentLine $line, SalesDocument $model, string $field): ?string;
+
+    public function renderTitle(Translator $i18n, SalesDocument $model, string $field): ?string;
 }

--- a/Core/View/Tab/PurchasesDocument.html.twig
+++ b/Core/View/Tab/PurchasesDocument.html.twig
@@ -17,6 +17,39 @@
 <script>
     let waitCounter = 0;
 
+    function findProduct() {
+        $("#findProductInput").autocomplete({
+            source: function (request, response) {
+                $.ajax({
+                    method: "POST",
+                    url: '{{ fsc.url() }}',
+                    data: {action: 'autocomplete-product', term: request.term},
+                    dataType: "json",
+                    success: function (results) {
+                        let values = [];
+                        results.forEach(function (element) {
+                            if (element.key === null || element.key === element.value) {
+                                values.push(element);
+                            } else {
+                                values.push({key: element.key, value: element.key + " | " + element.value});
+                            }
+                        });
+                        response(values);
+                    },
+                    error: function (msg) {
+                        alert(msg.status + " " + msg.responseText);
+                    }
+                });
+            },
+            select: function (event, ui) {
+                if (ui.item.key !== null) {
+                    const value = ui.item.value.split(" | ");
+                    purchasesFormAction("fast-product", value[0]);
+                }
+            }
+        });
+    }
+
     function purchasesFastLine(e) {
         if (e.which == 13) {
             purchasesFormAction('fast-line', '0');
@@ -75,7 +108,11 @@
                 $(".doc-line-desc:last").focus();
             } else if (document.forms['purchasesForm']['action'].value === 'fast-line') {
                 document.forms['purchasesForm']['fastli'].focus();
+            } else if (document.forms['purchasesForm']['action'].value === 'fast-product') {
+                $("#findProductInput").focus();
             }
+
+            findProduct();
         }).catch(function (error) {
             alert('error');
             console.warn(error);
@@ -196,6 +233,8 @@
     {% endif %}
 
     $(document).ready(function () {
+        findProduct();
+
         $("#findSupplierInput").autocomplete({
             autoFocus: true,
             source: function (request, response) {

--- a/Core/View/Tab/PurchasesDocument.html.twig
+++ b/Core/View/Tab/PurchasesDocument.html.twig
@@ -235,6 +235,10 @@
     $(document).ready(function () {
         findProduct();
 
+        if (document.forms['purchasesForm']['codproveedor'].value === '') {
+            $('#btnFindSupplierModal').click();
+        }
+
         $("#findSupplierInput").autocomplete({
             autoFocus: true,
             source: function (request, response) {

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -235,6 +235,10 @@
     $(document).ready(function () {
         findProduct();
 
+        if (document.forms['salesForm']['codcliente'].value === '') {
+            $('#btnFindCustomerModal').click();
+        }
+
         $("#findCustomerInput").autocomplete({
             autoFocus: true,
             source: function (request, response) {

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -17,6 +17,39 @@
 <script>
     let waitCounter = 0;
 
+    function findProduct() {
+        $("#findProductInput").autocomplete({
+            source: function (request, response) {
+                $.ajax({
+                    method: "POST",
+                    url: '{{ fsc.url() }}',
+                    data: {action: 'autocomplete-product', term: request.term},
+                    dataType: "json",
+                    success: function (results) {
+                        let values = [];
+                        results.forEach(function (element) {
+                            if (element.key === null || element.key === element.value) {
+                                values.push(element);
+                            } else {
+                                values.push({key: element.key, value: element.key + " | " + element.value});
+                            }
+                        });
+                        response(values);
+                    },
+                    error: function (msg) {
+                        alert(msg.status + " " + msg.responseText);
+                    }
+                });
+            },
+            select: function (event, ui) {
+                if (ui.item.key !== null) {
+                    const value = ui.item.value.split(" | ");
+                    salesFormAction("fast-product", value[0]);
+                }
+            }
+        });
+    }
+
     function salesFastLine(e) {
         if (e.which == 13) {
             salesFormAction('fast-line', '0');
@@ -75,7 +108,11 @@
                 $(".doc-line-desc:last").focus();
             } else if (document.forms['salesForm']['action'].value === 'fast-line') {
                 document.forms['salesForm']['fastli'].focus();
+            } else if (document.forms['salesForm']['action'].value === 'fast-product') {
+                $("#findProductInput").focus();
             }
+
+            findProduct();
         }).catch(function (error) {
             alert('error');
             console.warn(error);
@@ -196,6 +233,8 @@
     {% endif %}
 
     $(document).ready(function () {
+        findProduct();
+
         $("#findCustomerInput").autocomplete({
             autoFocus: true,
             source: function (request, response) {


### PR DESCRIPTION
Se han quitado los padding-x en las columnas y border-radius de los inputs, además de poner todos los inputs y botones en tamaño sm, en los formularios de compras y ventas.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->