### PR TITLE
agregar phpdocs a constructoras

### DIFF
--- a/Core/Base/DataBase/DataBaseWhere.php
+++ b/Core/Base/DataBase/DataBaseWhere.php
@@ -66,12 +66,13 @@ class DataBaseWhere
     private $value;
 
     /**
-     * DataBaseWhere constructor.
+     * Filtra los resultados en los métodos all(), count() y loadFromCode() de los modelos.
+     * @link https://facturascripts.com/publicaciones/databasewhere-478
      *
-     * @param string $fields
-     * @param mixed $value
-     * @param string $operator
-     * @param string $operation
+     * @param string $fields Nombre del campo sobre el que se realiza el filtro. Se puede usar 'campo1|campo2|campo3'.
+     * @param mixed $value Valor por el cual se filtra.
+     * @param string $operator Operador a aplicar('=' por defecto): '=', '<', '>', '<=', '>=', '!=', 'IN', 'NOT IN', 'IS', 'IS NOT', 'LIKE', 'XLIKE', 'REGEXP'.
+     * @param string $operation Operador lógico a aplicar('AND' por defecto): 'AND', 'OR'. Importante: esta operación se aplica al propio elemento, no al siguiente.
      */
     public function __construct($fields, $value, $operator = '=', $operation = 'AND')
     {

--- a/Core/Model/Base/ModelClass.php
+++ b/Core/Model/Base/ModelClass.php
@@ -33,12 +33,13 @@ abstract class ModelClass extends ModelCore
 {
 
     /**
-     * Returns all models that correspond to the selected filters.
+     * Devuelve un array con todos los registros de del modelo que cumplen los parámetros indicados.
+     * @link https://facturascripts.com/publicaciones/all-863
      *
-     * @param array $where filters to apply to model records.
-     * @param array $order fields to use in the sorting. For example ['code' => 'ASC']
-     * @param int $offset
-     * @param int $limit
+     * @param array $where (opcional) filtros a aplicar al listado. Un array de filtros {@see DataBaseWhere}.
+     * @param array $order (opcional) ordenación a aplicar. Array ['key' => 'valor'] donde la key es el nombre de la columna y el valor puede ser ASC o DESC. Ejemplo ['fecha' => 'ASC'].
+     * @param int $offset (opcional) permite indicar un desplazamiento del primer registro a recorrer.
+     * @param int $limit (opcional) permite indicar el número máximo de registros(50 por defecto)(0 sin límite).
      *
      * @return static[]
      */


### PR DESCRIPTION
# Descripción

- Se añade documentación para los parámetros en la constructora extraída directamente de la documentación oficial de FacturaScripts.

- Se incluye enlace a la documentación que permite acceder a información ampliada.

Esta documentación de la constructora reduce la curva de aprendizaje y mejora la experiencia de desarrollo.

Se recomienda que el enlace de la documentación sean enlaces permanentes y así si se actualiza la documentación no haya que cambiar el código.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
