### PR TITLE
Tarea #511 - Generar asientos de facturas sin asientos.

### DIFF
--- a/Core/Controller/EditCliente.php
+++ b/Core/Controller/EditCliente.php
@@ -194,8 +194,12 @@ class EditCliente extends ComercialContactController
                 $view->loadData('', $where, ['idcontacto' => 'DESC']);
                 break;
 
-            case 'ListAlbaranCliente':
             case 'ListFacturaCliente':
+                $view->loadData('', $where);
+                $this->addButtonGenerateAccountingInvoices('ListFacturaCliente', $codcliente);
+                break;
+
+            case 'ListAlbaranCliente':
             case 'ListPedidoCliente':
             case 'ListPresupuestoCliente':
             case 'ListReciboCliente':

--- a/Core/Controller/EditProveedor.php
+++ b/Core/Controller/EditProveedor.php
@@ -200,8 +200,12 @@ class EditProveedor extends ComercialContactController
                 $view->loadData('', $where, ['idcontacto' => 'DESC']);
                 break;
 
-            case 'ListAlbaranProveedor':
             case 'ListFacturaProveedor':
+                $view->loadData('', $where);
+                $this->addButtonGenerateAccountingInvoices('ListFacturaProveedor', $codproveedor);
+                break;
+
+            case 'ListAlbaranProveedor':
             case 'ListPedidoProveedor':
             case 'ListPresupuestoProveedor':
             case 'ListProductoProveedor':

--- a/Core/Controller/ListFacturaCliente.php
+++ b/Core/Controller/ListFacturaCliente.php
@@ -131,4 +131,12 @@ class ListFacturaCliente extends ListBusinessDocument
         $this->addFilterCheckbox('ListFacturaCliente', 'idasiento', 'invoice-without-acc-entry', 'idasiento', 'IS', null);
         $this->addButtonLockInvoice('ListFacturaCliente');
     }
+
+    protected function loadData($viewName, $view)
+    {
+        parent::loadData($viewName, $view);
+        if ($viewName === 'ListFacturaCliente') {
+            $this->addButtonGenerateAccountingInvoices('ListFacturaCliente');
+        }
+    }
 }

--- a/Core/Controller/ListFacturaProveedor.php
+++ b/Core/Controller/ListFacturaProveedor.php
@@ -72,6 +72,7 @@ class ListFacturaProveedor extends ListBusinessDocument
         $this->addFilterCheckbox('ListFacturaProveedor', 'pagada', 'unpaid', 'pagada', '=', false);
         $this->addFilterCheckbox('ListFacturaProveedor', 'idasiento', 'invoice-without-acc-entry', 'idasiento', 'IS', null);
         $this->addButtonLockInvoice('ListFacturaProveedor');
+        $this->addButtonGenerateAccountingInvoices('ListFacturaProveedor');
 
         if ($this->user->admin) {
             $this->addButton($viewName, [
@@ -157,6 +158,14 @@ class ListFacturaProveedor extends ListBusinessDocument
         }
 
         return parent::execPreviousAction($action);
+    }
+
+    protected function loadData($viewName, $view)
+    {
+        parent::loadData($viewName, $view);
+        if ($viewName === 'ListFacturaProveedor') {
+            $this->addButtonGenerateAccountingInvoices('ListFacturaProveedor');
+        }
     }
 
     protected function renumberInvoicesAction(): void

--- a/Core/Lib/ExtendedController/ComercialContactController.php
+++ b/Core/Lib/ExtendedController/ComercialContactController.php
@@ -252,6 +252,9 @@ abstract class ComercialContactController extends EditController
             case 'edit-file':
                 return $this->editFileAction();
 
+            case 'generate-accounting-entries':
+                return $this->generateAccountingEntriesAction($model, $allowUpdate, $this->dataBase);
+
             case 'group-document':
                 return $this->groupDocumentAction($codes, $model);
 

--- a/Core/Lib/ExtendedController/ListBusinessDocument.php
+++ b/Core/Lib/ExtendedController/ListBusinessDocument.php
@@ -181,6 +181,9 @@ abstract class ListBusinessDocument extends ListController
                 BusinessDocumentGenerator::setSameDate(true);
                 return $this->approveDocumentAction($codes, $model, $allowUpdate, $this->dataBase);
 
+            case 'generate-accounting-entries':
+                return $this->generateAccountingEntriesAction($model, $allowUpdate, $this->dataBase);
+
             case 'group-document':
                 return $this->groupDocumentAction($codes, $model);
 


### PR DESCRIPTION
[Tarea #511](https://facturascripts.com/roadmap/EditTask?code=511)

En vez de mostrar el botón solo en los listados de facturas de compras y ventas, se implemento de tal forma para mostrar el mismo botón dentro de la ficha del cliente y del proveedor. De este modo se consigue el mismo efecto de ambas partes.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.