### PR TITLE
Tarea #1642 - Corrección al eliminar variante

### DIFF
--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -176,7 +176,7 @@ class Variante extends Base\ModelClass
     public function delete(): bool
     {
         // no se puede eliminar la variante principal
-        if ($this->referencia == $this->getProducto()->referencia) {
+        if ($this->referencia === $this->getProducto()->referencia) {
             $this->toolBox()->i18nLog()->warning('you-cant-delete-primary-variant');
             return false;
         }

--- a/Test/Core/Model/ProductoTest.php
+++ b/Test/Core/Model/ProductoTest.php
@@ -398,6 +398,31 @@ final class ProductoTest extends TestCase
         $this->assertFalse($variant->exists(), 'variant-still-exists');
     }
 
+    public function testVarianteWithRef()
+    {
+        // creamos un producto
+        $product = $this->getTestProduct();
+        $this->assertTrue($product->save(), 'product-cant-save');
+
+        // añadimos una variante con referencia
+        $variant = new Variante();
+        $variant->idproducto = $product->idproducto;
+        $variant->referencia = '0' . $product->referencia;
+        $this->assertTrue($variant->save(), 'variant-cant-save-with-ref');
+
+        // eliminamos variante
+        $this->assertTrue($variant->delete(), 'variant-cant-delete');
+
+        // comprobamos que no podemos eliminar la única variante
+        $where = [ new DataBaseWhere('referencia', $product->referencia) ];
+        $this->assertTrue($variant->loadFromCode('', $where), 'cant-reload-variant');
+        $this->assertFalse($variant->delete(), 'can-delete-only-variant');
+
+        // eliminamos el producto
+        $this->assertTrue($product->delete(), 'product-cant-delete');
+        $this->assertFalse($variant->exists(), 'variant-still-exists');
+    }
+
     public function testNegativePrice()
     {
         // creamos un producto con precio negativo


### PR DESCRIPTION
# Descripción
Al eliminar una variante cuya referencia numérica (08314) era igual a la referencia del producto (8314) daba error.
Se ha corregido dicho problema y se ha añadido un test unitario para comprobar que no vuelve a suceder.

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT
