### PR TITLE
Corrección por filtro de empresa

### DIFF
--- a/Core/Base/AjaxForms/PurchasesHeaderHTML.php
+++ b/Core/Base/AjaxForms/PurchasesHeaderHTML.php
@@ -69,8 +69,8 @@ class PurchasesHeaderHTML
             return;
         }
 
+        $model->setWarehouse($formData['codalmacen'] ?? $model->codalmacen);
         $model->cifnif = $formData['cifnif'] ?? $model->cifnif;
-        $model->codalmacen = $formData['codalmacen'] ?? $model->codalmacen;
         $model->coddivisa = $formData['coddivisa'] ?? $model->coddivisa;
         $model->codpago = $formData['codpago'] ?? $model->codpago;
         $model->codproveedor = $formData['codproveedor'] ?? $model->codproveedor;
@@ -261,7 +261,7 @@ class PurchasesHeaderHTML
                 return self::cifnif($i18n, $model);
 
             case 'codalmacen':
-                return self::codalmacen($i18n, $model);
+                return self::codalmacen($i18n, $model, 'purchasesFormAction');
 
             case 'coddivisa':
                 return self::coddivisa($i18n, $model);

--- a/Core/Base/AjaxForms/SalesHeaderHTML.php
+++ b/Core/Base/AjaxForms/SalesHeaderHTML.php
@@ -22,6 +22,7 @@ namespace FacturaScripts\Core\Base\AjaxForms;
 use FacturaScripts\Core\Base\Contract\SalesModInterface;
 use FacturaScripts\Core\Base\Translator;
 use FacturaScripts\Core\DataSrc\Agentes;
+use FacturaScripts\Core\Model\Almacen;
 use FacturaScripts\Core\DataSrc\Paises;
 use FacturaScripts\Core\Model\AgenciaTransporte;
 use FacturaScripts\Core\Model\Base\ModelCore;
@@ -76,8 +77,8 @@ class SalesHeaderHTML
             return;
         }
 
+        $model->setWarehouse($formData['codalmacen'] ?? $model->codalmacen);
         $model->cifnif = $formData['cifnif'] ?? $model->cifnif;
-        $model->codalmacen = $formData['codalmacen'] ?? $model->codalmacen;
         $model->codcliente = $formData['codcliente'] ?? $model->codcliente;
         $model->codigoenv = $formData['codigoenv'] ?? $model->codigoenv;
         $model->coddivisa = $formData['coddivisa'] ?? $model->coddivisa;
@@ -493,7 +494,7 @@ class SalesHeaderHTML
                 return self::codagente($i18n, $model);
 
             case 'codalmacen':
-                return self::codalmacen($i18n, $model);
+                return self::codalmacen($i18n, $model, 'salesFormAction');
 
             case 'codcliente':
                 return self::codcliente($i18n, $model);

--- a/Core/Model/Base/BusinessDocument.php
+++ b/Core/Model/Base/BusinessDocument.php
@@ -345,6 +345,26 @@ abstract class BusinessDocument extends ModelOnChangeClass
     }
 
     /**
+     * Sets warehouse and company for this document.
+     *
+     * @param string $codalmacen
+     *
+     * @return bool
+     */
+    public function setWarehouse(string $codalmacen): bool
+    {
+        $almacen = new Almacen();
+        if ($almacen->loadFromCode($codalmacen)) {
+            $this->codalmacen = $almacen->codalmacen;
+            $this->idempresa = $almacen->idempresa ?? $this->idempresa;
+            return true;
+        }
+
+        $this->toolBox()->i18nLog()->warning('warehouse-not-found');
+        return false;
+    }
+
+    /**
      * @return string
      */
     public function subjectColumnValue()
@@ -465,25 +485,5 @@ abstract class BusinessDocument extends ModelOnChangeClass
     {
         $more = ['codalmacen', 'coddivisa', 'codpago', 'codserie', 'fecha', 'hora', 'idempresa', 'numero', 'total'];
         parent::setPreviousData(array_merge($more, $fields));
-    }
-
-    /**
-     * Sets warehouse and company for this document.
-     *
-     * @param string $codalmacen
-     *
-     * @return bool
-     */
-    protected function setWarehouse(string $codalmacen): bool
-    {
-        $almacen = new Almacen();
-        if ($almacen->loadFromCode($codalmacen)) {
-            $this->codalmacen = $almacen->codalmacen;
-            $this->idempresa = $almacen->idempresa ?? $this->idempresa;
-            return true;
-        }
-
-        $this->toolBox()->i18nLog()->warning('warehouse-not-found');
-        return false;
     }
 }

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -22,6 +22,7 @@ namespace FacturaScripts\Core\Model;
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Empresas;
 use FacturaScripts\Dinamic\Lib\RegimenIVA;
+use FacturaScripts\Dinamic\Model\Almacen as DinAlmacen;
 use FacturaScripts\Dinamic\Model\CuentaBanco as DinCuentaBanco;
 
 /**
@@ -105,6 +106,18 @@ class Empresa extends Base\Contact
         $companyAccounts = new DinCuentaBanco();
         $where = [new DataBaseWhere($this->primaryColumn(), $this->primaryColumnValue())];
         return $companyAccounts->all($where, [], 0, 0);
+    }
+
+    /**
+     * Returns the warehouses associated with the company.
+     *
+     * @return DinAlmacen[]
+     */
+    public function getWarehouse(): array
+    {
+        $warehouse = new DinAlmacen();
+        $where = [new DataBaseWhere($this->primaryColumn(), $this->primaryColumnValue())];
+        return $warehouse->all($where, [], 0, 0);
     }
 
     public function install(): string


### PR DESCRIPTION
# Descripción

Aplicado filtro a las formas de pago para que sólo muestre las formas de pago de la empresa del documento.
Aplicado recálculo del documento cuando se cambia el almacén.

Cuando se produce un cambio de almacén puede provocar un al cambio de empresa. Así:
- Al cambiar de almacén se actualizan los datos de empresa y sus formas de pago.
- Cuando el documento es nuevo, y no se ha creado la cabecera permite el cambio de almacén entre empresas
- Cuando el documento está creado, sólo se permite cambiar entre almacenes de la misma empresa

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT