### PR TITLE
Controlar el widget select parent cuando es required.

### DIFF
--- a/Core/Assets/JS/WidgetSelect.js
+++ b/Core/Assets/JS/WidgetSelect.js
@@ -20,12 +20,13 @@ function widgetSelectGetData(select, parent) {
     let data = {
         action: 'select',
         activetab: select.closest('form').find('input[name="activetab"]').val(),
-        term: getValueTypeParent(parent),
         field: select.attr("data-field"),
         fieldcode: select.attr("data-fieldcode"),
         fieldfilter: select.attr("data-fieldfilter"),
         fieldtitle: select.attr("data-fieldtitle"),
+        required: select.attr('required') === 'required' ? 1 : 0,
         source: select.attr("data-source"),
+        term: getValueTypeParent(parent),
     };
 
     $.ajax({

--- a/Core/Lib/ExtendedController/BaseController.php
+++ b/Core/Lib/ExtendedController/BaseController.php
@@ -420,6 +420,7 @@ abstract class BaseController extends Controller
      */
     protected function selectAction(): array
     {
+        $required = (bool)$this->request->get('required', false);
         $data = $this->requestGet(['field', 'fieldcode', 'fieldfilter', 'fieldtitle', 'formname', 'source', 'term']);
 
         $where = [];
@@ -429,12 +430,22 @@ abstract class BaseController extends Controller
 
         $results = [];
         $utils = $this->toolBox()->utils();
-        foreach ($this->codeModel->all($data['source'], $data['fieldcode'], $data['fieldtitle'], true, $where) as $value) {
+        foreach ($this->codeModel->all($data['source'], $data['fieldcode'], $data['fieldtitle'], false, $where) as $value) {
             $results[] = ['key' => $utils->fixHtml($value->code), 'value' => $utils->fixHtml($value->description)];
         }
 
+        // cuando el widget es requerido
+        // devolvemos los datos encontrados aunque estén vacíos
+        if ($required) {
+            return $results;
+        }
+
         if (empty($results)) {
+            // si no hay datos, añadimos un valor nulo avisando de que no hay datos
             $results[] = ['key' => null, 'value' => $this->toolBox()->i18n()->trans('no-data')];
+        } else {
+            // si hay datos, pero el widget no es requerido, añadimos un valor nulo al principio
+            $results = array_merge([['key' => null, 'value' => '------']], $results);
         }
 
         return $results;


### PR DESCRIPTION
Necesitamos saber cuando el widget es requerido o no, ahora se manda esa información en el ajax del js. En consecuencia el controlador puede devolver un array diferente dependiendo de cada caso.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.