### PR TITLE
Cambiar la forma de cargar FontAwesome por SVG+JS.

### DIFF
--- a/Core/View/Installer/Install.html.twig
+++ b/Core/View/Installer/Install.html.twig
@@ -8,11 +8,11 @@
     <meta name="generator" content="FacturaScripts"/>
     <meta name="robots" content="noindex"/>
     <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css"/>
-    <link rel="stylesheet" href="node_modules/@fortawesome/fontawesome-free/css/all.min.css"/>
     <link rel="shortcut icon" href="Core/Assets/Images/favicon.ico"/>
     <link rel="apple-touch-icon" sizes="180x180" href="Core/Assets/Images/apple-icon-180x180.png"/>
     <script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
     <script type="text/javascript" src="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script type="text/javascript" src="{{ asset('node_modules/@fortawesome/fontawesome-free/js/all.js') }}"></script>
     <script>
         $(document).ready(function () {
             document.fs_install.fs_timezone.value = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/Core/View/Installer/Install.html.twig
+++ b/Core/View/Installer/Install.html.twig
@@ -8,11 +8,12 @@
     <meta name="generator" content="FacturaScripts"/>
     <meta name="robots" content="noindex"/>
     <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="node_modules/@fortawesome/fontawesome-free/css/all.min.css"/>
     <link rel="shortcut icon" href="Core/Assets/Images/favicon.ico"/>
     <link rel="apple-touch-icon" sizes="180x180" href="Core/Assets/Images/apple-icon-180x180.png"/>
     <script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
     <script type="text/javascript" src="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-    <script type="text/javascript" src="{{ asset('node_modules/@fortawesome/fontawesome-free/js/all.js') }}"></script>
+    <script type="text/javascript" src="node_modules/@fortawesome/fontawesome-free/js/all.js"></script>
     <script>
         $(document).ready(function () {
             document.fs_install.fs_timezone.value = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -42,7 +42,6 @@
     {% endfor %}
     {% block css %}
         <link rel="stylesheet" href="{{ asset('node_modules/bootstrap/dist/css/bootstrap.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('node_modules/@fortawesome/fontawesome-free/css/all.min.css') }}"/>
         <link rel="stylesheet" href="{{ asset('Dinamic/Assets/CSS/custom.css') }}?v=6"/>
     {% endblock %}
     {# Adds custom CSS assets #}
@@ -61,6 +60,7 @@
         <script src="{{ asset('node_modules/bootbox/dist/bootbox.min.js') }}"></script>
         <script src="{{ asset('node_modules/bootbox/dist/bootbox.locales.min.js') }}"></script>
         <script src="{{ asset('node_modules/pace-js/pace.min.js') }}"></script>
+        <script src="{{ asset('node_modules/@fortawesome/fontawesome-free/js/all.js') }}"></script>
         <script src="{{ asset('Dinamic/Assets/JS/Custom.js') }}?v=6"></script>
     {% endblock %}
     {# Adds custom JS assets #}

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -42,6 +42,7 @@
     {% endfor %}
     {% block css %}
         <link rel="stylesheet" href="{{ asset('node_modules/bootstrap/dist/css/bootstrap.min.css') }}"/>
+        <link rel="stylesheet" href="{{ asset('node_modules/@fortawesome/fontawesome-free/css/all.min.css') }}"/>
         <link rel="stylesheet" href="{{ asset('Dinamic/Assets/CSS/custom.css') }}?v=6"/>
     {% endblock %}
     {# Adds custom CSS assets #}

--- a/Core/View/Master/MicroTemplate.html.twig
+++ b/Core/View/Master/MicroTemplate.html.twig
@@ -35,6 +35,7 @@
         {% endblock %}
         {% block css %}
             <link rel="stylesheet" href="{{ asset('node_modules/bootstrap/dist/css/bootstrap.min.css') }}" />
+            <link rel="stylesheet" href="{{ asset('node_modules/@fortawesome/fontawesome-free/css/all.min.css') }}"/>
         {% endblock %}
         {# Adds custom CSS assets #}
         {% for css in assetManager.get('css') %}

--- a/Core/View/Master/MicroTemplate.html.twig
+++ b/Core/View/Master/MicroTemplate.html.twig
@@ -35,7 +35,6 @@
         {% endblock %}
         {% block css %}
             <link rel="stylesheet" href="{{ asset('node_modules/bootstrap/dist/css/bootstrap.min.css') }}" />
-            <link rel="stylesheet" href="{{ asset('node_modules/@fortawesome/fontawesome-free/css/all.min.css') }}" />
         {% endblock %}
         {# Adds custom CSS assets #}
         {% for css in assetManager.get('css') %}
@@ -44,6 +43,7 @@
         {% block javascripts %}
             <script type="text/javascript" src="{{ asset('node_modules/jquery/dist/jquery.min.js') }}"></script>
             <script type="text/javascript" src="{{ asset('node_modules/bootstrap/dist/js/bootstrap.bundle.min.js') }}"></script>
+            <script type="text/javascript" src="{{ asset('node_modules/@fortawesome/fontawesome-free/js/all.js') }}"></script>
         {% endblock %}
         {# Adds custom JS assets #}
         {% for js in assetManager.get('js') %}


### PR DESCRIPTION
FontAwesome está usando el sistema de capas viejo, por lo que con la última versión 6 (la actual que tiene el core) no se pueden disfrutar de muchas de las opciones que tiene para efectos en los iconos. Solo hay que dejar de cargar los iconos con CSS y usar SVG+JS.

Información y comparación de las 2 formas
https://fontawesome.com/docs/web/dig-deeper/webfont-vs-svg

Instalación
https://fontawesome.com/docs/web/setup/host-yourself/svg-js

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.