### PR TITLE
Tarea #680. Mensaje de advertencia cif duplicado

### DIFF
--- a/Core/Controller/EditCliente.php
+++ b/Core/Controller/EditCliente.php
@@ -232,4 +232,19 @@ class EditCliente extends ComercialContactController
             $columnShipping->widget->setValuesFromCodeModel($contacts2);
         }
     }
+
+    protected function execAfterAction($action) {
+        switch ($action) {
+            case 'save-ok':
+            case 'edit':
+                $testSubject = new \FacturaScripts\Dinamic\Model\Cliente();
+                $testSubject->loadFromCode($this->request->get('code', ''));
+
+                if ($testSubject->cifnifExists($testSubject->codcliente, $testSubject->cifnif)) {
+                    $this->toolBox()->i18nLog()->warning('duplicated-cifnif');
+                }
+        }
+        parent::execAfterAction($action);
+    }
+
 }

--- a/Core/Controller/EditProveedor.php
+++ b/Core/Controller/EditProveedor.php
@@ -229,4 +229,19 @@ class EditProveedor extends ComercialContactController
             $columnBilling->widget->setValuesFromCodeModel($contacts);
         }
     }
+
+    protected function execAfterAction($action) {
+        switch ($action) {
+            case 'save-ok':
+            case 'edit':
+                $testSubject = new \FacturaScripts\Dinamic\Model\Proveedor();
+                $testSubject->loadFromCode($this->request->get('code', ''));
+
+                if ($testSubject->cifnifExists($testSubject->codproveedor, $testSubject->cifnif)) {
+                    $this->toolBox()->i18nLog()->warning('duplicated-cifnif');
+                }
+        }
+        parent::execAfterAction($action);
+    }
+
 }

--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -211,6 +211,7 @@ class Cliente extends Base\ComercialContact
             }
         }
         $this->diaspago = empty($arrayDias) ? null : implode(',', $arrayDias);
+
         return parent::test();
     }
 
@@ -219,7 +220,7 @@ class Cliente extends Base\ComercialContact
         if (empty($this->codcliente)) {
             $this->codcliente = (string)$this->newCode();
         }
-
+        
         $return = parent::saveInsert($values);
         if ($return && empty($this->idcontactofact)) {
             $parts = explode(' ', $this->nombre);
@@ -243,7 +244,28 @@ class Cliente extends Base\ComercialContact
                 return $this->save();
             }
         }
-
+        
         return $return;
     }
+
+   /**
+     * Return true if cifnif exist in database
+     * @return boolean
+     */
+    public function cifnifExists(string $codcliente, string $cifnif): bool {
+        if ($cifnif === '') {
+            return false;
+        }
+        $where = [new DataBaseWhere('cifnif', $cifnif)
+            , new DataBaseWhere('codcliente', $codcliente, '<>')
+        ];
+        $testData = new \FacturaScripts\Dinamic\Model\Cliente();
+        $testData = $testData->all($where);
+       
+        if (count($testData) > 0) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/Core/Model/Proveedor.php
+++ b/Core/Model/Proveedor.php
@@ -172,4 +172,24 @@ class Proveedor extends Base\ComercialContact
 
         return $return;
     }
+
+    /**
+     * Return true if cifnif exist in database
+     * @return boolean
+     */
+    public function cifnifExists(string $codproveedor, string $cifnif): bool {
+        if ($cifnif === '') {
+            return false;
+        }
+        $where = [new DataBaseWhere('cifnif', $cifnif)
+            , new DataBaseWhere('codproveedor', $codproveedor, '<>')
+        ];
+        $testData = new \FacturaScripts\Dinamic\Model\Proveedor();
+        $testData = $testData->all($where);
+        if (count($testData) > 0) {
+            return true;
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
Añadir mensaje de advertencia al crear un cliente o proveedor cuyo cifnif ya existe. Pero dejar crearlo.