### PR TITLE
Bug: Actualización de sistema para guardar los codigos de iva

### DIFF
--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -33,9 +33,9 @@ trait CommonLineHTML
     {
         $options = [];
         foreach (Impuestos::all() as $imp) {
-            $options[] = $line->iva == $imp->iva ?
-                '<option value="' . $imp->iva . '" selected="">' . $imp->descripcion . '</option>' :
-                '<option value="' . $imp->iva . '">' . $imp->descripcion . '</option>';
+            $options[] = $line->codimpuesto == $imp->codimpuesto ?
+                '<option data-codimpuesto="'.$imp->codimpuesto.'" value="' . $imp->iva . '" selected="">' . $imp->descripcion . '</option>' :
+                '<option data-codimpuesto="'.$imp->codimpuesto.'" value="' . $imp->iva . '">' . $imp->descripcion . '</option>';
         }
 
         $attributes = $model->editable && false === $line->suplido ?
@@ -44,7 +44,7 @@ trait CommonLineHTML
         return '<div class="col-sm col-lg-1 order-6">'
             . '<div class="d-lg-none mt-3 small">' . $i18n->trans('tax') . '</div>'
             . '<select ' . $attributes . ' class="form-control form-control-sm border-0">' . implode('', $options) . '</select>'
-            . '</div>';
+            . '</div><input type="hidden" value="'.htmlentities($jsFunc).'">';
     }
 
     private static function descripcion(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string

--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -44,7 +44,7 @@ trait CommonLineHTML
         return '<div class="col-sm col-lg-1 order-6">'
             . '<div class="d-lg-none mt-3 small">' . $i18n->trans('tax') . '</div>'
             . '<select ' . $attributes . ' class="form-control form-control-sm border-0">' . implode('', $options) . '</select>'
-            . '</div><input type="hidden" value="'.htmlentities($jsFunc).'">';
+            . '</div>';
     }
 
     private static function descripcion(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -119,7 +119,7 @@ class SalesLineHTML
             $idlinea = $line->idlinea ?? 'n' . self::$num;
 
             // codimpuesto
-            $map['iva_' . $idlinea] = $line->iva;
+            $map['iva_' . $idlinea] = ['codimpuesto' => $line->codimpuesto]; //(Lo hacemos por codimpuesto mejor)
 
             // total
             $map['linetotal_' . $idlinea] = $line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100;
@@ -174,6 +174,7 @@ class SalesLineHTML
         $line->descripcion = $formData['descripcion_' . $id];
         $line->irpf = (float)($formData['irpf_' . $id] ?? '0');
         $line->iva = (float)($formData['iva_' . $id] ?? '0');
+        $line->codimpuesto = $formData['codimpuesto_' . $id];
         $line->recargo = (float)($formData['recargo_' . $id] ?? '0');
         $line->suplido = (bool)($formData['suplido_' . $id] ?? '0');
         $line->pvpunitario = (float)$formData['pvpunitario_' . $id];

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -64,7 +64,12 @@
         document.forms['salesForm']['selectedLine'].value = selectedLine;
 
         const formData = new FormData(document.forms['salesForm']);
-        const plainFormData = Object.fromEntries(formData.entries());
+        let plainFormData = Object.fromEntries(formData.entries());
+        //Obtenemos los codigos de iva para guardarlos tambien
+        document.querySelectorAll("select[name*='iva_']").forEach(function (item, index) {
+            let name = item.name.replace('iva', 'codimpuesto');
+            plainFormData[name] = item.options[item.selectedIndex].dataset.codimpuesto;
+        });
         const formDataJsonString = JSON.stringify(plainFormData);
 
         let data = new FormData();
@@ -73,7 +78,7 @@
         data.append('multireqtoken', document.forms['salesForm']['multireqtoken'].value);
         data.append('selectedLine', document.forms['salesForm']['selectedLine'].value);
         data.append('data', formDataJsonString);
-        console.log(data);
+        console.log(plainFormData);
 
         fetch('{{ fsc.url() }}', {
             method: 'POST',
@@ -92,7 +97,10 @@
                 document.getElementById("salesFormLines").innerHTML = data.lines;
             } else {
                 $.each(data.linesMap, function (index, value) {
-                    document.forms['salesForm'][index].value = value;
+                    if (typeof value.codimpuesto === 'undefined' )
+                        document.forms['salesForm'][index].value = value;
+                    else
+                        document.forms['salesForm'][index].querySelector('[data-codimpuesto="'+ value.codimpuesto +'"]').selected = true;
                 });
             }
             if (data.footer !== '') {
@@ -146,7 +154,12 @@
         document.forms['salesForm']['selectedLine'].value = selectedLine;
 
         const formData = new FormData(document.forms['salesForm']);
-        const plainFormData = Object.fromEntries(formData.entries());
+        let plainFormData = Object.fromEntries(formData.entries());
+        //Obtenemos los codigos de iva para guardarlos tambien
+        document.querySelectorAll("select[name*='iva_']").forEach(function (item, index) {
+            let name = item.name.replace('iva', 'codimpuesto');
+            plainFormData[name] = item.options[item.selectedIndex].dataset.codimpuesto;
+        });
         const formDataJsonString = JSON.stringify(plainFormData);
 
         let data = new FormData();
@@ -155,7 +168,7 @@
         data.append('multireqtoken', document.forms['salesForm']['multireqtoken'].value);
         data.append('selectedLine', document.forms['salesForm']['selectedLine'].value);
         data.append('data', formDataJsonString);
-        console.log(data);
+        console.log(plainFormData);
 
         fetch('{{ fsc.url() }}', {
             method: 'POST',


### PR DESCRIPTION
Se han tocado los archivos necesarios para guardar los códigos de iva en las lineas de pedidos, albaranes y facturas.
Soluciona un error por el cual era imposible establecer mas de un iva del mismo tipo.