### PR TITLE
Obtenemos los idiomas del core, plugins y MyFiles.

### DIFF
--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -125,11 +125,41 @@ class Translator
     public function getAvailableLanguages(): array
     {
         $languages = [];
-        $dir = FS_FOLDER . '/Core/Translation';
-        foreach (scandir($dir, SCANDIR_SORT_ASCENDING) as $fileName) {
+
+        // obtenemos los idiomas del core
+        $dirCore = FS_FOLDER . '/Core/Translation';
+        foreach (scandir($dirCore, SCANDIR_SORT_ASCENDING) as $fileName) {
             if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
                 $key = substr($fileName, 0, -5);
                 $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
+            }
+        }
+
+        // obtenemos los idiomas de los plugins activos
+        foreach (Plugins::list() as $plugin) {
+            if (!$plugin->enabled) {
+                continue;
+            }
+
+            $dirPlugin = FS_FOLDER . '/Plugins/' . $plugin->name . '/Translation';
+            foreach (scandir($dirPlugin, SCANDIR_SORT_ASCENDING) as $fileName) {
+                if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
+                    $key = substr($fileName, 0, -5);
+                    if (!in_array($key, $languages)) {
+                        $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
+                    }
+                }
+            }
+        }
+
+        // obtenemos los idiomas personalizados
+        $dirCustom = FS_FOLDER . '/MyFiles/Translation';
+        foreach (scandir($dirCustom, SCANDIR_SORT_ASCENDING) as $fileName) {
+            if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
+                $key = substr($fileName, 0, -5);
+                if (!in_array($key, $languages)) {
+                    $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
+                }
             }
         }
 

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -124,36 +124,24 @@ class Translator
      */
     public function getAvailableLanguages(): array
     {
+        $directories = [FS_FOLDER . '/Core/Translation', FS_FOLDER . '/MyFiles/Translation'];
         $languages = [];
 
-        // obtenemos los idiomas del core
-        $dirCore = FS_FOLDER . '/Core/Translation';
-        foreach (scandir($dirCore, SCANDIR_SORT_ASCENDING) as $fileName) {
-            if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
-                $key = substr($fileName, 0, -5);
-                $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
-            }
-        }
-
-        // obtenemos los idiomas de los plugins activos
+        // obtenemos los directorios de los plugins
         foreach (Plugins::enabled() as $plugin) {
             $dirPlugin = FS_FOLDER . '/Plugins/' . $plugin->name . '/Translation';
-            foreach (scandir($dirPlugin, SCANDIR_SORT_ASCENDING) as $fileName) {
-                if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
-                    $key = substr($fileName, 0, -5);
-                    if (!isset($languages[$key])) {
-                        $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
-                    }
-                }
-            }
+            $directories[] = $dirPlugin;
         }
 
-        // obtenemos los idiomas personalizados
-        $dirCustom = FS_FOLDER . '/MyFiles/Translation';
-        foreach (scandir($dirCustom, SCANDIR_SORT_ASCENDING) as $fileName) {
-            if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
-                $key = substr($fileName, 0, -5);
-                if (!isset($languages[$key])) {
+        // obtenemos los idiomas según los directorios
+        foreach ($directories as $directory) {
+            if (false === file_exists($directory) || false === is_dir($directory)) {
+                continue;
+            }
+
+            foreach (scandir($directory, SCANDIR_SORT_ASCENDING) as $fileName) {
+                if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
+                    $key = substr($fileName, 0, -5);
                     $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
                 }
             }

--- a/Core/Base/Translator.php
+++ b/Core/Base/Translator.php
@@ -136,16 +136,12 @@ class Translator
         }
 
         // obtenemos los idiomas de los plugins activos
-        foreach (Plugins::list() as $plugin) {
-            if (!$plugin->enabled) {
-                continue;
-            }
-
+        foreach (Plugins::enabled() as $plugin) {
             $dirPlugin = FS_FOLDER . '/Plugins/' . $plugin->name . '/Translation';
             foreach (scandir($dirPlugin, SCANDIR_SORT_ASCENDING) as $fileName) {
                 if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
                     $key = substr($fileName, 0, -5);
-                    if (!in_array($key, $languages)) {
+                    if (!isset($languages[$key])) {
                         $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
                     }
                 }
@@ -157,7 +153,7 @@ class Translator
         foreach (scandir($dirCustom, SCANDIR_SORT_ASCENDING) as $fileName) {
             if ($fileName !== '.' && $fileName !== '..' && !is_dir($fileName) && substr($fileName, -5) === '.json') {
                 $key = substr($fileName, 0, -5);
-                if (!in_array($key, $languages)) {
+                if (!isset($languages[$key])) {
                     $languages[$key] = $this->trans('languages-' . substr($fileName, 0, -5));
                 }
             }


### PR DESCRIPTION
Actualmente la función getAvailableLanguages() de la clase Translator solo devuelve los idiomas del core. Eso es un problema cuando los plugins añades idiomas, o se personalizan idiomas desde MyFiles, ya que no se podrían seleccionar. Con está solución se obtienen todos los idiomas disponibles.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.