### PR TITLE
Tarea #740 - Guardar documento antes de cambiar el estado.

### DIFF
--- a/Core/Base/AjaxForms/PurchasesController.php
+++ b/Core/Base/AjaxForms/PurchasesController.php
@@ -341,7 +341,7 @@ abstract class PurchasesController extends PanelController
     protected function saveStatusAction(): bool
     {
         $this->setTemplate(false);
-
+        $this->saveDocAction();
         $model = $this->getModel();
         $model->idestado = (int)$this->request->request->get('selectedLine');
         if (false === $model->save()) {

--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -345,7 +345,7 @@ abstract class SalesController extends PanelController
     protected function saveStatusAction(): bool
     {
         $this->setTemplate(false);
-
+        $this->saveDocAction();
         $model = $this->getModel();
         $model->idestado = (int)$this->request->request->get('selectedLine');
         if (false === $model->save()) {


### PR DESCRIPTION
Your PR description goes here.

Existe un bug que al añadir un producto a un documento de compra o venta, si se cambia el estado sin guardar se pierden las nuevas líneas añadidas. Se debe poder guardar justo antes de cambiar el estado.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->