### PR TITLE
Task#1025 roles access

### DIFF
--- a/Core/Controller/EditUser.php
+++ b/Core/Controller/EditUser.php
@@ -182,7 +182,8 @@ class EditUser extends EditController
         $roleUserModel = new RoleUser();
         foreach ($roleUserModel->all([new DataBaseWhere('nick', $user->nick)]) as $roleUser) {
             foreach ($roleUser->getRoleAccess() as $roleAccess) {
-                if (false === $roleAccess->getPage()->showonmenu) {
+                $page = $roleAccess->getPage();
+                if (false === $page->exist() || false === $page->showonmenu) {
                     continue;
                 }
 

--- a/Core/Table/roles_access.xml
+++ b/Core/Table/roles_access.xml
@@ -60,10 +60,6 @@
         <type>FOREIGN KEY (codrole) REFERENCES roles (codrole) ON DELETE CASCADE ON UPDATE CASCADE</type>
     </constraint>
     <constraint>
-        <name>roles_access_page</name>
-        <type>FOREIGN KEY (pagename) REFERENCES pages (name) ON DELETE CASCADE ON UPDATE CASCADE</type>
-    </constraint>
-    <constraint>
         <name>unique_roles_access</name>
         <type>UNIQUE (codrole,pagename)</type>
     </constraint>

--- a/Test/Core/Model/RoleTest.php
+++ b/Test/Core/Model/RoleTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2023  Carlos García Gómez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Model;
+
+use FacturaScripts\Core\App\AppSettings;
+use FacturaScripts\Core\Model\Page;
+use FacturaScripts\Core\Model\Role;
+use FacturaScripts\Core\Model\RoleAccess;
+use FacturaScripts\Core\Model\User;
+use PHPUnit\Framework\TestCase;
+
+final class RoleTest extends TestCase
+{
+
+    public function testCreateRole()
+    {
+        $role = new Role();
+        $role->codrole = 'test1';
+        $role->descripcion = 'test1';
+        $this->assertTrue($role->save());
+
+        // comprobamos que se ha creado el grupo
+        $this->assertTrue($role->exists());
+
+        // eliminamos
+        $this->assertTrue($role->delete());
+    }
+
+    public function testCreateRoleWithoutCode()
+    {
+        $role = new Role();
+        $role->descripcion = 'test without code';
+        $this->assertTrue($role->save());
+
+        // comprobamos que se ha creado el grupo
+        $this->assertTrue($role->exists());
+
+        // eliminamos
+        $this->assertTrue($role->delete());
+    }
+
+    public function testRoleAccessAfterDelete()
+    {
+        // crear role
+        $role = new Role();
+        $role->descripcion = 'test without code';
+        $this->assertTrue($role->save());
+        $this->assertTrue($role->exists());
+
+        // crear page
+        $page = new Page();
+        $page->name = 'test5';
+        $page->title = 'test5';
+        $page->icon = 'fas fa-test';
+        $page->menu = 'admin';
+        $this->assertTrue($page->save());
+        $this->assertTrue($page->exists());
+
+        // crear role access
+        $rolePage = new RoleAccess();
+        $rolePage->codrole = $role->codrole;
+        $rolePage->pagename = $page->name;
+        $this->assertTrue($rolePage->save());
+        $this->assertTrue($rolePage->exists());
+
+        // borrarmos page
+        $this->assertTrue($page->delete());
+
+        // comprobamos que sigue existiendo roleaccess
+        $this->assertTrue($rolePage->exists());
+
+        // borramos roleacceess
+        $this->assertTrue($rolePage->delete());
+
+        // borramos role
+        $this->assertTrue($role->delete());
+    }
+}


### PR DESCRIPTION
# Descripción
- Se ha suprimido la FK entre el modelo RoleAccess y el modelo Page. Con esto se consigue que al eliminar las páginas al desactivar un plugin no desaparezcan los permisos de usuarios definidos.

## Description (english)
- The FK between the RoleAccess model and the Page model has been removed. With this it is achieved that when deleting the pages when deactivating a plugin the defined user permissions do not disappear.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [X] He ejecutado los tests unitarios.

### How has the changes been tested? (english)
Any modification must have been tested minimally. Mark or describe the tests you have performed:
- [X] I have reviewed my code before sending it.
- [X] I have tested it on my PC.
- [ ] I have tested it on an empty database.
- [X] I have run the unit tests.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT

### Help (english)
Here are some help links:
- (Documentation for developers) https://facturascripts.com/help?type=developer
- (Development roadmap) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT
