### PR TITLE
Patch not allowed actions for documents

### DIFF
--- a/Core/Base/AjaxForms/PurchasesController.php
+++ b/Core/Base/AjaxForms/PurchasesController.php
@@ -153,6 +153,17 @@ abstract class PurchasesController extends PanelController
         return false;
     }
 
+   /**
+     * @param $message
+     * @return void
+     */
+    private function sendNotAllowedResponse($message): void
+    {
+        $this->setTemplate(false);
+        $this->response->setStatusCode(401);
+        $this->response->setContent(json_encode(['ok' => false, 'messages' => self::ToolBox()::i18n()->trans($message)]));
+    }
+
     /**
      * @param string $action
      *
@@ -160,6 +171,15 @@ abstract class PurchasesController extends PanelController
      */
     protected function execPreviousAction($action)
     {
+        if (in_array($action, ['save-doc', 'save-status', 'save-paid']) && $this->permissions->allowUpdate === false){
+            $this->sendNotAllowedResponse('not-allowed-modify');
+            return false;
+        }
+
+        if ($action == 'delete-doc' && $this->permissions->allowDelete === false){
+            $this->sendNotAllowedResponse('not-allowed-delete');
+            return false;
+        }
         switch ($action) {
             case 'add-file':
                 return $this->addFileAction();

--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -156,6 +156,17 @@ abstract class SalesController extends PanelController
         return false;
     }
 
+   /**
+     * @param $message
+     * @return void
+     */
+    private function sendNotAllowedResponse($message): void
+    {
+        $this->setTemplate(false);
+        $this->response->setStatusCode(401);
+        $this->response->setContent(json_encode(['ok' => false, 'messages' => self::ToolBox()::i18n()->trans($message)]));
+    }
+
     /**
      * @param string $action
      *
@@ -163,6 +174,15 @@ abstract class SalesController extends PanelController
      */
     protected function execPreviousAction($action)
     {
+        if (in_array($action, ['save-doc', 'save-status', 'save-paid']) && $this->permissions->allowUpdate === false){
+            $this->sendNotAllowedResponse('not-allowed-modify');
+            return false;
+        }
+
+        if ($action == 'delete-doc' && $this->permissions->allowDelete === false){
+            $this->sendNotAllowedResponse('not-allowed-delete');
+            return false;
+        }
         switch ($action) {
             case 'add-file':
                 return $this->addFileAction();


### PR DESCRIPTION
# Descripción
Agregue un método en SalesController y PurchasesController que envía una respuesta de no autorizado para las acciones `save-doc save-status save-paid delete-doc`  en caso de que el usuario no tenga los permisos para hacerlo.


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

