### PR TITLE
Mejora widget select encadenado

### DIFF
--- a/Core/Controller/EditAsiento.php
+++ b/Core/Controller/EditAsiento.php
@@ -296,6 +296,12 @@ class EditAsiento extends PanelController
                 }
 
                 $this->title .= ' ' . $view->model->primaryDescription();
+                $this->addButton($viewName, [
+                    'action' => 'CopyModel?model=' . $this->getModelClassName() . '&code=' . $view->model->primaryColumnValue(),
+                    'icon' => 'fas fa-cut',
+                    'label' => 'copy',
+                    'type' => 'link'
+                ]);
                 break;
         }
     }

--- a/Core/View/CopyModel.html.twig
+++ b/Core/View/CopyModel.html.twig
@@ -13,179 +13,67 @@
                     <input type="hidden" name="code" value="{{ fsc.modelCode }}"/>
                     <input type="hidden" name="model" value="{{ fsc.modelClass }}"/>
                     <div class="card shadow mb-4">
-                        <div class="card-body">
-                            <div class="form-row">
-                                {% if fsc.model.codcliente %}
+                        {% if fsc.modelClass == 'Asiento' %}
+                            {# copiar asientos #}
+                            <div class="card-body">
+                                <div class="form-row">
                                     <div class="col-sm">
+                                        {{ i18n.trans('concept') }}
                                         <div class="form-group">
-                                            <div class="input-group">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text">
-                                                        <i class="fas fa-search"></i>
-                                                    </span>
-                                                </div>
-                                                <input type="hidden" id="codclienteAutocomplete" name="codcliente"
-                                                       value="{{ fsc.model.codcliente }}"/>
-                                                <input type="text" id="codcliente"
-                                                       value="{{ fsc.model.nombrecliente | raw }}"
-                                                       class="form-control autocomplete-dc"
-                                                       data-field="codcliente" data-source="Cliente"
-                                                       data-fieldcode="codcliente" data-fieldtitle="nombre"
-                                                       placeholder="{{ i18n.trans('customer') }}" autocomplete="off"/>
-                                            </div>
+                                            <input type="text" name="concepto" value=""
+                                                   class="form-control" required=""/>
                                         </div>
                                     </div>
-                                {% elseif fsc.model.codproveedor %}
                                     <div class="col-sm">
+                                        {{ i18n.trans('daily') }}
                                         <div class="form-group">
-                                            <div class="input-group">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text">
-                                                        <i class="fas fa-search"></i>
-                                                    </span>
-                                                </div>
-                                                <input type="hidden" id="codproveedorAutocomplete" name="codproveedor"
-                                                       value="{{ fsc.model.codproveedor }}"/>
-                                                <input type="text" id="codproveedor"
-                                                       value="{{ fsc.model.nombre | raw }}"
-                                                       class="form-control autocomplete-dc"
-                                                       data-field="codproveedor" data-source="Proveedor"
-                                                       data-fieldcode="codproveedor" data-fieldtitle="nombre"
-                                                       placeholder="{{ i18n.trans('supplier') }}" autocomplete="off"/>
-                                            </div>
+                                            <select name="iddiario" class="form-control">
+                                                {{ fsc.loadDiaries()|raw }}
+                                            </select>
                                         </div>
                                     </div>
-                                {% endif %}
-                                <div class="col-sm">
-                                    <div class="form-group">
-                                        <input type="date" name="fecha" value="{{ "now" | date('Y-m-d') }}"
-                                               class="form-control" required=""/>
-                                    </div>
-                                </div>
-                                <div class="col-sm">
-                                    <div class="form-group">
-                                        <input type="time" name="hora" value="{{ "now" | date('H:i:s') }}"
-                                               class="form-control" required=""/>
-                                    </div>
-                                </div>
-                                {% if fsc.model.codcliente %}
                                     <div class="col-sm">
+                                        {{ i18n.trans('channel') }}
                                         <div class="form-group">
-                                            <div class="input-group">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text">
-                                                        <i class="fas fa-hashtag"></i>
-                                                    </span>
-                                                </div>
-                                                <input type="text" name="numero2" class="form-control"
-                                                       placeholder="{{ i18n.trans('number2') }}"/>
-                                            </div>
+                                            <input type="number" name="canal" value=""
+                                                   class="form-control"/>
                                         </div>
                                     </div>
-                                {% elseif fsc.model.codproveedor %}
                                     <div class="col-sm">
+                                        {{ i18n.trans('date') }}
                                         <div class="form-group">
-                                            <div class="input-group">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text">
-                                                        <i class="fas fa-hashtag"></i>
-                                                    </span>
-                                                </div>
-                                                <input type="text" name="numproveedor" class="form-control"
-                                                       placeholder="{{ i18n.trans('numsupplier') }}"/>
-                                            </div>
+                                            <input type="date" name="fecha" value="{{ "now" | date('Y-m-d') }}"
+                                                   class="form-control" required=""/>
                                         </div>
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                        <div class="table-responsive">
-                            <table class="table table-hover">
-                                <thead>
-                                <tr>
-                                    <th>{{ i18n.trans('reference') }}</th>
-                                    <th>{{ i18n.trans('description') }}</th>
-                                    <th class="text-right">{{ i18n.trans('quantity') }}</th>
-                                    <th class="text-right">{{ i18n.trans('price') }}</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                {% for line in fsc.model.getLines() %}
-                                    <tr>
-                                        <td>{{ line.referencia }}</td>
-                                        <td>{{ line.descripcion | raw | nl2br }}</td>
-                                        <td class="text-right">{{ line.cantidad }}</td>
-                                        <td class="text-right">{{ line.pvpunitario }}</td>
-                                    </tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                        <div class="card-body">
-                            <div class="form-row">
-                                <div class="col-sm">
-                                    <div class="form-group">
-                                        {{ i18n.trans('warehouse') }}
-                                        <select name="codalmacen" class="form-control" required="">
-                                            {% for item in fsc.codeModel.all('almacenes', 'codalmacen', 'nombre', false) %}
-                                                {% if item.code == fsc.model.codalmacen %}
-                                                    <option value="{{ item.code }}" selected="">
-                                                        {{ item.description }}
-                                                    </option>
-                                                {% else %}
-                                                    <option value="{{ item.code }}">
-                                                        {{ item.description }}
-                                                    </option>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="col-sm">
-                                    <div class="form-group">
-                                        {{ i18n.trans('serie') }}
-                                        <select name="codserie" class="form-control" required="">
-                                            {% for item in fsc.codeModel.all('series', 'codserie', 'descripcion', false) %}
-                                                {% if item.code == fsc.model.codserie %}
-                                                    <option value="{{ item.code }}" selected="">
-                                                        {{ item.description }}
-                                                    </option>
-                                                {% else %}
-                                                    <option value="{{ item.code }}">
-                                                        {{ item.description }}
-                                                    </option>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="col-sm">
-                                    <div class="form-group">
-                                        {{ i18n.trans('payment-method') }}
-                                        <select name="codpago" class="form-control" required="">
-                                            {% for item in fsc.codeModel.all('formaspago', 'codpago', 'descripcion', false) %}
-                                                {% if item.code == fsc.model.codpago %}
-                                                    <option value="{{ item.code }}" selected="">
-                                                        {{ item.description }}
-                                                    </option>
-                                                {% else %}
-                                                    <option value="{{ item.code }}">
-                                                        {{ item.description }}
-                                                    </option>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </select>
                                     </div>
                                 </div>
                             </div>
-                            <div class="form-row align-items-end">
-                                <div class="col-sm-8">
-                                    <div class="form-group">
-                                        {{ i18n.trans('observations') }}
-                                        <textarea name="observaciones"
-                                                  class="form-control">{{ fsc.model.observaciones }}</textarea>
-                                    </div>
-                                </div>
+                            <div class="table-responsive">
+                                <table class="table table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th>{{ i18n.trans('subaccount') }}</th>
+                                            <th>{{ i18n.trans('counterpart') }}</th>
+                                            <th>{{ i18n.trans('concept') }}</th>
+                                            <th>{{ i18n.trans('debit') }}</th>
+                                            <th>{{ i18n.trans('credit') }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for line in fsc.model.getLines() %}
+                                            <tr>
+                                                <td>{{ line.codsubcuenta }}</td>
+                                                <td>{{ line.codcontrapartida }}</td>
+                                                <td>{{ line.concepto }}</td>
+                                                <td>{{ line.debe }}</td>
+                                                <td>{{ line.haber }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        <div class="card-body">
+                            <div class="form-row">
                                 <div class="col-sm text-right">
                                     <div class="form-group">
                                         <button type="submit" class="btn btn-primary">
@@ -195,6 +83,193 @@
                                 </div>
                             </div>
                         </div>
+                            {# fin copiar asientos #}
+                        {% else %}
+                            {# copiar documentos #}
+                            <div class="card-body">
+                                <div class="form-row">
+                                    {% if fsc.model.codcliente %}
+                                        <div class="col-sm">
+                                            <div class="form-group">
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                    <span class="input-group-text">
+                                                        <i class="fas fa-search"></i>
+                                                    </span>
+                                                    </div>
+                                                    <input type="hidden" id="codclienteAutocomplete" name="codcliente"
+                                                           value="{{ fsc.model.codcliente }}"/>
+                                                    <input type="text" id="codcliente"
+                                                           value="{{ fsc.model.nombrecliente | raw }}"
+                                                           class="form-control autocomplete-dc"
+                                                           data-field="codcliente" data-source="Cliente"
+                                                           data-fieldcode="codcliente" data-fieldtitle="nombre"
+                                                           placeholder="{{ i18n.trans('customer') }}" autocomplete="off"/>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% elseif fsc.model.codproveedor %}
+                                        <div class="col-sm">
+                                            <div class="form-group">
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                    <span class="input-group-text">
+                                                        <i class="fas fa-search"></i>
+                                                    </span>
+                                                    </div>
+                                                    <input type="hidden" id="codproveedorAutocomplete" name="codproveedor"
+                                                           value="{{ fsc.model.codproveedor }}"/>
+                                                    <input type="text" id="codproveedor"
+                                                           value="{{ fsc.model.nombre | raw }}"
+                                                           class="form-control autocomplete-dc"
+                                                           data-field="codproveedor" data-source="Proveedor"
+                                                           data-fieldcode="codproveedor" data-fieldtitle="nombre"
+                                                           placeholder="{{ i18n.trans('supplier') }}" autocomplete="off"/>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                    <div class="col-sm">
+                                        <div class="form-group">
+                                            <input type="date" name="fecha" value="{{ "now" | date('Y-m-d') }}"
+                                                   class="form-control" required=""/>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm">
+                                        <div class="form-group">
+                                            <input type="time" name="hora" value="{{ "now" | date('H:i:s') }}"
+                                                   class="form-control" required=""/>
+                                        </div>
+                                    </div>
+                                    {% if fsc.model.codcliente %}
+                                        <div class="col-sm">
+                                            <div class="form-group">
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                    <span class="input-group-text">
+                                                        <i class="fas fa-hashtag"></i>
+                                                    </span>
+                                                    </div>
+                                                    <input type="text" name="numero2" class="form-control"
+                                                           placeholder="{{ i18n.trans('number2') }}"/>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% elseif fsc.model.codproveedor %}
+                                        <div class="col-sm">
+                                            <div class="form-group">
+                                                <div class="input-group">
+                                                    <div class="input-group-prepend">
+                                                    <span class="input-group-text">
+                                                        <i class="fas fa-hashtag"></i>
+                                                    </span>
+                                                    </div>
+                                                    <input type="text" name="numproveedor" class="form-control"
+                                                           placeholder="{{ i18n.trans('numsupplier') }}"/>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            <div class="table-responsive">
+                                <table class="table table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th>{{ i18n.trans('reference') }}</th>
+                                            <th>{{ i18n.trans('description') }}</th>
+                                            <th class="text-right">{{ i18n.trans('quantity') }}</th>
+                                            <th class="text-right">{{ i18n.trans('price') }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for line in fsc.model.getLines() %}
+                                            <tr>
+                                                <td>{{ line.referencia }}</td>
+                                                <td>{{ line.descripcion | raw | nl2br }}</td>
+                                                <td class="text-right">{{ line.cantidad }}</td>
+                                                <td class="text-right">{{ line.pvpunitario }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="card-body">
+                                <div class="form-row">
+                                    <div class="col-sm">
+                                        <div class="form-group">
+                                            {{ i18n.trans('warehouse') }}
+                                            <select name="codalmacen" class="form-control" required="">
+                                                {% for item in fsc.codeModel.all('almacenes', 'codalmacen', 'nombre', false) %}
+                                                    {% if item.code == fsc.model.codalmacen %}
+                                                        <option value="{{ item.code }}" selected="">
+                                                            {{ item.description }}
+                                                        </option>
+                                                    {% else %}
+                                                        <option value="{{ item.code }}">
+                                                            {{ item.description }}
+                                                        </option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm">
+                                        <div class="form-group">
+                                            {{ i18n.trans('serie') }}
+                                            <select name="codserie" class="form-control" required="">
+                                                {% for item in fsc.codeModel.all('series', 'codserie', 'descripcion', false) %}
+                                                    {% if item.code == fsc.model.codserie %}
+                                                        <option value="{{ item.code }}" selected="">
+                                                            {{ item.description }}
+                                                        </option>
+                                                    {% else %}
+                                                        <option value="{{ item.code }}">
+                                                            {{ item.description }}
+                                                        </option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm">
+                                        <div class="form-group">
+                                            {{ i18n.trans('payment-method') }}
+                                            <select name="codpago" class="form-control" required="">
+                                                {% for item in fsc.codeModel.all('formaspago', 'codpago', 'descripcion', false) %}
+                                                    {% if item.code == fsc.model.codpago %}
+                                                        <option value="{{ item.code }}" selected="">
+                                                            {{ item.description }}
+                                                        </option>
+                                                    {% else %}
+                                                        <option value="{{ item.code }}">
+                                                            {{ item.description }}
+                                                        </option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="form-row align-items-end">
+                                    <div class="col-sm-8">
+                                        <div class="form-group">
+                                            {{ i18n.trans('observations') }}
+                                            <textarea name="observaciones"
+                                                      class="form-control">{{ fsc.model.observaciones }}</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm text-right">
+                                        <div class="form-group">
+                                            <button type="submit" class="btn btn-primary">
+                                                <i class="fas fa-save"></i> {{ i18n.trans('save') }}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {# fin copiar documentos #}
+                        {% endif %}
                     </div>
                 </form>
             </div>
@@ -212,7 +287,7 @@
     <script src="{{ asset('node_modules/jquery-ui-dist/jquery-ui.min.js') }}"></script>
     <script type="text/javascript">
         function businessDocViewAutocompleteGetData(formId, formData, term) {
-            var rawForm = $("form[id=" + formId + "]").serializeArray();
+            let rawForm = $("form[id=" + formId + "]").serializeArray();
             $.each(rawForm, function (i, input) {
                 formData[input.name] = input.value;
             });
@@ -223,13 +298,13 @@
 
         $(document).ready(function () {
             $(".autocomplete-dc").each(function () {
-                var data = {
+                let data = {
                     field: $(this).attr("data-field"),
                     fieldcode: $(this).attr("data-fieldcode"),
                     fieldtitle: $(this).attr("data-fieldtitle"),
                     source: $(this).attr("data-source")
                 };
-                var formName = $(this).closest("form").attr("name");
+                let formName = $(this).closest("form").attr("name");
                 $(this).autocomplete({
                     source: function (request, response) {
                         $.ajax({
@@ -238,7 +313,7 @@
                             data: businessDocViewAutocompleteGetData(formName, data, request.term),
                             dataType: "json",
                             success: function (results) {
-                                var values = [];
+                                let values = [];
                                 results.forEach(function (element) {
                                     if (element.key === null || element.key === element.value) {
                                         values.push(element);
@@ -256,7 +331,7 @@
                     select: function (event, ui) {
                         if (ui.item.key !== null) {
                             $("#" + data.field + "Autocomplete").val(ui.item.key);
-                            var value = ui.item.value.split(" | ");
+                            let value = ui.item.value.split(" | ");
                             if (value.length > 1) {
                                 ui.item.value = value[1];
                             } else {


### PR DESCRIPTION
El widget select recoge los datos del widget padre que tiene encadenado. Según el tipo del padre así debería de coger las datos. Se ha modificado el js para recoger mejor esos datos en todos los casos.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.