### PR TITLE
Add text info to EditPageOption view

### DIFF
--- a/Core/View/EditPageOption.html.twig
+++ b/Core/View/EditPageOption.html.twig
@@ -75,6 +75,9 @@
                                             {'onChange': 'this.form.submit()'}) }}
                                     </div>
                                 </div>
+                                <div class="col">
+                                    <h2 class="h5 text-center"><small>{{ i18n.trans('page-option-info') }}</small></h2>
+                                </div>
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
A user information text label has been added to the top of the window.
The label contemplates the translation system. For this it is necessary to incorporate the label (ES_es example):
- "page-option-info": "Desde aquí puedes modificar los campos visibles en este listado o formulario"
