### PR TITLE
Tarea #2650 - No permitir comillas dobles

### DIFF
--- a/Core/Base/DataBase/MysqlQueries.php
+++ b/Core/Base/DataBase/MysqlQueries.php
@@ -266,6 +266,9 @@ class MysqlQueries implements DataBaseQueries
             }
         }
 
+        // No permitimos el uso de comillas dobles en las restricciones.
+        $sql = str_replace('"', '`', $sql);
+
         return $this->fixPostgresql($sql);
     }
 

--- a/Test/Core/Base/Base/DataBase/MysqlQueriesTest.php
+++ b/Test/Core/Base/Base/DataBase/MysqlQueriesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Base\DataBase;
+
+use FacturaScripts\Core\Base\DataBase\MysqlQueries;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use PHPUnit\Framework\TestCase;
+
+class MysqlQueriesTest extends TestCase
+{
+    use LogErrorsTrait;
+
+    public function testSqlTableConstraints()
+    {
+        $mysqlQueries = new MysqlQueries();
+
+        $xmlCons = [
+            [
+                'name' => 'ca_anticipos_users',
+                'constraint' => 'FOREIGN KEY ("user") REFERENCES users (nick) ON DELETE RESTRICT ON UPDATE CASCADE'
+            ]
+        ];
+
+        $result = $mysqlQueries->sqlTableConstraints($xmlCons);
+
+        $expected = ', CONSTRAINT ca_anticipos_users FOREIGN KEY (`user`) REFERENCES users (nick) ON DELETE RESTRICT ON UPDATE CASCADE';
+        $this->assertEquals($expected, $result);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}


### PR DESCRIPTION
# Descripción

- Cuando tenemos alguna columna con nombre reservado como user y además tenemos una restricción en dicha columna, en PostgreSQL es necesario poner el nombre de la columna entre comillas dobles, pero en MySQL con comillas tipo acento. 

- en PostgreSQL: FOREIGN KEY ("user") REFERENCES users (nick) ON DELETE RESTRICT ON UPDATE CASCADE
- en MySQL: FOREIGN KEY (\`user\`) REFERENCES users (nick) ON DELETE RESTRICT ON UPDATE CASCADE

- Modificamos la clase `MysqlQueries` cambiando en el método `sqlTableConstraints()` las comillas dobles por las comillas tipo acento. De esta forma solo tenemos que introducir una sola línea en la clase que se encuentra afectada por este BUG.

- Realizamos los tests unitarios que comprueban este BUG. En el test se podrían haber usados textos mas genéricos o dummy pero he querido poner este ejemplo que fue el que descubrió este BUG porque así resulta mas descriptivo y el resultado es el mismo.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.