### PR TITLE
Tarea #1426 - Añadir opción mantener correlación fechas

### DIFF
--- a/Core/Lib/BusinessDocumentCode.php
+++ b/Core/Lib/BusinessDocumentCode.php
@@ -122,8 +122,10 @@ class BusinessDocumentCode
                     $expectedNumber >= $sequence->inicio &&
                     $document->codejercicio == $preCodejercicio) {
                     // hole found
-                    $document->fecha = $preDate;
-                    $document->hora = $preHour;
+                    if ($sequence->mantener_correlacion_fecha) {
+                        $document->fecha = $preDate;
+                        $document->hora = $preHour;
+                    }
                     $sequence->save();
                     return (string)$expectedNumber;
                 }

--- a/Core/Model/SecuenciaDocumento.php
+++ b/Core/Model/SecuenciaDocumento.php
@@ -59,6 +59,9 @@ class SecuenciaDocumento extends Base\ModelClass
     /** @var bool */
     public $usarhuecos;
 
+    /** @var bool */
+    public $mantener_correlacion_fecha;
+
     public function clear()
     {
         parent::clear();
@@ -67,6 +70,7 @@ class SecuenciaDocumento extends Base\ModelClass
         $this->numero = 1;
         $this->patron = '{EJE}{SERIE}{0NUM}';
         $this->usarhuecos = false;
+        $this->mantener_correlacion_fecha = true;
     }
 
     public function install(): string

--- a/Core/Table/secuencias_documentos.xml
+++ b/Core/Table/secuencias_documentos.xml
@@ -56,6 +56,12 @@
         <null>NO</null>
         <default>false</default>
     </column>
+    <column>
+        <name>mantener_correlacion_fecha</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
     <constraint>
         <name>secuencias_documentos_pkey</name>
         <type>PRIMARY KEY (idsecuencia)</type>

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -746,6 +746,7 @@
     "july": "Julio",
     "june": "Junio",
     "justified": "Justificado",
+    "keep-correlation-date": "Mantener correlación de fechas",
     "keys": "Claves",
     "lang-code": "Código de idioma",
     "language": "Idioma",

--- a/Core/XMLView/EditSecuenciaDocumento.xml
+++ b/Core/XMLView/EditSecuenciaDocumento.xml
@@ -67,6 +67,9 @@
             <column name="use-gaps" numcolumns="2" order="130">
                 <widget type="checkbox" fieldname="usarhuecos"/>
             </column>
+            <column name="keep-correlation-date" numcolumns="2" order="135">
+                <widget type="checkbox" fieldname="mantener_correlacion_fecha"/>
+            </column>
             <column name="pattern" order="140">
                 <widget type="text" fieldname="patron" maxlength="50" required="true"/>
             </column>


### PR DESCRIPTION
# Descripción
- Se añade la funcionalidad para disponer de una opción que permita elegir cuando se usan los huecos disponibles se mantenga la correlación en las fechas o no.
- He añadido el campo `mantener_correlacion_fecha` en la tabla.
- He añadido el campo `mantener_correlacion_fecha` en el modelo `BusinessDocumentCode`.
- He añadido el campo `mantener_correlacion_fecha` en la vista.
- He añadido el texto `mantener_correlacion_fecha` el archivo de traducciones 'es_ES'.
- He añadido los tests correspondientes.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.