### PR TITLE
Mostrar el número de fila en los documentos de venta y compra.

### DIFF
--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -137,7 +137,7 @@ trait CommonLineHTML
             . '</div>';
     }
 
-    private static function referencia(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string
+    private static function referencia(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, int $numlinea): string
     {
         $sortable = $model->editable ?
             '<input type="hidden" name="orden_' . $idlinea . '" value="' . $line->orden . '"/>' :
@@ -146,12 +146,12 @@ trait CommonLineHTML
         $variante = new Variante();
         $where = [new DataBaseWhere('referencia', $line->referencia)];
         if (empty($line->referencia) || false === $variante->loadFromCode('', $where)) {
-            return '<div class="col-sm-2 col-lg-1 order-1">' . $sortable . '</div>';
+            return '<div class="col-sm-2 col-lg-1 order-1">' . $sortable . '<div class="small text-break"><small>' . $numlinea . '.</small></div></div>';
         }
 
         return '<div class="col-sm-2 col-lg-1 order-1">'
             . '<div class="small text-break"><div class="d-lg-none mt-2 text-truncate">' . $i18n->trans('reference') . '</div>'
-            . $sortable . '<a href="' . $variante->url() . '" target="_blank">' . $line->referencia . '</a>'
+            . $sortable . '<small>' . $numlinea . '.</small> <a href="' . $variante->url() . '" target="_blank">' . $line->referencia . '</a>'
             . '<input type="hidden" name="referencia_' . $idlinea . '" value="' . $line->referencia . '"/>'
             . '</div>'
             . '</div>';

--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -296,7 +296,7 @@ class PurchasesLineHTML
                 return self::recargo($i18n, $idlinea, $line, $model, 'purchasesFormActionWait');
 
             case 'referencia':
-                return self::referencia($i18n, $idlinea, $line, $model);
+                return self::referencia($i18n, $idlinea, $line, $model, self::$num);
 
             case 'suplido':
                 return self::suplido($i18n, $idlinea, $line, $model, 'purchasesFormAction');

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -363,7 +363,7 @@ class SalesLineHTML
                 return self::recargo($i18n, $idlinea, $line, $model, 'salesFormActionWait');
 
             case 'referencia':
-                return self::referencia($i18n, $idlinea, $line, $model);
+                return self::referencia($i18n, $idlinea, $line, $model, self::$num);
 
             case 'suplido':
                 return self::suplido($i18n, $idlinea, $line, $model, 'salesFormAction');


### PR DESCRIPTION
Al lado de la referencia en pequeño se muestra el número de fila para localizar rápido una fila del documento en archivos grandes.

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->