### PR TITLE
Tarea #948 - Filtrar productos al buscar en documentos de compra y venta

### DIFF
--- a/Core/Base/AjaxForms/PurchasesController.php
+++ b/Core/Base/AjaxForms/PurchasesController.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Base\AjaxForms;
 
 use FacturaScripts\Core\Base\Calculator;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Series;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\DocFilesTrait;
@@ -100,7 +101,11 @@ abstract class PurchasesController extends PanelController
         $list = [];
         $variante = new Variante();
         $query = (string)$this->request->get('term');
-        foreach ($variante->codeModelSearch($query, 'referencia') as $value) {
+        $where = [
+            new DataBaseWhere('p.bloqueado', 0),
+            new DataBaseWhere('p.secompra', 1)
+        ];
+        foreach ($variante->codeModelSearch($query, 'referencia', $where) as $value) {
             $list[] = [
                 'key' => $this->toolBox()->utils()->fixHtml($value->code),
                 'value' => $this->toolBox()->utils()->fixHtml($value->description)

--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Base\AjaxForms;
 
 use FacturaScripts\Core\Base\Calculator;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Series;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\DocFilesTrait;
@@ -100,7 +101,11 @@ abstract class SalesController extends PanelController
         $list = [];
         $variante = new Variante();
         $query = (string)$this->request->get('term');
-        foreach ($variante->codeModelSearch($query, 'referencia') as $value) {
+        $where = [
+            new DataBaseWhere('p.bloqueado', 0),
+            new DataBaseWhere('p.sevende', 1)
+        ];
+        foreach ($variante->codeModelSearch($query, 'referencia', $where) as $value) {
             $list[] = [
                 'key' => $this->toolBox()->utils()->fixHtml($value->code),
                 'value' => $this->toolBox()->utils()->fixHtml($value->description)

--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Dinamic\Model\AtributoValor as DinAtributoValor;
 use FacturaScripts\Dinamic\Model\Producto as DinProducto;
 use FacturaScripts\Dinamic\Model\Stock as DinStock;
@@ -135,9 +136,10 @@ class Variante extends Base\ModelClass
         $sql = "SELECT v." . $field . " AS code, p.descripcion AS description, v.idatributovalor1, v.idatributovalor2, v.idatributovalor3, v.idatributovalor4"
             . " FROM " . static::tableName() . " v"
             . " LEFT JOIN " . DinProducto::tableName() . " p ON v.idproducto = p.idproducto"
-            . " WHERE LOWER(v.referencia) LIKE '" . $find . "%'"
+            . DataBaseWhere::getSQLWhere($where)
+            . " AND (LOWER(v.referencia) LIKE '" . $find . "%'"
             . " OR LOWER(v.codbarras) = '" . $find . "'"
-            . " OR LOWER(p.descripcion) LIKE '%" . $find . "%'"
+            . " OR LOWER(p.descripcion) LIKE '%" . $find . "%')"
             . " ORDER BY v." . $field . " ASC";
 
         foreach (self::$dataBase->selectLimit($sql, CodeModel::ALL_LIMIT) as $data) {


### PR DESCRIPTION
Al hacer compras o ventas, al añadir productos escribiendo la referencia en el campo referencia, está autocompletando incluso productos que están bloqueados. Parece que no se está aplicando la restricción de:

No mostrar en búsquedas los productos bloqueados.
No mostrar en ventas los productos con se vende desmarcado.
No mostrar en compras los productos con se compra desmarcado.

[Tarea #948](https://facturascripts.com/roadmap/EditTask?code=948)

## How has this been tested?

<!---Replace `[ ]` with `[X]` to mark what you do in the next list.--->
<!---Reemplaza `[ ]` por `[X]` para marcar como completado en la lista.--->

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->