### PR TITLE
La variable waitCounter ya está declarada.

### DIFF
--- a/Core/Assets/JS/WidgetSelect.js
+++ b/Core/Assets/JS/WidgetSelect.js
@@ -1,4 +1,4 @@
-let waitCounter = 0;
+let waitSelectCounter = 0;
 
 function getValueTypeParent(parent) {
     if (parent.is('select')) {
@@ -63,10 +63,10 @@ $(document).ready(function () {
         } else if (parent.is('input') || parent.is('textarea')) {
             parent.keyup(async function(){
                 // usamos un contador y un temporizador para solamente procesar la última llamada
-                waitCounter++;
-                let waitNum = waitCounter;
+                waitSelectCounter++;
+                let waitNum = waitSelectCounter;
                 await new Promise(r => setTimeout(r, 500));
-                if (waitNum < waitCounter) {
+                if (waitNum < waitSelectCounter) {
                     return false;
                 }
 


### PR DESCRIPTION
La variable waitCounter ya está declarada en los documentos de compra y venta, y al volverse a declarar en algún js de los que cargue el head da error. Por lo que se ha renombrado la variable del js de WidgetSelect.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.