### PR TITLE
Tarea #1292 - Filtrar atributos en selector de variables.

### DIFF
--- a/Core/Table/atributos.xml
+++ b/Core/Table/atributos.xml
@@ -16,6 +16,12 @@
         <type>character varying(100)</type>
         <null>NO</null>
     </column>
+    <column>
+        <name>numerocombo</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>atributos_pkey</name>
         <type>PRIMARY KEY (codatributo)</type>

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -255,6 +255,7 @@
     "columns": "Columnas",
     "combination-code": "Código de combinación",
     "combinations": "Combinaciones",
+    "combo-number": "Número de combo",
     "commercial-terms": "Términos comerciales",
     "commission": "Comisión",
     "commission-general-info": "Relación de porcentajes de comisión que se aplican en la venta de productos. Se aplicará el porcentaje con las condiciones más restrictivas o concretas de las informadas.",

--- a/Core/XMLView/EditAtributo.xml
+++ b/Core/XMLView/EditAtributo.xml
@@ -25,7 +25,16 @@
             <column name="name" order="100">
                 <widget type="text" fieldname="nombre" maxlength="100" required="true"/>
             </column>
-            <column name="code" description="optional" numcolumns="3" order="110">
+            <column name="combo-number" order="200" numcolumns="2">
+                <widget type="select" fieldname="numerocombo" translate="true" required="true">
+                    <values title="select">0</values>
+                    <values title="1">1</values>
+                    <values title="2">2</values>
+                    <values title="3">3</values>
+                    <values title="4">4</values>
+                </widget>
+            </column>
+            <column name="code" description="optional" numcolumns="3" order="300">
                 <widget type="text" fieldname="codatributo" icon="fas fa-hashtag" maxlength="20" readonly="dinamic"/>
             </column>
         </group>


### PR DESCRIPTION
# Descripción
- Filtrar valores de atributos en la vista EditVariables, según el combo seleccionado en la vista EditAtributo.
- Se ha modificado el método `loadCustomAttributeWidgets()` para añadir los valores del Select desde el controlador filtrando los valores de los atributos según el combo elegido.
- Se ha agregado el campo `numerocombo` en la tabla `atributos` para guardar el combo seleccionado en cada atributo.
- Se completa los textos de traducciones necesarios.
- Se añade la columna numerocombo a la vista EditAtributo para que permita elegir al combo que pertenece cada atributo.
- El único inconveniente que veo en este sistema es que si dos o mas atributos eligen el mismo combo, se muestran sus valores unos tras otros.
- Se recomienda que estudien la posibilidad de implementar "maestro-detalle" con los atributos igual que pasa con las productos-variables(crear relación uno a muchos variables-atributos)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
