### PR TITLE
Solucionado bug al devolver el total calculado redondeado

### DIFF
--- a/Core/Base/Calculator.php
+++ b/Core/Base/Calculator.php
@@ -160,8 +160,8 @@ final class Calculator
         $subtotals['totalsuplidos'] = round($subtotals['totalsuplidos'], FS_NF0);
 
         // calculamos el total
-        $subtotals['total'] = $subtotals['neto'] + $subtotals['totalsuplidos'] + $subtotals['totaliva']
-            + $subtotals['totalrecargo'] - $subtotals['totalirpf'];
+        $subtotals['total'] = round($subtotals['neto'] + $subtotals['totalsuplidos'] + $subtotals['totaliva']
+            + $subtotals['totalrecargo'] - $subtotals['totalirpf'], FS_NF0);
 
         // turno para que los mods apliquen cambios
         foreach (self::$mods as $mod) {


### PR DESCRIPTION
Si no devolvemos el total de la factura cuando llamamos a Calculator los Test fallan al comprobar el total contra el total de su asiento.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [X] He probado que funciona correctamente con una base de datos vacía.
- [X] He ejecutado los tests unitarios.