### PR TITLE
Corregir el cálculo del precio de coste

### DIFF
--- a/Core/Model/ProductoProveedor.php
+++ b/Core/Model/ProductoProveedor.php
@@ -154,7 +154,7 @@ class ProductoProveedor extends Base\ModelOnChangeClass
 
         $this->neto = round($this->precio * $this->getEUDiscount(), DinProducto::ROUND_DECIMALS);
         $tasaconv = Divisas::get($this->coddivisa)->tasaconvcompra;
-        $this->netoeuros = empty($tasaconv) ? 0 : round($this->netoeuros / $tasaconv, 5);
+        $this->netoeuros = empty($tasaconv) ? 0 : round($this->neto / $tasaconv, 5);
         return parent::test();
     }
 

--- a/Core/Model/ProductoProveedor.php
+++ b/Core/Model/ProductoProveedor.php
@@ -153,7 +153,8 @@ class ProductoProveedor extends Base\ModelOnChangeClass
         }
 
         $this->neto = round($this->precio * $this->getEUDiscount(), DinProducto::ROUND_DECIMALS);
-        $this->netoeuros = Divisas::get($this->coddivisa)->tasaconvcompra * $this->neto;
+        $tasaconv = Divisas::get($this->coddivisa)->tasaconvcompra;
+        $this->netoeuros = empty($tasaconv) ? 0 : round($this->netoeuros / $tasaconv, 5);
         return parent::test();
     }
 


### PR DESCRIPTION
# Descripción
- Ahora se aplica la tasa de conversión en la tabla de productos por proveedor igual que en los documentos de compra. Para calcular el precio de coste en euros se obtiene el valor en la moneda del proveedor y se divide por la tasa de conversión.

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT
