### PR TITLE
Task #636: Fix link province to country

### DIFF
--- a/Core/Model/ImpuestoZona.php
+++ b/Core/Model/ImpuestoZona.php
@@ -161,7 +161,9 @@ class ImpuestoZona extends ModelClass
     public function test() {
         if (empty($this->codpais)) {
             $this->codisopro = '';
-        } else {
+        }
+
+        if (false === empty($this->codisopro)) {
             $province = $this->getProvince();
             if ($province->codpais !== $this->codpais) {
                 $this->toolBox()->i18nLog()->warning('province-not-country');

--- a/Core/Model/ImpuestoZona.php
+++ b/Core/Model/ImpuestoZona.php
@@ -20,8 +20,8 @@ namespace FacturaScripts\Core\Model;
 
 use FacturaScripts\Core\Model\Base\ModelTrait;
 use FacturaScripts\Dinamic\Model\Base\ModelClass;
-use FacturaScripts\Dinamic\Model\Pais;
-use FacturaScripts\Dinamic\Model\Provincia;
+use FacturaScripts\Dinamic\Model\Pais as DinPais;
+use FacturaScripts\Dinamic\Model\Provincia as DinProvincia;
 
 /**
  * A tax (VAT) that can be associated to tax, country, province, and.
@@ -101,7 +101,7 @@ class ImpuestoZona extends ModelClass
      */
     public function getCountry()
     {
-        $country = new Pais();
+        $country = new DinPais();
         $country->loadFromCode($this->codpais);
         return $country;
     }
@@ -113,7 +113,7 @@ class ImpuestoZona extends ModelClass
      */
     public function getProvince()
     {
-        $province = new Provincia();
+        $province = new DinProvincia();
         $province->loadFromCode($this->codisopro);
         return $province;
     }
@@ -158,7 +158,8 @@ class ImpuestoZona extends ModelClass
      *
      * @return bool
      */
-    public function test() {
+    public function test()
+    {
         if (empty($this->codpais)) {
             $this->codisopro = null;
         }

--- a/Core/Model/ImpuestoZona.php
+++ b/Core/Model/ImpuestoZona.php
@@ -160,7 +160,7 @@ class ImpuestoZona extends ModelClass
      */
     public function test() {
         if (empty($this->codpais)) {
-            $this->codisopro = '';
+            $this->codisopro = null;
         }
 
         if (false === empty($this->codisopro)) {

--- a/Core/Table/impuestoszonas.xml
+++ b/Core/Table/impuestoszonas.xml
@@ -44,4 +44,12 @@
         <name>ca_impuestoszonas_impuestos2</name>
         <type>FOREIGN KEY (codimpuestosel) REFERENCES impuestos (codimpuesto) ON DELETE RESTRICT ON UPDATE CASCADE</type>
     </constraint>
+    <constraint>
+        <name>ca_impuestoszonas_paises</name>
+        <type>FOREIGN KEY (codpais) REFERENCES paises (codpais) ON DELETE SET NULL ON UPDATE CASCADE</type>
+    </constraint>    
+    <constraint>
+        <name>ca_impuestoszonas_provincias</name>
+        <type>FOREIGN KEY (codisopro) REFERENCES provincias (idprovincia) ON DELETE SET NULL ON UPDATE CASCADE</type>
+    </constraint>    
 </table>

--- a/Test/Core/Base/CalculatorTest.php
+++ b/Test/Core/Base/CalculatorTest.php
@@ -437,7 +437,10 @@ final class CalculatorTest extends TestCase
 
         // cargamos la lista de países
         $country = new Pais();
-        $this->assertTrue($country->loadFromCode('AND'), 'can-load-country-AND');
+        $country->codpais = 'AND';
+        $country->codiso = 'AD';
+        $country->nombre = 'ANDORRA';
+        $this->assertTrue($country->save(), 'can-not-save-country-AND');
 
         // creamos una zona o excepción para el IVA 21 en Andorra
         $zone1 = new ImpuestoZona();
@@ -498,7 +501,10 @@ final class CalculatorTest extends TestCase
 
         // cargamos la lista de países
         $country = new Pais();
-        $this->assertTrue($country->loadFromCode('AND'), 'can-load-country-AND');
+        $country->codpais = 'AND';
+        $country->codiso = 'AD';
+        $country->nombre = 'ANDORRA';
+        $this->assertTrue($country->save(), 'can-not-save-country-AND');
 
         // creamos una zona o excepción para el IVA 21 en Andorra
         $zone1 = new ImpuestoZona();

--- a/Test/Core/Base/CalculatorTest.php
+++ b/Test/Core/Base/CalculatorTest.php
@@ -437,6 +437,7 @@ final class CalculatorTest extends TestCase
 
         // cargamos la lista de países
         $country = new Pais();
+        $this->assertTrue($country->loadFromCode('AND'), 'can-load-country-AND');
 
         // creamos una zona o excepción para el IVA 21 en Andorra
         $zone1 = new ImpuestoZona();
@@ -494,6 +495,10 @@ final class CalculatorTest extends TestCase
             $tax1->iva = 20;
             $this->assertTrue($tax1->save(), 'can-not-save-iva20');
         }
+
+        // cargamos la lista de países
+        $country = new Pais();
+        $this->assertTrue($country->loadFromCode('AND'), 'can-load-country-AND');
 
         // creamos una zona o excepción para el IVA 21 en Andorra
         $zone1 = new ImpuestoZona();

--- a/Test/Core/Base/CalculatorTest.php
+++ b/Test/Core/Base/CalculatorTest.php
@@ -24,6 +24,7 @@ use FacturaScripts\Core\DataSrc\Series;
 use FacturaScripts\Core\Lib\RegimenIVA;
 use FacturaScripts\Core\Model\Impuesto;
 use FacturaScripts\Core\Model\ImpuestoZona;
+use FacturaScripts\Core\Model\Pais;
 use FacturaScripts\Core\Model\PresupuestoCliente;
 use FacturaScripts\Core\Model\PresupuestoProveedor;
 use FacturaScripts\Core\Model\Serie;
@@ -433,6 +434,9 @@ final class CalculatorTest extends TestCase
             $tax2->iva = 19;
             $this->assertTrue($tax2->save(), 'can-not-save-iva19');
         }
+
+        // cargamos la lista de países
+        $country = new Pais();
 
         // creamos una zona o excepción para el IVA 21 en Andorra
         $zone1 = new ImpuestoZona();


### PR DESCRIPTION
Database integrity has been forced for the codpais and codisoprov fields.
An error has been added in the model test if the selected country code does not match the country assigned to the province.

## How has this been tested?
- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
