### PR TITLE
Fix renumber method

### DIFF
--- a/Core/Model/Asiento.php
+++ b/Core/Model/Asiento.php
@@ -293,7 +293,7 @@ class Asiento extends Base\ModelOnChangeClass
         $number = 1;
         $sql = 'SELECT idasiento,numero,fecha FROM ' . static::tableName()
             . ' WHERE codejercicio = ' . self::$dataBase->var2str($exercise->codejercicio)
-            . ' ORDER BY fecha ASC, idasiento ASC';
+            . " ORDER BY fecha ASC, CASE WHEN operacion = 'A' THEN 1 ELSE 2 END ASC, idasiento ASC";
 
         $rows = self::$dataBase->selectLimit($sql, self::RENUMBER_LIMIT, $offset);
         while (!empty($rows)) {


### PR DESCRIPTION
- Fixed sql ordering to return opening record first.
- Modified the test so that it creates two entries with the date of the first day of the year and assigns one as opening operation.
- Added check that the first entry when reading all entries is the opening entry.

### How has the changes been tested? (english)
- [X] I have reviewed my code before sending it.
- [X] I have tested it on my PC.
- [ ] I have tested it on an empty database.
- [X] I have run the unit tests.