### PR TITLE
Corrección al obtener el formulario del WidgetSelect.

### DIFF
--- a/Core/Assets/JS/WidgetSelect.js
+++ b/Core/Assets/JS/WidgetSelect.js
@@ -55,11 +55,38 @@ $(document).ready(function () {
 
         let select = $(this);
         let parent = select.closest('form').find('[name="' + parentStr + '"]');
-
-        if (parent.is('select') || ['color', 'datetime-local', 'date', 'time', 'hidden'].includes(parent.attr('type'))) {
+        if (parent.is('select') || ['color', 'datetime-local', 'date', 'time'].includes(parent.attr('type'))) {
             parent.change(function(){
                 widgetSelectGetData(select, parent);
             });
+        } else if (parent.attr('type') === 'hidden') {
+            var hiddenInput = document.querySelector("[name='" + parentStr + "']");
+            hiddenInput.addEventListener('change', function () {
+                widgetSelectGetData(select, parent);
+            });
+
+            let previousValue = hiddenInput.value;
+
+            // 1: crea una instancia de MutationObserver
+            const observer = new MutationObserver((mutations) => {
+                // 2: iterar sobre la matriz `MutationRecord`
+                mutations.forEach(mutation => {
+                    // 3.1: comprobar si el tipo de mutación y el nombre del atributo coinciden
+                    // 3.2: verificar si el valor cambió
+                    if (
+                        mutation.type === 'attributes'
+                        && mutation.attributeName === 'value'
+                        && hiddenInput.value !== previousValue
+                    ) {
+                        previousValue = hiddenInput.value;
+                        // 3.4: activar el evento `cambio`
+                        hiddenInput.dispatchEvent(new Event('change'));
+                    }
+                });
+            });
+
+            // 4: observar cambios en `hiddenInput`
+            observer.observe(hiddenInput, { attributes: true });
         } else if (parent.is('input') || parent.is('textarea')) {
             parent.keyup(async function(){
                 // usamos un contador y un temporizador para solamente procesar la última llamada

--- a/Core/Assets/JS/WidgetSelect.js
+++ b/Core/Assets/JS/WidgetSelect.js
@@ -19,7 +19,7 @@ function widgetSelectGetData(select, parent) {
 
     let data = {
         action: 'select',
-        activetab: select.form().find('input[name="activetab"]').val(),
+        activetab: select.closest('form').find('input[name="activetab"]').val(),
         term: getValueTypeParent(parent),
         field: select.attr("data-field"),
         fieldcode: select.attr("data-fieldcode"),
@@ -54,7 +54,7 @@ $(document).ready(function () {
         }
 
         let select = $(this);
-        let parent = select.form().find('[name="' + parentStr + '"]');
+        let parent = select.closest('form').find('[name="' + parentStr + '"]');
 
         if (parent.is('select') || ['color', 'datetime-local', 'date', 'time', 'hidden'].includes(parent.attr('type'))) {
             parent.change(function(){


### PR DESCRIPTION
Al obtener el formulario donde se encuentra el select da error. Solo pasa al usar un EditListController, cambiando la forma en la que se obtiene el formulario corregimos el problema, y funciona tanto en un EditListController como en un EditController.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.