### PR TITLE
Remove required reference code

### DIFF
--- a/Core/Model/Producto.php
+++ b/Core/Model/Producto.php
@@ -280,7 +280,7 @@ class Producto extends Base\ModelClass
         $this->observaciones = $utils->noHtml($this->observaciones);
         $this->referencia = $utils->noHtml($this->referencia);
 
-        if (strlen($this->referencia) < 1 || strlen($this->referencia) > 30) {
+        if (strlen($this->referencia) > 30) {
             $this->toolBox()->i18nLog()->warning(
                 'invalid-column-lenght',
                 ['%value%' => $this->referencia, '%column%' => 'referencia', '%min%' => '1', '%max%' => '30']
@@ -340,6 +340,10 @@ class Producto extends Base\ModelClass
      */
     protected function saveInsert(array $values = [])
     {
+        if (empty($this->referencia)) {
+            $this->referencia = (string)$this->newCode('referencia');
+        }
+
         if (parent::saveInsert($values)) {
             $variant = new Variante();
             $variant->idproducto = $this->idproducto;

--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -295,7 +295,7 @@ class Variante extends Base\ModelClass
     {
         $utils = $this->toolBox()->utils();
         $this->referencia = $utils->noHtml($this->referencia);
-        if (\strlen($this->referencia) < 1 || \strlen($this->referencia) > 30) {
+        if (\strlen($this->referencia) > 30) {
             $this->toolBox()->i18nLog()->warning(
                 'invalid-column-lenght',
                 ['%value%' => $this->referencia, '%column%' => 'referencia', '%min%' => '1', '%max%' => '30']
@@ -325,6 +325,10 @@ class Variante extends Base\ModelClass
      */
     protected function saveInsert(array $values = [])
     {
+        if (empty($this->referencia)) {
+            $this->referencia = (string)$this->newCode('referencia');
+        }
+
         if (false === parent::saveInsert($values)) {
             return false;
         }

--- a/Core/XMLView/EditProducto.xml
+++ b/Core/XMLView/EditProducto.xml
@@ -23,8 +23,7 @@
     <columns>
         <group name="main" numcolumns="12">
             <column name="reference" numcolumns="3" order="100">
-                <widget type="text" fieldname="referencia" maxlength="30" icon="fas fa-hashtag" required="true"
-                        readonly="dinamic"/>
+                <widget type="text" fieldname="referencia" maxlength="30" icon="fas fa-hashtag" readonly="dinamic"/>
             </column>
             <column name="manufacturer" titleurl="ListFabricante" order="110">
                 <widget type="select" fieldname="codfabricante" onclick="EditFabricante">

--- a/Core/XMLView/EditVariante.xml
+++ b/Core/XMLView/EditVariante.xml
@@ -26,7 +26,7 @@
                 <widget type="text" fieldname="idproducto" required="true" />
             </column>
             <column name="reference" numcolumns="2" order="110">
-                <widget type="text" fieldname="referencia" maxlength="30" icon="fas fa-hashtag" required="true" />
+                <widget type="text" fieldname="referencia" maxlength="30" icon="fas fa-hashtag" />
             </column>
             <column name="attribute-value-1" titleurl="ListAtributo" numcolumns="2" order="120">
                 <widget type="select" fieldname="idatributovalor1" onclick="EditAtributo" />


### PR DESCRIPTION
Now it is allowed to leave without informing the reference in the products and their variants. If not informed, the system calculates an automatic numerical code based on the last code used in that field.

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
