### PR TITLE
Solucionado bug al activar plugin con la carga del Dinamic.

### DIFF
--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -161,8 +161,6 @@ final class PluginManager
                 self::$enabledPlugins[] = $plugin;
                 $this->save();
                 $this->deploy(false, true);
-                $this->initPlugin($pluginName);
-                ToolBox::i18nLog()->notice('plugin-enabled', ['%pluginName%' => $pluginName]);
                 return true;
             }
         }
@@ -199,6 +197,7 @@ final class PluginManager
         if (class_exists($pluginClass) && in_array($pluginName, $this->enabledPlugins())) {
             $initObject = new $pluginClass();
             $initObject->update();
+            ToolBox::i18nLog()->notice('plugin-enabled', ['%pluginName%' => $pluginName]);
         }
     }
 

--- a/Core/Controller/AdminPlugins.php
+++ b/Core/Controller/AdminPlugins.php
@@ -152,6 +152,7 @@ class AdminPlugins extends Base\Controller
 
         $pluginName = $this->request->get('plugin', '');
         $this->pluginManager->enable($pluginName);
+        $this->redirect($this->url() . '?action=init&plugin=' . $pluginName);
         $this->toolBox()->cache()->clear();
     }
 
@@ -169,6 +170,10 @@ class AdminPlugins extends Base\Controller
 
             case 'enable':
                 $this->enablePluginAction();
+                break;
+
+            case 'init':
+                $this->initPluginAction();
                 break;
 
             case 'rebuild':
@@ -191,6 +196,11 @@ class AdminPlugins extends Base\Controller
                 }
                 break;
         }
+    }
+
+    private function initPluginAction()
+    {
+        $this->pluginManager->initPlugin($this->request->get('plugin', ''));
     }
 
     private function rebuildAction(): void


### PR DESCRIPTION
Your PR description goes here.

El problema es que a veces al usar una clase cargandola desde el init, al activar el plugin aún no esta terminado de cargar todo el dinamic y entonces falla. Con este cambio solucionamos ese problema llamando al init del plugin una vez terminado de cargar el dinamic.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [x] Database with random data
<!---- [ ] If additional tests was realized, added here--->