### PR TITLE
formatear campos total y neto en lineas de documentos

### DIFF
--- a/Core/Base/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Base/AjaxForms/PurchasesLineHTML.php
@@ -130,10 +130,10 @@ class PurchasesLineHTML
             $map['iva_' . $idlinea] = $line->iva;
 
             // total
-            $map['linetotal_' . $idlinea] = $line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100;
+            $map['linetotal_' . $idlinea] = ToolBox::numbers()::format($line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100);
 
             // neto
-            $map['lineneto_' . $idlinea] = $line->pvptotal;
+            $map['lineneto_' . $idlinea] = ToolBox::numbers()::format($line->pvptotal);
         }
 
         // mods

--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -131,10 +131,10 @@ class SalesLineHTML
             $map['iva_' . $idlinea] = $line->iva;
 
             // total
-            $map['linetotal_' . $idlinea] = $line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100;
+            $map['linetotal_' . $idlinea] = ToolBox::numbers()::format($line->pvptotal * (100 + $line->iva + $line->recargo - $line->irpf) / 100);
 
             // neto
-            $map['lineneto_' . $idlinea] = $line->pvptotal;
+            $map['lineneto_' . $idlinea] = ToolBox::numbers()::format($line->pvptotal);
         }
 
         // mods


### PR DESCRIPTION
# Descripción
- Aplicar formato a los campos total y neto en la linea de compra o venta.

Así evitamos que aparezcan un numero de decimales incorrecto como se puede ver en esta imagen:
![Captura](https://github.com/NeoRazorX/facturascripts/assets/2836337/03c01a2a-a522-4e7c-b91e-14ead80cf4f2)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.