### PR TITLE
Fix Customer's risk updated

### DIFF
--- a/Core/Lib/CustomerRiskTools.php
+++ b/Core/Lib/CustomerRiskTools.php
@@ -85,6 +85,13 @@ class CustomerRiskTools
      */
     public static function getInvoicesRisk($codcliente, $idempresa = null): float
     {       
+        $unpaidInvoicesAmount = static::getUnpaidInvoices($codcliente, $idempresa);
+        
+        // If there are no unpaid invoices there is no need to calculate unpaid bills.
+        if($unpaidInvoicesAmount == 0.0) {
+            return 0.0;
+        }
+        
         $sqlInvoices = "SELECT idfactura FROM facturascli"
             . " WHERE codcliente = " . static::database()->var2str($codcliente)
             . " AND pagada = false";
@@ -101,7 +108,7 @@ class CustomerRiskTools
         }
 
         foreach (static::dataBase()->select($sqlReceipt) as $item) {
-            return (float) (static::getUnpaidInvoices($codcliente, $idempresa)-$item['total']);
+            return (float) ($unpaidInvoicesAmount-$item['total']);
         }
 
         return 0.0;

--- a/Core/Lib/CustomerRiskTools.php
+++ b/Core/Lib/CustomerRiskTools.php
@@ -76,7 +76,7 @@ class CustomerRiskTools
     }
 
     /**
-     * Returns the sum of the customer's unpaid invoices receipts.
+     * Returns the customer's unpaid invoices minus the customer's paid invoices receipts of those unpaid invoices.
      *
      * @param string $codcliente
      * @param int    $idempresa
@@ -84,14 +84,46 @@ class CustomerRiskTools
      * @return float
      */
     public static function getInvoicesRisk($codcliente, $idempresa = null): float
-    {
-        $sql = "SELECT SUM(importe) AS total FROM recibospagoscli"
+    {       
+        $sqlInvoices = "SELECT idfactura FROM facturascli"
             . " WHERE codcliente = " . static::database()->var2str($codcliente)
-            . " AND pagado = false";
+            . " AND pagada = false";
+        if (null !== $idempresa) {
+            $sqlInvoices .= " AND idempresa = " . static::database()->var2str($idempresa);
+        }
+        
+        $sqlReceipt = "SELECT SUM(importe) AS total FROM recibospagoscli"
+            . " WHERE codcliente = " . static::database()->var2str($codcliente)
+            . " AND idfactura in (".$sqlInvoices.")"
+            . " AND pagado = true";
+        if (null !== $idempresa) {
+            $sqlReceipt .= " AND idempresa = " . static::database()->var2str($idempresa);
+        }
+
+        foreach (static::dataBase()->select($sqlReceipt) as $item) {
+            return (float) (static::getUnpaidInvoices($codcliente, $idempresa)-$item['total']);
+        }
+
+        return 0.0;
+    }
+    
+    /**
+     * Returns the sum of the customer's unpaid invoices.
+     *
+     * @param string $codcliente
+     * @param int    $idempresa
+     *
+     * @return float
+     */
+    protected static function getUnpaidInvoices($codcliente, $idempresa = null): float
+    {
+        $sql = "SELECT SUM(total) AS total FROM facturascli"
+            . " WHERE codcliente = " . static::database()->var2str($codcliente)
+            . " AND pagada = false";
         if (null !== $idempresa) {
             $sql .= " AND idempresa = " . static::database()->var2str($idempresa);
         }
-
+        
         foreach (static::dataBase()->select($sql) as $item) {
             return (float) $item['total'];
         }

--- a/Core/Model/Base/Receipt.php
+++ b/Core/Model/Base/Receipt.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model\Base;
 
+use FacturaScripts\Dinamic\Lib\CustomerRiskTools;
 use FacturaScripts\Dinamic\Lib\ReceiptGenerator;
 use FacturaScripts\Dinamic\Model\Cliente;
 use FacturaScripts\Dinamic\Model\FormaPago;

--- a/Core/Model/Base/Receipt.php
+++ b/Core/Model/Base/Receipt.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model\Base;
 
 use FacturaScripts\Dinamic\Lib\ReceiptGenerator;
+use FacturaScripts\Dinamic\Model\Cliente;
 use FacturaScripts\Dinamic\Model\FormaPago;
 
 /**

--- a/Core/Model/Base/Receipt.php
+++ b/Core/Model/Base/Receipt.php
@@ -225,6 +225,8 @@ abstract class Receipt extends ModelOnChangeClass
     protected function onDelete()
     {
         $this->updateInvoice();
+        // Update client risk
+        $this->updateRisk();
         parent::onDelete();
     }
 
@@ -238,7 +240,10 @@ abstract class Receipt extends ModelOnChangeClass
             $this->newPayment();
             $this->updateInvoice();
         }
-
+        
+        // Update client risk
+        $this->updateRisk();
+        
         return true;
     }
 
@@ -246,6 +251,8 @@ abstract class Receipt extends ModelOnChangeClass
     {
         if (parent::saveUpdate($values)) {
             $this->updateInvoice();
+            // Update client risk
+            $this->updateRisk();
             return true;
         }
 
@@ -266,5 +273,15 @@ abstract class Receipt extends ModelOnChangeClass
         $invoice = $this->getInvoice();
         $generator = new ReceiptGenerator();
         $generator->update($invoice);
+    }
+    
+    protected function updateRisk() {
+        if (property_exists($this, 'codcliente')) {
+            $customer = new Cliente();
+            if ($customer->loadFromCode($this->codcliente)) {
+                $customer->riesgoalcanzado = CustomerRiskTools::getCurrent($customer->primaryColumnValue());
+                $customer->save();
+            }
+        }
     }
 }

--- a/Core/Model/Base/Receipt.php
+++ b/Core/Model/Base/Receipt.php
@@ -19,9 +19,7 @@
 
 namespace FacturaScripts\Core\Model\Base;
 
-use FacturaScripts\Dinamic\Lib\CustomerRiskTools;
 use FacturaScripts\Dinamic\Lib\ReceiptGenerator;
-use FacturaScripts\Dinamic\Model\Cliente;
 use FacturaScripts\Dinamic\Model\FormaPago;
 
 /**
@@ -227,8 +225,6 @@ abstract class Receipt extends ModelOnChangeClass
     protected function onDelete()
     {
         $this->updateInvoice();
-        // Update client risk
-        $this->updateRisk();
         parent::onDelete();
     }
 
@@ -243,9 +239,6 @@ abstract class Receipt extends ModelOnChangeClass
             $this->updateInvoice();
         }
         
-        // Update client risk
-        $this->updateRisk();
-        
         return true;
     }
 
@@ -253,8 +246,6 @@ abstract class Receipt extends ModelOnChangeClass
     {
         if (parent::saveUpdate($values)) {
             $this->updateInvoice();
-            // Update client risk
-            $this->updateRisk();
             return true;
         }
 
@@ -277,13 +268,4 @@ abstract class Receipt extends ModelOnChangeClass
         $generator->update($invoice);
     }
     
-    protected function updateRisk() {
-        if (property_exists($this, 'codcliente')) {
-            $customer = new Cliente();
-            if ($customer->loadFromCode($this->codcliente)) {
-                $customer->riesgoalcanzado = CustomerRiskTools::getCurrent($customer->primaryColumnValue());
-                $customer->save();
-            }
-        }
-    }
 }

--- a/Core/Model/ReciboCliente.php
+++ b/Core/Model/ReciboCliente.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Dinamic\Lib\CustomerRiskTools;
 use FacturaScripts\Dinamic\Model\Cliente as DinCliente;
 use FacturaScripts\Dinamic\Model\FacturaCliente as DinFacturaCliente;
 use FacturaScripts\Dinamic\Model\PagoCliente as DinPagoCliente;
@@ -29,8 +30,7 @@ use FacturaScripts\Dinamic\Model\PagoCliente as DinPagoCliente;
  *
  * @author Carlos Garcia Gomez <carlos@facturascripts.com>
  */
-class ReciboCliente extends Base\Receipt
-{
+class ReciboCliente extends Base\Receipt {
 
     use Base\ModelTrait;
 
@@ -44,14 +44,12 @@ class ReciboCliente extends Base\Receipt
      */
     public $gastos;
 
-    public function clear()
-    {
+    public function clear() {
         parent::clear();
         $this->gastos = 0.0;
     }
 
-    public function getInvoice(): DinFacturaCliente
-    {
+    public function getInvoice(): DinFacturaCliente {
         $invoice = new DinFacturaCliente();
         $invoice->loadFromCode($this->idfactura);
         return $invoice;
@@ -62,30 +60,26 @@ class ReciboCliente extends Base\Receipt
      *
      * @return DinPagoCliente[]
      */
-    public function getPayments(): array
-    {
+    public function getPayments(): array {
         $payModel = new DinPagoCliente();
         $where = [new DataBaseWhere('idrecibo', $this->idrecibo)];
         return $payModel->all($where, [], 0, 0);
     }
 
-    public function getSubject(): DinCliente
-    {
+    public function getSubject(): DinCliente {
         $cliente = new DinCliente();
         $cliente->loadFromCode($this->codcliente);
         return $cliente;
     }
 
-    public function install(): string
-    {
+    public function install(): string {
         // needed dependencies
         new Cliente();
 
         return parent::install();
     }
 
-    public function setExpiration(string $date)
-    {
+    public function setExpiration(string $date) {
         parent::setExpiration($date);
 
         // obtenemos los días de pago del cliente
@@ -115,13 +109,11 @@ class ReciboCliente extends Base\Receipt
         $this->vencimiento = date(self::DATE_STYLE, min($newDates));
     }
 
-    public static function tableName(): string
-    {
+    public static function tableName(): string {
         return 'recibospagoscli';
     }
 
-    public function url(string $type = 'auto', string $list = 'ListFacturaCliente?activetab=List'): string
-    {
+    public function url(string $type = 'auto', string $list = 'ListFacturaCliente?activetab=List'): string {
         if ('list' === $type && !empty($this->idfactura)) {
             return $this->getInvoice()->url() . '&activetab=List' . $this->modelClassName();
         } elseif ('pay' === $type) {
@@ -136,8 +128,7 @@ class ReciboCliente extends Base\Receipt
      *
      * @return bool
      */
-    protected function newPayment(): bool
-    {
+    protected function newPayment(): bool {
         if ($this->disablePaymentGeneration) {
             return false;
         }
@@ -151,4 +142,43 @@ class ReciboCliente extends Base\Receipt
         $pago->nick = $this->nick;
         return $pago->save();
     }
+
+    protected function onDelete() {
+        // Update client risk
+        $this->updateRisk();
+        parent::onDelete();
+    }
+
+    protected function saveInsert(array $values = []): bool {
+        // Update client risk
+        $this->updateRisk();
+
+        parent::saveInsert($values);
+        return true;
+    }
+
+    protected function saveUpdate(array $values = []): bool {
+        if (parent::saveUpdate($values)) {
+            // Update client risk
+            $this->updateRisk();
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Update customer risk when a receipt is created, updated or deleted.
+     *
+     * @return void
+     */
+    protected function updateRisk() {
+
+        $customer = new DinCliente();
+        if ($customer->loadFromCode($this->codcliente)) {
+            $customer->riesgoalcanzado = CustomerRiskTools::getCurrent($customer->primaryColumnValue());
+            $customer->save();
+        }
+    }
+
 }


### PR DESCRIPTION
Until now, if a user updated a customer's invoice receipt, the customer's risk remained the same. With this update the risk is updated. The risk calculation formula has also been changed in order to have a more realistic approximation of the risk. Now the formula is:
Risk = Cost of new orders + Cost of undelivered delivery notes + ( Amount of unpaid invoices - Amount of paid receipts of unpaid invoices).

## How has this been tested?

- [X] MySQL
- [ ] PostgreSQL
- [ ] Clean database
- [X] Database with random data