### PR TITLE
Corrige nombre de campo

### DIFF
--- a/Core/XMLView/ListCuentaBanco.xml
+++ b/Core/XMLView/ListCuentaBanco.xml
@@ -36,7 +36,7 @@
             <widget type="text" fieldname="codsubcuenta"/>
         </column>
         <column name="expenses" order="130">
-            <widget type="text" fieldname="codsubcuentagastos"/>
+            <widget type="text" fieldname="codsubcuentagasto"/>
         </column>
         <column name="swift" order="140">
             <widget type="text" fieldname="swift"/>


### PR DESCRIPTION
# Descripción
- En la vista ListCuentaBanco la columna para los gastos el nombre de campo tenía una 's' de más, por lo que no se mostraba correctamente el dato de la columna.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT
