### PR TITLE
Añadir soporte al widget select para cargar datos en base a otro widget.

### DIFF
--- a/Core/Assets/JS/WidgetSelect.js
+++ b/Core/Assets/JS/WidgetSelect.js
@@ -1,0 +1,64 @@
+function getValueTypeParent(parent) {
+    let term = '';
+
+    if (parent.is('input')) {
+        term = parent.val();
+    } else if (parent.is('select')) {
+        term = parent.find('option:selected').val();
+    } else if (parent.is('checkbox') && parent.prop("checked")) {
+        term = parent.val();
+    } else if (parent.is('radio')) {
+        term = parent.find(':checked').val();
+    } else if (parent.is('textarea')) {
+        term = parent.val();
+    }
+
+    return term;
+}
+
+function widgetSelectGetData(select) {
+    select.html('');
+
+    let data = {
+        action: 'select',
+        activetab: select.form().find('input[name="activetab"]').val(),
+        term: getValueTypeParent(select.form().find('[name="' + select.attr('parent') + '"]')),
+        field: select.attr("data-field"),
+        fieldcode: select.attr("data-fieldcode"),
+        fieldfilter: select.attr("data-fieldfilter"),
+        fieldtitle: select.attr("data-fieldtitle"),
+        source: select.attr("data-source"),
+    };
+
+    $.ajax({
+        method: "POST",
+        url: window.location.href,
+        data: data,
+        dataType: "json",
+        success: function (results) {
+            results.forEach(function (element) {
+                let selected = (element.key == select.attr('value')) ? 'selected' : '';
+                select.append('<option value="'+element.key+'" '+selected+'>'+element.value+'</option>');
+            });
+        },
+        error: function (msg) {
+            alert(msg.status + " " + msg.responseText);
+        }
+    });
+}
+
+$(document).ready(function () {
+    $('.parentSelect').each(function(){
+        let parent = $(this).attr('parent');
+        if (parent === 'undefined' || parent === false || parent === '') {
+            return;
+        }
+
+        let select = $(this);
+        select.form().find('select[name="' + parent + '"]').on('change', function(){
+            widgetSelectGetData(select);
+        });
+
+        widgetSelectGetData(select);
+    });
+});

--- a/Core/Lib/ExtendedController/BaseController.php
+++ b/Core/Lib/ExtendedController/BaseController.php
@@ -405,4 +405,32 @@ abstract class BaseController extends Controller
         }
         return $result;
     }
+
+    /**
+     * Run the select action.
+     * Returns a JSON string for the searched values.
+     *
+     * @return array
+     */
+    protected function selectAction(): array
+    {
+        $data = $this->requestGet(['field', 'fieldcode', 'fieldfilter', 'fieldtitle', 'formname', 'source', 'term']);
+
+        $where = [];
+        foreach (DataBaseWhere::applyOperation($data['fieldfilter'] ?? '') as $field => $operation) {
+            $where[] = new DataBaseWhere($field, $data['term'], '=', $operation);
+        }
+
+        $results = [];
+        $utils = $this->toolBox()->utils();
+        foreach ($this->codeModel->all($data['source'], $data['fieldcode'], $data['fieldtitle'], false, $where) as $value) {
+            $results[] = ['key' => $utils->fixHtml($value->code), 'value' => $utils->fixHtml($value->description)];
+        }
+
+        if (empty($results)) {
+            $results[] = ['key' => null, 'value' => $this->toolBox()->i18n()->trans('no-data')];
+        }
+
+        return $results;
+    }
 }

--- a/Core/Lib/ExtendedController/PanelController.php
+++ b/Core/Lib/ExtendedController/PanelController.php
@@ -296,6 +296,12 @@ abstract class PanelController extends BaseController
                     $this->views[$this->active]->model->clear();
                 }
                 break;
+
+            case 'select':
+                $this->setTemplate(false);
+                $results = $this->selectAction();
+                $this->response->setContent(json_encode($results));
+                return false;
         }
 
         return true;


### PR DESCRIPTION
En muchas ocasiones necesitamos que un widget select cargue los datos en base a los datos de otro widget. Por ejemplo cargar las provincias en base al país seleccionado.

Caso de uso en el XMLView de EDitContacto
```
<column name="province" numcolumns="2" order="140">
    <widget type="select" fieldname="provincia" parent="codpais">
        <values source="provincias" fieldcode="idprovincia" fieldtitle="provincia" fieldfilter="codpais"/>
    </widget>
</column>
<column name="country" titleurl="ListPais" numcolumns="2" order="150">
    <widget type="select" fieldname="codpais" onclick="EditPais" required="true">
        <values source="paises" fieldcode="codpais" fieldtitle="nombre"/>
    </widget>
</column>
```

Podemos ver que el widget de la provincia hace referencia al widget del país, además en los valores de la provincia se le dice por que campo debe filtrar de los países.

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data
<!---- [ ] If additional tests was realized, added here--->