### PR TITLE
No contabilizar partida de impuestos

### DIFF
--- a/Core/Lib/Accounting/InvoiceToAccounting.php
+++ b/Core/Lib/Accounting/InvoiceToAccounting.php
@@ -400,6 +400,8 @@ class InvoiceToAccounting extends AccountingClass
         $concept .= $this->document->numproveedor ? ' (' . $this->document->numproveedor . ') - ' . $this->document->nombre :
             ' - ' . $this->document->nombre;
 
+        $serie = $this->document->getSerie();
+
         $entry = new Asiento();
         $this->setAccountingData($entry, $concept);
         if (false === $entry->save()) {
@@ -408,7 +410,7 @@ class InvoiceToAccounting extends AccountingClass
         }
 
         if ($this->addSupplierLine($entry) &&
-            $this->addPurchaseTaxLines($entry) &&
+            ($serie->siniva || $this->addPurchaseTaxLines($entry)) &&
             $this->addPurchaseIrpfLines($entry) &&
             $this->addPurchaseSuppliedLines($entry) &&
             $this->addGoodsPurchaseLine($entry) &&
@@ -430,6 +432,8 @@ class InvoiceToAccounting extends AccountingClass
         $concept .= $this->document->numero2 ? ' (' . $this->document->numero2 . ') - ' . $this->document->nombrecliente :
             ' - ' . $this->document->nombrecliente;
 
+        $serie = $this->document->getSerie();
+
         $entry = new Asiento();
         $this->setAccountingData($entry, $concept);
         if (false === $entry->save()) {
@@ -438,7 +442,7 @@ class InvoiceToAccounting extends AccountingClass
         }
 
         if ($this->addCustomerLine($entry) &&
-            $this->addSalesTaxLines($entry) &&
+            ($serie->siniva || $this->addSalesTaxLines($entry)) &&
             $this->addSalesIrpfLines($entry) &&
             $this->addSalesSuppliedLines($entry) &&
             $this->addGoodsSalesLine($entry) &&


### PR DESCRIPTION
# Descripción
- Cuando la serie está marcada como sin impuesto no se contabiliza la linea de asiento de impuestos ni recargo de equivalencia.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT