### PR TITLE
Tarea #1993 - Ampliar limite 1000 metodo all()

### DIFF
--- a/Core/Lib/Widget/WidgetSelect.php
+++ b/Core/Lib/Widget/WidgetSelect.php
@@ -43,6 +43,9 @@ class WidgetSelect extends BaseWidget
     /** @var string */
     protected $fieldtitle;
 
+    /** @var int */
+    protected int $limit;
+
     /** @var string */
     protected $parent;
 
@@ -94,7 +97,8 @@ class WidgetSelect extends BaseWidget
             'source' => $this->source,
             'fieldcode' => $this->fieldcode,
             'fieldfilter' => $this->fieldfilter,
-            'fieldtitle' => $this->fieldtitle
+            'fieldtitle' => $this->fieldtitle,
+            'limit' => $this->limit
         ];
     }
 
@@ -240,6 +244,7 @@ class WidgetSelect extends BaseWidget
             . ' data-fieldcode="' . $this->fieldcode . '"'
             . ' data-fieldtitle="' . $this->fieldtitle . '"'
             . ' data-fieldfilter="' . $this->fieldfilter . '"'
+            . ' data-limit="' . $this->limit . '"'
             . '>';
 
         $found = false;
@@ -281,7 +286,9 @@ class WidgetSelect extends BaseWidget
         $this->fieldcode = $child['fieldcode'] ?? 'id';
         $this->fieldfilter = $child['fieldfilter'] ?? $this->fieldfilter;
         $this->fieldtitle = $child['fieldtitle'] ?? $this->fieldcode;
+        $this->limit = $child['limit'] ?? CodeModel::ALL_LIMIT;
         if ($loadData && $this->source) {
+            static::$codeModel::setLimit($this->limit);
             $values = static::$codeModel->all($this->source, $this->fieldcode, $this->fieldtitle, !$this->required);
             $this->setValuesFromCodeModel($values, $this->translate);
         }

--- a/Core/Model/CodeModel.php
+++ b/Core/Model/CodeModel.php
@@ -42,6 +42,8 @@ class CodeModel
      */
     protected static $dataBase;
 
+    protected static int $limit;
+
     /**
      * Value of the code field of the model read.
      *
@@ -107,7 +109,7 @@ class CodeModel
 
         $sql = 'SELECT DISTINCT ' . $fieldCode . ' AS code, ' . $fieldDescription . ' AS description '
             . 'FROM ' . $tableName . DataBaseWhere::getSQLWhere($where) . ' ORDER BY 2 ASC';
-        foreach (self::$dataBase->selectLimit($sql, self::ALL_LIMIT) as $row) {
+        foreach (self::$dataBase->selectLimit($sql, self::getLimit()) as $row) {
             $result[] = new static($row);
         }
 
@@ -189,6 +191,14 @@ class CodeModel
     }
 
     /**
+     * @return int
+     */
+    public static function getLimit(): int
+    {
+        return self::$limit ?? self::ALL_LIMIT;
+    }
+
+    /**
      * Load a CodeModel list (code and description) for the indicated table and search.
      *
      * @param string $tableName
@@ -211,6 +221,14 @@ class CodeModel
         $fields = $fieldCode . '|' . $fieldDescription;
         $where[] = new DataBaseWhere($fields, mb_strtolower($query, 'UTF8'), 'LIKE');
         return self::all($tableName, $fieldCode, $fieldDescription, false, $where);
+    }
+
+    /**
+     * @param int $newLimit
+     */
+    public static function setLimit(int $newLimit): void
+    {
+        self::$limit = $newLimit;
     }
 
     /**


### PR DESCRIPTION
# Descripción

- Se añade la funcion setLimit(int) y getLimit() para poder establecer el nuevo límite y si no hay ninguno definido, entonces que devuelva 1000.
- He añadido un nuevo parámetro `limit` a la etiqueta values del widget select

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
