### PR TITLE
Añadir el metodo remember a la clase Cache

### DIFF
--- a/Core/Cache.php
+++ b/Core/Cache.php
@@ -19,6 +19,8 @@
 
 namespace FacturaScripts\Core;
 
+use Closure;
+
 /**
  * @author Carlos García Gómez <carlos@facturascripts.com>
  */
@@ -107,5 +109,23 @@ final class Cache
         // reemplazamos / y \ por _
         $name = str_replace(['/', '\\'], '_', $key);
         return FS_FOLDER . self::FILE_PATH . '/' . $name . '.cache';
+    }
+
+    /**
+     * Obtenemos el valor almacenado si existe o por el contrario almacenamos lo que devuelva la funcion callback.
+     *
+     * @param  string  $key
+     * @param  \Closure  $callback
+     * @return mixed
+     */
+    public static function remember($key, Closure $callback)
+    {
+        if (! is_null($value = self::get($key))) {
+            return $value;
+        }
+
+        $value = $callback();
+        self::set($key, $value);
+        return $value;
     }
 }

--- a/Test/Core/CacheTest.php
+++ b/Test/Core/CacheTest.php
@@ -88,4 +88,37 @@ final class CacheTest extends TestCase
             $this->assertNull(Cache::get($key));
         }
     }
+
+    public function testCacheRememberKeyNotExist(): void
+    {
+        Cache::clear();
+
+        $key = 'test-key';
+        $value = 1;
+
+        $cacheValue = Cache::remember($key, function () use ($value) {
+            return $value + 1;
+        });
+
+        $this->assertEquals(Cache::get($key), $cacheValue, 'cache-value-not-found');
+        $this->assertNotEquals(Cache::get($key), $value, 'cache-value-not-found');
+    }
+
+    public function testCacheRememberKeyExist(): void
+    {
+        Cache::clear();
+
+        $key = 'test-key';
+        $value = '1234';
+        $closureValue = '5678';
+
+        Cache::set($key, $value);
+
+        $cacheValue = Cache::remember($key, function () use ($closureValue) {
+            return $closureValue;
+        });
+
+        $this->assertEquals(Cache::get($key), $cacheValue, 'cache-value-not-found');
+        $this->assertNotEquals(Cache::get($key), $closureValue, 'cache-value-not-found');
+    }
 }


### PR DESCRIPTION
# Descripción
- He añadido el método `remember` a la clase `Cache` que acepta dos parámetros. Uno la `key` de la `Cache` y el otro es una `función callback`. De esta forma, en una sola llamada podemos obtener el resultado y guardarlo en caché si no existe.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
