### PR TITLE
Mostrar número de línea en los documentos de compra y venta.

### DIFF
--- a/Core/Base/AjaxForms/CommonLineHTML.php
+++ b/Core/Base/AjaxForms/CommonLineHTML.php
@@ -171,7 +171,7 @@ trait CommonLineHTML
             . '</div>';
     }
 
-    private static function referencia(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model): string
+    private static function referencia(Translator $i18n, string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, int $numlinea): string
     {
         $sortable = $model->editable ?
             '<input type="hidden" name="orden_' . $idlinea . '" value="' . $line->orden . '"/>' :
@@ -180,11 +180,11 @@ trait CommonLineHTML
         $variante = new Variante();
         $where = [new DataBaseWhere('referencia', $line->referencia)];
         if (empty($line->referencia)) {
-            return '<div class="col-sm-2 col-lg-1 order-1">' . $sortable . '</div>';
+            return '<div class="col-sm-2 col-lg-1 order-1">' . $sortable . '<div class="small text-break"><small>' . $numlinea . '.</small></div></div>';
         }
 
         $link = $variante->loadFromCode('', $where) ?
-            '<a href="' . $variante->url() . '" target="_blank">' . $line->referencia . '</a>' :
+            '<small>' . $numlinea . '.</small> <a href="' . $variante->url() . '" target="_blank">' . $line->referencia . '</a>' :
             $line->referencia;
 
         return '<div class="col-sm-2 col-lg-1 order-1">'

--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -296,7 +296,7 @@ class PurchasesLineHTML
                 return self::recargo($i18n, $idlinea, $line, $model, 'purchasesFormActionWait');
 
             case 'referencia':
-                return self::referencia($i18n, $idlinea, $line, $model);
+                return self::referencia($i18n, $idlinea, $line, $model, self::$num);
 
             case 'suplido':
                 return self::suplido($i18n, $idlinea, $line, $model, 'purchasesFormAction');

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -373,7 +373,7 @@ class SalesLineHTML
                 return self::recargo($i18n, $idlinea, $line, $model, 'salesFormActionWait');
 
             case 'referencia':
-                return self::referencia($i18n, $idlinea, $line, $model);
+                return self::referencia($i18n, $idlinea, $line, $model, self::$num);
 
             case 'salto_pagina':
                 return self::genericBool($i18n, $idlinea, $line, $model, 'salto_pagina', 'page-break');


### PR DESCRIPTION
Es necesario poder mostrar el número de línea en los documentos. PlantillasPDF lleva dicha opción, es muy difícil mandar un pdf al cliente con muchas páginas y que te diga, la línea 127 está mal y al ir al documento debes buscarla con Ctrl+f o contanto las líneas.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.