### PR TITLE
Tarea #971 - Añadidas opciones de salto de línea, mostrar cantidad y mostrar precios

### DIFF
--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -174,6 +174,54 @@ trait CommonLineHTML
             . $i18n->trans('more') . '"><i class="fas fa-ellipsis-h"></i></button></div>';
     }
 
+    private static function showCantidad(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, string $field): string
+    {
+        $attributes = $model->editable ?
+            'name="' . $field . '_' . $idlinea . '" id="ch' . $field . '_' . $idlinea . '"' :
+            'disabled=""';
+        $checked = (bool)$line->{$field} ? 'checked' : '';
+        return '<div class="col-12">'
+            . '<div class="form-check">'
+            . '<input type="checkbox" ' . $attributes . ' value="1" ' . $checked . ' class="form-check-input"/>'
+            . '<label class="form-check-label" for="ch' . $field . '_' . $idlinea . '">'
+            . $i18n->trans('show-quantity')
+            . '</label>'
+            . '</div>'
+            . '</div>';
+    }
+
+    private static function showPrecio(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, string $field): string
+    {
+        $attributes = $model->editable ?
+            'name="' . $field . '_' . $idlinea . '" id="ch' . $field . '_' . $idlinea . '"' :
+            'disabled=""';
+        $checked = (bool)$line->{$field} ? 'checked' : '';
+        return '<div class="col-12">'
+            . '<div class="form-check">'
+            . '<input type="checkbox" ' . $attributes . ' value="1" ' . $checked . ' class="form-check-input"/>'
+            . '<label class="form-check-label" for="ch' . $field . '_' . $idlinea . '">'
+            . $i18n->trans('show-price')
+            . '</label>'
+            . '</div>'
+            . '</div>';
+    }
+
+    private static function saltoPagina(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, string $field): string
+    {
+        $attributes = $model->editable ?
+            'name="' . $field . '_' . $idlinea . '" id="ch' . $field . '_' . $idlinea . '"' :
+            'disabled=""';
+        $checked = (bool)$line->{$field} ? 'checked' : '';
+        return '<div class="col-12">'
+            . '<div class="form-check">'
+            . '<input type="checkbox" ' . $attributes . ' value="1" ' . $checked . ' class="form-check-input"/>'
+            . '<label class="form-check-label" for="ch' . $field . '_' . $idlinea . '">'
+            . $i18n->trans('page-break')
+            . '</label>'
+            . '</div>'
+            . '</div>';
+    }
+
     private static function suplido(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, string $jsFunc): string
     {
         $attributes = $model->editable ?

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -189,6 +189,9 @@ class SalesLineHTML
         $line->dtopor2 = (float)$formData['dtopor2_' . $id];
         $line->descripcion = $formData['descripcion_' . $id];
         $line->irpf = (float)($formData['irpf_' . $id] ?? '0');
+        $line->mostrar_cantidad = (bool)($formData['mostrar_cantidad_' . $id] ?? '0');
+        $line->mostrar_precio = (bool)($formData['mostrar_precio_' . $id] ?? '0');
+        $line->salto_pagina = (bool)($formData['salto_pagina_' . $id] ?? '0');
         $line->suplido = (bool)($formData['suplido_' . $id] ?? '0');
         $line->pvpunitario = (float)$formData['pvpunitario_' . $id];
 
@@ -356,6 +359,12 @@ class SalesLineHTML
             case 'irpf':
                 return self::irpf($i18n, $idlinea, $line, $model, 'salesFormAction');
 
+            case 'mostrar_cantidad':
+                return self::showCantidad($i18n, $idlinea, $line, $model, 'mostrar_cantidad');
+
+            case 'mostrar_precio':
+                return self::showPrecio($i18n, $idlinea, $line, $model, 'mostrar_precio');
+
             case 'pvpunitario':
                 return self::precio($i18n, $idlinea, $line, $model, 'salesFormActionWait');
 
@@ -364,6 +373,9 @@ class SalesLineHTML
 
             case 'referencia':
                 return self::referencia($i18n, $idlinea, $line, $model);
+
+            case 'salto_pagina':
+                return self::saltoPagina($i18n, $idlinea, $line, $model, 'salto_pagina');
 
             case 'suplido':
                 return self::suplido($i18n, $idlinea, $line, $model, 'salesFormAction');
@@ -393,6 +405,11 @@ class SalesLineHTML
             . '<div class="form-row">'
             . self::renderField($i18n, $idlinea, $line, $model, 'suplido')
             . self::renderField($i18n, $idlinea, $line, $model, 'dtopor2')
+            . '</div>'
+            . '<div class="form-row">'
+            . self::renderField($i18n, $idlinea, $line, $model, 'mostrar_cantidad')
+            . self::renderField($i18n, $idlinea, $line, $model, 'mostrar_precio')
+            . self::renderField($i18n, $idlinea, $line, $model, 'salto_pagina')
             . '</div>'
             . '<div class="form-row">'
             . self::renderNewModalFields($i18n, $idlinea, $line, $model)

--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -264,6 +264,10 @@ abstract class PDFDocument extends PDFCore
             foreach ($this->getLineHeaders() as $key => $value) {
                 if ($key === 'referencia') {
                     $data[$key] = empty($line->{$key}) ? Utils::fixHtml($line->descripcion) : Utils::fixHtml($line->{$key} . " - " . $line->descripcion);
+                } elseif ($key === 'cantidad' && property_exists($line, 'mostrar_cantidad')) {
+                    $data[$key] = $line->mostrar_cantidad ? $line->{$key} : '';
+                } elseif ($key === 'pvpunitario' && property_exists($line, 'mostrar_precio')) {
+                    $data[$key] = $line->mostrar_precio ? $this->numberTools->format($line->{$key}) : '';
                 } elseif ($value['type'] === 'percentage') {
                     $data[$key] = $this->numberTools->format($line->{$key}) . '%';
                 } elseif ($value['type'] === 'number') {
@@ -274,10 +278,19 @@ abstract class PDFDocument extends PDFCore
             }
 
             $tableData[] = $data;
+
+            if (property_exists($line, 'salto_pagina') && $line->salto_pagina) {
+                $this->removeEmptyCols($tableData, $headers, $this->numberTools->format(0));
+                $this->pdf->ezTable($tableData, $headers, '', $tableOptions);
+                $tableData = [];
+                $this->pdf->ezNewPage();
+            }
         }
 
-        $this->removeEmptyCols($tableData, $headers, $this->numberTools->format(0));
-        $this->pdf->ezTable($tableData, $headers, '', $tableOptions);
+        if (false === empty($tableData)) {
+            $this->removeEmptyCols($tableData, $headers, $this->numberTools->format(0));
+            $this->pdf->ezTable($tableData, $headers, '', $tableOptions);
+        }
     }
 
     /**

--- a/Core/Model/Base/SalesDocumentLine.php
+++ b/Core/Model/Base/SalesDocumentLine.php
@@ -42,6 +42,13 @@ abstract class SalesDocumentLine extends BusinessDocumentLine
     public $mostrar_precio;
 
     /**
+     * Jump to a new page in the pdf if TRUE.
+     *
+     * @var bool
+     */
+    public $salto_pagina;
+
+    /**
      * Reset the values of all model properties.
      */
     public function clear()
@@ -49,5 +56,6 @@ abstract class SalesDocumentLine extends BusinessDocumentLine
         parent::clear();
         $this->mostrar_cantidad = true;
         $this->mostrar_precio = true;
+        $this->salto_pagina = false;
     }
 }

--- a/Core/Table/lineasalbaranescli.xml
+++ b/Core/Table/lineasalbaranescli.xml
@@ -99,6 +99,11 @@
         <type>character varying(30)</type>
     </column>
     <column>
+        <name>salto_pagina</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+    <column>
         <name>servido</name>
         <type>double precision</type>
         <null>NO</null>

--- a/Core/Table/lineasfacturascli.xml
+++ b/Core/Table/lineasfacturascli.xml
@@ -103,6 +103,11 @@
         <type>character varying(30)</type>
     </column>
     <column>
+        <name>salto_pagina</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+    <column>
         <name>servido</name>
         <type>double precision</type>
         <null>NO</null>

--- a/Core/Table/lineaspedidoscli.xml
+++ b/Core/Table/lineaspedidoscli.xml
@@ -99,6 +99,11 @@
         <type>character varying(30)</type>
     </column>
     <column>
+        <name>salto_pagina</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+    <column>
         <name>servido</name>
         <type>double precision</type>
         <null>NO</null>

--- a/Core/Table/lineaspresupuestoscli.xml
+++ b/Core/Table/lineaspresupuestoscli.xml
@@ -99,6 +99,11 @@
         <type>character varying(30)</type>
     </column>
     <column>
+        <name>salto_pagina</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+    <column>
         <name>servido</name>
         <type>double precision</type>
         <null>NO</null>

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -871,6 +871,7 @@
     "others-filters": "Otros filtros",
     "out-of-stock": "Sin stock",
     "page": "Página",
+    "page-break": "Salto de página",
     "page-configuration": "Página de Configuración",
     "page-option-info": "Estas son las opciones de maquetación y permisos de este formulario o listado. Puedes modificar el orden de los campos, ocultarlos, hacerlos de solo lectura o aumentar el nivel de privilegios. Los cambios se aplicarán al usuario seleccionado.",
     "page-total-amount": "Total de la página",


### PR DESCRIPTION
Añadir campo (checkbox) salto de página a las líneas de facturas, albaranes, pedidos y presupuestos de venta. Añadir también al formulario de edición los checkbox para los campos ya existentes mostrar_cantidad y mostrar_precio.

[Tarea #971](https://facturascripts.com/roadmap/EditTask?code=971)

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->