### PR TITLE
Task#461 cerrar pedido

### DIFF
--- a/Core/Base/AjaxForms/SalesHeaderHTML.php
+++ b/Core/Base/AjaxForms/SalesHeaderHTML.php
@@ -90,7 +90,7 @@ class SalesHeaderHTML
         $model->numero2 = $formData['numero2'] ?? $model->numero2;
         $model->tasaconv = (float)($formData['tasaconv'] ?? $model->tasaconv);
 
-        foreach (['codagente', 'codtrans', 'finoferta'] as $key) {
+        foreach (['codagente', 'codtrans', 'finoferta', 'servido'] as $key) {
             if (isset($formData[$key])) {
                 $model->{$key} = empty($formData[$key]) ? null : $formData[$key];
             }
@@ -346,6 +346,7 @@ class SalesHeaderHTML
             . self::renderField($i18n, $model, 'femail')
             . self::renderField($i18n, $model, 'user')
             . self::renderField($i18n, $model, 'codagente')
+            . self::renderField($i18n, $model, 'servido')
             . self::renderNewFields($i18n, $model)
             . '</div>'
             . '</div>'
@@ -552,6 +553,9 @@ class SalesHeaderHTML
             case 'provincia':
                 return self::addressField($i18n, $model, 'provincia', 'province', 6, 100);
 
+            case 'servido':
+                return self::servido($i18n, $model);
+
             case 'tasaconv':
                 return self::tasaconv($i18n, $model);
 
@@ -589,5 +593,32 @@ class SalesHeaderHTML
             }
         }
         return $html;
+    }
+
+    private static function servido(Translator $i18n, SalesDocument $model): string
+    {
+        if (false === property_exists($model, 'servido') || empty($model->primaryColumnValue())) {
+            return '';
+        }
+
+        $values = [
+            0 => $i18n->trans('pending'),
+            1 => $i18n->trans('partial'),
+            100 => $i18n->trans('completed'),
+        ];
+        $options = [];
+        foreach ($values as $key => $value) {
+            $options[] = ($key === $model->servido) ?
+                '<option value="' . $key . '" selected="">' . $value . '</option>' :
+                '<option value="' . $key . '">' . $value . '</option>';
+        }
+
+        $attributes = $model->editable ? 'name="servido"' : 'disabled=""';
+        return '<div class="col-sm-6">'
+            . '<div class="form-group">'
+            . $i18n->trans('served')
+            . '<select ' . $attributes . ' class="form-control">' . implode('', $options) . '</select>'
+            . '</div>'
+            . '</div>';
     }
 }

--- a/Core/Controller/DocumentStitcher.php
+++ b/Core/Controller/DocumentStitcher.php
@@ -210,6 +210,7 @@ class DocumentStitcher extends Controller
         }
 
         if ($full) {
+            $this->updateServedStatus($doc, true);
             $doc->setDocumentGeneration(false);
             $doc->idestado = $idestado;
             if (false === $doc->save()) {
@@ -217,6 +218,9 @@ class DocumentStitcher extends Controller
                 $this->toolBox()->i18nLog()->error('record-save-error');
                 return;
             }
+        } elseif ($this->updateServedStatus($doc, false)) {
+            $doc->setDocumentGeneration(false);
+            $doc->save();
         }
 
         // we get the lines again in case they have been updated
@@ -406,5 +410,21 @@ class DocumentStitcher extends Controller
                 $this->moreDocuments[] = $doc;
             }
         }
+    }
+
+    /**
+     *
+     * @param TransformerDocument $doc
+     * @param bool $full
+     * @return bool
+     */
+    protected function updateServedStatus(&$doc, bool $full): bool
+    {
+        if (isset($doc->servido)) {
+            $served = $full || (bool)$this->request->request->get('served_' . $doc->primaryColumnValue(), false);
+            $doc->servido = $served ? 100 : 1;
+            return true;
+        }
+        return false;
     }
 }

--- a/Core/Model/PedidoCliente.php
+++ b/Core/Model/PedidoCliente.php
@@ -126,6 +126,11 @@ class PedidoCliente extends Base\SalesDocument
             $this->finoferta = null;
         }
 
+        // force a value to served status
+        if (is_null( $this->servido)) {
+            $this->servido = 0;
+        }
+
         return parent::test();
     }
 }

--- a/Core/Model/PedidoCliente.php
+++ b/Core/Model/PedidoCliente.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2014-2022  Carlos Garcia Gomez     <carlos@facturascripts.com>
+ * Copyright (C) 2014-2023  Carlos Garcia Gomez     <carlos@facturascripts.com>
  * Copyright (C) 2014       Francesc Pineda Segarra <shawe.ewahs@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -30,6 +30,9 @@ use FacturaScripts\Dinamic\Model\LineaPedidoCliente as LineaPedido;
  */
 class PedidoCliente extends Base\SalesDocument
 {
+    const SERVED_NONE = 0;
+    const SERVED_PARTIAL = 1;
+    const SERVED_COMPLETE = 100;
 
     use Base\ModelTrait;
 
@@ -47,9 +50,21 @@ class PedidoCliente extends Base\SalesDocument
      */
     public $idpedido;
 
+    /**
+     * Indicates if the order is:
+     *   - 0 -> Not Served
+     *   - 1 -> Partially served
+     *   - 100 -> Completed
+     *
+     * @var int
+     */
+    public $servido;
+
     public function clear()
     {
         parent::clear();
+
+        $this->servido = self::SERVED_NONE;
 
         // set default expiration
         $expirationDays = $this->toolBox()->appSettings()->get('default', 'finofertadays');

--- a/Core/Table/pedidoscli.xml
+++ b/Core/Table/pedidoscli.xml
@@ -197,6 +197,11 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>servido</name>
+        <type>integer</type>
+        <default>0</default>
+    </column>
     <constraint>
         <name>pedidoscli_pkey</name>
         <type>PRIMARY KEY (idpedido)</type>

--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -222,6 +222,12 @@
                         <p>{{ doc.observaciones | raw }}</p>
                     {% endif %}
                 </div>
+                {% if doc.servido %}
+                <div class="col-sm-2">
+                    <input class="form-check-input" type="checkbox" value="true" name="served_{{ doc.primaryColumnValue() }}">
+                    <label class="form-check-label font-weight-bold">{{ i18n.trans('close-pending-order') }}</label>
+                </div>
+                {% endif %}
                 <div class="col-sm-3 text-right">
                     <p class="small mb-0">
                         <i class="far fa-calendar-alt fa-fw" aria-hidden="true"></i> {{ doc.fecha }}

--- a/Core/XMLView/ListPedidoCliente.xml
+++ b/Core/XMLView/ListPedidoCliente.xml
@@ -145,7 +145,7 @@
             <widget type="select" fieldname="servido" translate="true">
                 <values title="pending">0</values>
                 <values title="partial">1</values>
-                <values title="complete">100</values>
+                <values title="completed">100</values>
             </widget>
         </column>
     </columns>

--- a/Core/XMLView/ListPedidoCliente.xml
+++ b/Core/XMLView/ListPedidoCliente.xml
@@ -141,6 +141,13 @@
         <column name="date" display="right" order="420">
             <widget type="date" fieldname="fecha" />
         </column>
+        <column name="served" display="center" order="430">
+            <widget type="select" fieldname="servido" translate="true">
+                <values title="pending">0</values>
+                <values title="partial">1</values>
+                <values title="complete">100</values>
+            </widget>
+        </column>
     </columns>
     <rows>
         <row type="status">


### PR DESCRIPTION
# Descripción
- Añadido campo "servido" a la tabla y modelo de pedidos de clientes
- Añadida columna a la vista list
- Añadida columna al modal de la vista edit
- Añadido checkbox por documento, al controlador DocumentSwitcher. Ahora si el usuario marca el check, el pedido se marcará como completado indicando que no se desea servir el resto de material que no se ha servido del pedido. En caso de que el usuario no marque el nuevo check, se actualiza el estado de servido a completado o parcial según se haya servido todo el pedido o sólo una parte.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT
