### PR TITLE
Tarea #680. Añadir mensaje de advertencia al crear un cliente o proveedor cuyo cifnif ya existe. Pero dejar crearlo.

### DIFF
--- a/Core/Controller/EditCliente.php
+++ b/Core/Controller/EditCliente.php
@@ -247,4 +247,19 @@ class EditCliente extends ComercialContactController
             $columnShipping->widget->setValuesFromCodeModel($contacts2);
         }
     }
+
+    protected function execAfterAction($action) {
+        switch ($action) {
+            case 'save-ok':
+            case 'edit':
+                $testSubject = new \FacturaScripts\Dinamic\Model\Cliente();
+                $testSubject->loadFromCode($this->request->get('code', ''));
+
+                if ($testSubject->cifnifExists($testSubject->codcliente, $testSubject->cifnif)) {
+                    $this->toolBox()->i18nLog()->warning('duplicated-cifnif');
+                }
+        }
+        parent::execAfterAction($action);
+    }
+
 }

--- a/Core/Controller/EditProveedor.php
+++ b/Core/Controller/EditProveedor.php
@@ -246,4 +246,19 @@ class EditProveedor extends ComercialContactController
             $columnBilling->widget->setValuesFromCodeModel($contacts);
         }
     }
+
+    protected function execAfterAction($action) {
+        switch ($action) {
+            case 'save-ok':
+            case 'edit':
+                $testSubject = new \FacturaScripts\Dinamic\Model\Proveedor();
+                $testSubject->loadFromCode($this->request->get('code', ''));
+
+                if ($testSubject->cifnifExists($testSubject->codproveedor, $testSubject->cifnif)) {
+                    $this->toolBox()->i18nLog()->warning('duplicated-cifnif');
+                }
+        }
+        parent::execAfterAction($action);
+    }
+
 }

--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -216,11 +216,13 @@ class Cliente extends Base\ComercialContact
 
     protected function saveInsert(array $values = []): bool
     {
+        $this->toolBox()->i18nLog()->warning('Un mensaje porque me apetece');
         if (empty($this->codcliente)) {
             $this->codcliente = (string)$this->newCode();
         }
 
         $return = parent::saveInsert($values);
+        
         if ($return && empty($this->idcontactofact)) {
             $parts = explode(' ', $this->nombre);
 
@@ -240,10 +242,33 @@ class Cliente extends Base\ComercialContact
             $contact->tipoidfiscal = $this->tipoidfiscal;
             if ($contact->save()) {
                 $this->idcontactofact = $contact->idcontacto;
+                $this->toolBox()->i18nLog()->warning('saveInsert. Un mensaje porque me apetece');
+                error_log("cifnif duplicado.Mensajes mostrados\r\n", 3, "./r");
                 return $this->save();
             }
         }
-
+       
         return $return;
     }
+
+  
+
+    /**
+     * Return true if cifnif exist in database
+     * @return boolean
+     */
+    public function cifnifExists(string $codcliente, string $cifnif): bool {
+        if ($cifnif === '') {
+            return false;
+        }
+        $where = [new DataBaseWhere('cifnif', $cifnif)
+            , new DataBaseWhere('codcliente', $codcliente, '<>')
+        ];
+
+        if ($this->count($where) > 0) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/Core/Model/Proveedor.php
+++ b/Core/Model/Proveedor.php
@@ -172,4 +172,23 @@ class Proveedor extends Base\ComercialContact
 
         return $return;
     }
+
+    /**
+     * Return true if cifnif exist in database
+     * @return boolean
+     */
+    public function cifnifExists(string $codproveedor, string $cifnif): bool {
+        if ($cifnif === '') {
+            return false;
+        }
+        $where = [new DataBaseWhere('cifnif', $cifnif)
+            , new DataBaseWhere('codproveedor', $codproveedor, '<>')
+        ];
+
+        if ($this->count($where) > 0) {
+            return true;
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
Después de grabar cliente/proveedor, comprobar si ya existe un cliente/proveedor con ese cif
La comprobación se hace desde el controlador ya que como hace un redirect no se refleja el mensaje de cifnif duplicado