### PR TITLE
PluginManager. Enabled plugins devuelve un array con plugins desactivados

### DIFF
--- a/Core/Base/PluginManager.php
+++ b/Core/Base/PluginManager.php
@@ -185,7 +185,9 @@ final class PluginManager
     {
         $enabled = [];
         foreach (self::$enabledPlugins as $value) {
-            $enabled[] = $value['name'];
+            if ($value['enabled']) {
+                $enabled[] = $value['name'];
+            }
         }
 
         return $enabled;


### PR DESCRIPTION
Al llamar a la función enabledPlugins() de PluginManager devuelve la lista de todos los plugins de la instalación, aunque no estén activos.

# Descripción
- Sólo añade el nombre del plugin al array si enabled === true

 He revisado mi código antes de enviarlo.
He probado que funciona correctamente en mi PC.
