### PR TITLE
Tarea #781 - Solucionado bug al exportar en xls desde un JoinModel.

### DIFF
--- a/Core/Model/Base/JoinModel.php
+++ b/Core/Model/Base/JoinModel.php
@@ -221,12 +221,23 @@ abstract class JoinModel
      */
     public function getModelFields()
     {
+        $database = new DataBase();
         $fields = [];
         foreach ($this->getFields() as $key => $field) {
             $fields[$key] = [
                 'name' => $field,
                 'type' => ''
             ];
+
+            $arrayField = explode('.', $field);
+            if (false === is_array($arrayField) && false === isset($arrayField[0])) {
+                continue;
+            }
+
+            $columns = $database->getColumns($arrayField[0]);
+            if (isset($columns[$arrayField[1]])) {
+                $fields[$key]['type'] = $columns[$arrayField[1]]['type'];
+            }
         }
 
         return $fields;


### PR DESCRIPTION
Your PR description goes here.

Cuando se exporta un listado desde un JoinModel no sabemos los tipos de las columnas, esto hace que todas las columnas en un xls sean de tipo string. Con este arreglo obtenemos el tipo de cada columna para saber como formatear cada celda.

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->