### PR TITLE
Tarea #2130 - Establecer idioma en los documentos de ventas según el idioma del cliente.

### DIFF
--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -226,11 +226,20 @@ abstract class SalesController extends PanelController
     protected function exportAction()
     {
         $this->setTemplate(false);
+
+        $subject_langcode = $this->views[static::MAIN_VIEW_NAME]->model->getSubject()->langcode;
+        $subject_langcode = (false === empty($subject_langcode)) ? $subject_langcode : null;
+
+        $request_langcode = $this->request->request->get('langcode', '');
+        $request_langcode = (false === empty($request_langcode)) ? $request_langcode : null;
+
+        $langcode = $request_langcode ?? $subject_langcode ?? '';
+
         $this->exportManager->newDoc(
             $this->request->get('option', ''),
             $this->title,
             (int)$this->request->request->get('idformat', ''),
-            $this->request->request->get('langcode', '')
+            $langcode
         );
         $this->exportManager->addBusinessDocPage($this->views[static::MAIN_VIEW_NAME]->model);
         $this->exportManager->show($this->response);


### PR DESCRIPTION
# Descripción
- Establecer idioma en los documentos de ventas según el idioma del cliente.
- De esta forma:
-- Si **NO** elige el idioma en el menú `Avanzado de Imprimir` y el cliente **NO** tiene definido el idioma, se establece el idioma **por defecto**.
-- Si **NO** elige el idioma en el `menú Avanzado de Imprimir` y el cliente **SI** tiene definido el idioma, se establece el idioma del **cliente**.
-- Si se elige el idioma en el `menú Avanzado de Imprimir` y el cliente tiene definido el idioma, prevalece lo que se haya elegido en el menú y se establece el idioma que se haya elegido en el `menú Avanzado de Imprimir`.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
