### PR TITLE
Tarea #1565 - Update Font Awesome Version 6

### DIFF
--- a/Core/View/Installer/Install.html.twig
+++ b/Core/View/Installer/Install.html.twig
@@ -9,7 +9,6 @@
     <meta name="robots" content="noindex"/>
     <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="node_modules/@fortawesome/fontawesome-free/css/all.min.css"/>
-    <link rel="stylesheet" href="node_modules/@fortawesome/fontawesome-free/css/v4-shims.min.css"/>
     <link rel="shortcut icon" href="Core/Assets/Images/favicon.ico"/>
     <link rel="apple-touch-icon" sizes="180x180" href="Core/Assets/Images/apple-icon-180x180.png"/>
     <script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://facturascripts.com",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "5.*",
+    "@fortawesome/fontawesome-free": "6.*",
     "bootbox": "5.*",
     "bootstrap": "4.*",
     "chart.js": "2.*",


### PR DESCRIPTION
# Descripción
- Actualizar a la versión 6 en el archivo package.json
- No hace falta hacer nada más porque la versión 6 es compatible con las versiones anteriores, tanto la v5 como la v4.
- **We've tried our hardest to make Version 6 backward compatible with Font Awesome 5 and Font Awesome 4 too! Whether you're using Kits, components, hosting things yourself, using Web Fonts, or SVG + JS, we've done a lot to translate icons in existing projects to Version 6 automagically.**
- https://fontawesome.com/docs/web/setup/upgrade/whats-changed#backward-compatibility
- Unicamente se ha eliminado la linea que hacia referencia al archivo `v4-shims.min.css` que ya no es necesario al ser la versión 6 compatible con la 4.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

