### PR TITLE
Tarea #958 - En modelo Variante, no permitir valores nulos en coste, precio o margen.

### DIFF
--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -270,6 +270,10 @@ class Variante extends Base\ModelClass
 
     public function save(): bool
     {
+        $this->precio = $this->precio ?: 0.0;
+        $this->coste = $this->coste ?: 0.0;
+        $this->margen = $this->margen ?: 0.0;
+
         if ($this->margen > 0) {
             $newPrice = $this->coste * (100 + $this->margen) / 100;
             $this->precio = round($newPrice, DinProducto::ROUND_DECIMALS);

--- a/Test/Core/Model/VarianteTest.php
+++ b/Test/Core/Model/VarianteTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Model;
+
+use FacturaScripts\Core\Model\Producto;
+use PHPUnit\Framework\TestCase;
+
+class VarianteTest extends TestCase
+{
+    public function testNotAllowNullValues()
+    {
+        $producto = new Producto();
+        $producto->save();
+
+        $variante = $producto->getVariants()[0];
+        $variante->coste = null;
+        $variante->precio = null;
+        $variante->margen = null;
+        $variante->save();
+
+        $this->assertNotNull($variante->coste);
+        $this->assertNotNull($variante->precio);
+        $this->assertNotNull($variante->margen);
+
+        $producto->delete();
+    }
+}


### PR DESCRIPTION
# Descripción
- Se modifica el método `save()` del modelo Variante para que no se permitan guardar valores `null` en los campos coste, precio o margen. 
- Siempre que venga por algún motivo un valor null, se asignará el valor 0.0 automáticamente.
- Se realizan los tests unitarios correspondientes para comprobar esta funcionalidad.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
