### PR TITLE
Tarea #813

### DIFF
--- a/Core/Controller/ListFacturaCliente.php
+++ b/Core/Controller/ListFacturaCliente.php
@@ -66,14 +66,14 @@ class ListFacturaCliente extends ListBusinessDocument
     protected function createViewReceipts(string $viewName = 'ListReciboCliente')
     {
         $this->addView($viewName, 'ReciboCliente', 'receipts', 'fas fa-dollar-sign');
-        $this->addOrderBy($viewName, ['fecha', 'idrecibo'], 'date', 2);
+        $this->addOrderBy($viewName, ['fecha', 'idrecibo'], 'date');
         $this->addOrderBy($viewName, ['fechapago'], 'payment-date');
-        $this->addOrderBy($viewName, ['vencimiento'], 'expiration');
+        $this->addOrderBy($viewName, ['vencimiento'], 'expiration', 2);
         $this->addOrderBy($viewName, ['importe'], 'amount');
         $this->addSearchFields($viewName, ['codigofactura', 'observaciones']);
 
         // filtros
-        $this->addFilterPeriod($viewName, 'expiration', 'period', 'vencimiento');
+        $this->addFilterPeriod($viewName, 'period', 'expiration', 'vencimiento');
         $this->addFilterAutocomplete($viewName, 'codcliente', 'customer', 'codcliente', 'Cliente');
         $this->addFilterNumber($viewName, 'min-total', 'amount', 'importe', '>=');
         $this->addFilterNumber($viewName, 'max-total', 'amount', 'importe', '<=');

--- a/Core/Controller/ListFacturaProveedor.php
+++ b/Core/Controller/ListFacturaProveedor.php
@@ -94,14 +94,14 @@ class ListFacturaProveedor extends ListBusinessDocument
     protected function createViewReceipts(string $viewName = 'ListReciboProveedor')
     {
         $this->addView($viewName, 'ReciboProveedor', 'receipts', 'fas fa-dollar-sign');
-        $this->addOrderBy($viewName, ['fecha', 'idrecibo'], 'date', 2);
+        $this->addOrderBy($viewName, ['fecha', 'idrecibo'], 'date');
         $this->addOrderBy($viewName, ['fechapago'], 'payment-date');
-        $this->addOrderBy($viewName, ['vencimiento'], 'expiration');
+        $this->addOrderBy($viewName, ['vencimiento'], 'expiration', 2);
         $this->addOrderBy($viewName, ['importe'], 'amount');
         $this->addSearchFields($viewName, ['codigofactura', 'observaciones']);
 
         // filtros
-        $this->addFilterPeriod($viewName, 'expiration', 'period', 'vencimiento');
+        $this->addFilterPeriod($viewName, 'period', 'expiration', 'vencimiento');
         $this->addFilterAutocomplete($viewName, 'codproveedor', 'supplier', 'codproveedor', 'Proveedor');
         $this->addFilterNumber($viewName, 'min-total', 'amount', 'importe', '>=');
         $this->addFilterNumber($viewName, 'max-total', 'amount', 'importe', '<=');

--- a/Core/Lib/ExtendedController/ComercialContactController.php
+++ b/Core/Lib/ExtendedController/ComercialContactController.php
@@ -166,10 +166,13 @@ abstract class ComercialContactController extends EditController
         $this->addListView($viewName, $model, 'receipts', 'fas fa-dollar-sign');
 
         // sort options
-        $this->views[$viewName]->addOrderBy(['fecha'], 'date', 2);
+        $this->views[$viewName]->addOrderBy(['fecha'], 'date');
         $this->views[$viewName]->addOrderBy(['fechapago'], 'payment-date');
-        $this->views[$viewName]->addOrderBy(['vencimiento'], 'expiration');
+        $this->views[$viewName]->addOrderBy(['vencimiento'], 'expiration', 2);
         $this->views[$viewName]->addOrderBy(['importe'], 'amount');
+		
+		// filters
+        $this->views[$viewName]->addFilterPeriod('period','expiration', 'vencimiento');
 
         // search columns
         $this->views[$viewName]->addSearchFields(['codigofactura', 'observaciones']);

--- a/Core/XMLView/ListReciboCliente.xml
+++ b/Core/XMLView/ListReciboCliente.xml
@@ -42,6 +42,11 @@
         <column name="observations" order="150">
             <widget type="textarea" fieldname="observaciones"/>
         </column>
+		<column name="method-payment" order="155">
+            <widget type="autocomplete" fieldname="codpago">
+                <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
+            </widget>
+        </column>
         <column name="amount" display="right" order="160">
             <widget type="money" fieldname="importe">
                 <option color="danger">lt:0</option>

--- a/Core/XMLView/ListReciboProveedor.xml
+++ b/Core/XMLView/ListReciboProveedor.xml
@@ -42,6 +42,11 @@
         <column name="observations" order="150">
             <widget type="textarea" fieldname="observaciones"/>
         </column>
+		<column name="method-payment" order="155">
+            <widget type="autocomplete" fieldname="codpago">
+                <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
+            </widget>
+        </column>
         <column name="amount" display="right" order="160">
             <widget type="money" fieldname="importe">
                 <option color="danger">lt:0</option>


### PR DESCRIPTION
Tarea #813:
- Sustituir filtro en recibos, de Fecha a Vencimiento.
- Sustituir ordenación en recibos, de Fecha a Vencimiento.

# Descripción:
- En la pestaña de Recibos de las vistas de Facturas de Clientes y de Facturas de Proveedores, he sustituido el filtro de Fecha por el de Vencimiento. También he intercambiado el identificador del filtro y el label, para que se interprete que el dato a filtrar en el Vencimiento. 
- En la pestaña de Recibos de la edición de Clientes y en la de Proveedores,  he incluido el filtro de Vencimiento.
- He cambiado la ordenación predetermina de Fecha por el de Vencimiento, que será mas apropiado ya que la fecha del recibo no aparece en esos dos listados y en esa dos vistas de edición.