### PR TITLE
Tarea #908 - Ocultar filtros de usuario y agente en los listados de compras y venta

### DIFF
--- a/Core/Lib/ExtendedController/ListBusinessDocument.php
+++ b/Core/Lib/ExtendedController/ListBusinessDocument.php
@@ -48,9 +48,11 @@ abstract class ListBusinessDocument extends ListController
         $statusValues = $this->codeModel->all('estados_documentos', 'idestado', 'nombre', true, $where);
         $this->addFilterSelect($viewName, 'idestado', 'state', 'idestado', $statusValues);
 
-        $users = $this->codeModel->all('users', 'nick', 'nick');
-        if (count($users) > 1) {
-            $this->addFilterSelect($viewName, 'nick', 'user', 'nick', $users);
+        if ($this->permissions->onlyOwnerData === false) {
+            $users = $this->codeModel->all('users', 'nick', 'nick');
+            if (count($users) > 1) {
+                $this->addFilterSelect($viewName, 'nick', 'user', 'nick', $users);
+            }
         }
 
         $companies = Empresas::codeModel();
@@ -145,9 +147,11 @@ abstract class ListBusinessDocument extends ListController
         $this->addFilterAutocomplete($viewName, 'idcontactofact', 'billing-address', 'idcontactofact', 'contactos', 'idcontacto', 'direccion');
         $this->addFilterautocomplete($viewName, 'idcontactoenv', 'shipping-address', 'idcontactoenv', 'contactos', 'idcontacto', 'direccion');
 
-        $agents = Agentes::codeModel();
-        if (count($agents) > 1) {
-            $this->addFilterSelect($viewName, 'codagente', 'agent', 'codagente', $agents);
+        if ($this->permissions->onlyOwnerData === false) {
+            $agents = Agentes::codeModel();
+            if (count($agents) > 1) {
+                $this->addFilterSelect($viewName, 'codagente', 'agent', 'codagente', $agents);
+            }
         }
 
         $carriers = $this->codeModel->all('agenciastrans', 'codtrans', 'nombre');


### PR DESCRIPTION
Ocultar filtros de usuario y agente en los listados de compras y ventas cuando el usuario solamente tiene permiso para ver lo suyo.

[Tarea #908](https://facturascripts.com/roadmap/EditTask?code=908)

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->