### PR TITLE
Completar tests del modelo contacto

### DIFF
--- a/Core/Model/Contacto.php
+++ b/Core/Model/Contacto.php
@@ -154,7 +154,7 @@ class Contacto extends Base\Contact
     {
         $results = [];
         $field = empty($fieldCode) ? $this->primaryColumn() : $fieldCode;
-        $fields = 'apellidos|cifnif|descripcion|email|empresa|idcontacto|nombre|observaciones|telefono1|telefono2';
+        $fields = 'apellidos|cifnif|descripcion|email|empresa|nombre|observaciones|telefono1|telefono2';
         $where[] = new DataBaseWhere($fields, mb_strtolower($query, 'UTF8'), 'LIKE');
         foreach ($this->all($where) as $item) {
             $results[] = new CodeModel(['code' => $item->{$field}, 'description' => $item->fullName()]);


### PR DESCRIPTION
# Descripción
- He eliminado `idcontacto` de los campos de la búsqueda en el método `codeModelSearch()`  porque en Postgresql falla al no tratarse de un string y no es necesario que se encuentre este campo en las búsquedas.
- He completado los tests para todos los métodos de la clase hasta alcanzar el 100% de cobertura.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

![image](https://github.com/NeoRazorX/facturascripts/assets/2836337/c4c921f8-ab39-41c6-8233-bad6167e7c1c)
