### PR TITLE
Set default divisa to app default divisa

### DIFF
--- a/Core/Model/ProductoProveedor.php
+++ b/Core/Model/ProductoProveedor.php
@@ -97,6 +97,7 @@ class ProductoProveedor extends Base\ModelOnChangeClass
     {
         parent::clear();
         $this->actualizado = date(self::DATETIME_STYLE);
+        $this->coddivisa = $this->toolBox()->appSettings()->get('default', 'coddivisa');
         $this->dtopor = 0.0;
         $this->dtopor2 = 0.0;
         $this->neto = 0.0;


### PR DESCRIPTION
In the cost prices by supplier and currency, the default currency of the application is established in the initialization of values.

- [x] I have reviewed my code before sending it.
- [x] I have tested it on my PC.
- [ ] I have tested it on an empty database.
- [ ] I have run the unit tests.
