### PR TITLE
Tarea #1787 Fecha Fact Origen en Fact Rectif

### DIFF
--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -452,7 +452,9 @@ abstract class PDFDocument extends PDFCore
 
         // rectified invoice?
         if (isset($model->codigorect) && !empty($model->codigorect)) {
-            $tableData[3] = ['key' => $this->i18n->trans('original'), 'value' => $model->codigorect];
+            $model2 = new $model();
+			$model2->loadFromCode('', [new DataBaseWhere('codigo', $model->codigorect)]);
+			$tableData[3] = ['key' => $this->i18n->trans('original'), 'value' => $model->codigorect . ', ' . $model2->fecha];
         } elseif (property_exists($model, 'numproveedor') && $model->numproveedor) {
             $tableData[3] = ['key' => $this->i18n->trans('numsupplier'), 'value' => $model->numproveedor];
         } elseif (property_exists($model, 'numero2') && $model->numero2) {


### PR DESCRIPTION
Tarea #1787 Recupera la fecha de la Factura origen para mostrarla en el PDF de la Factura rectificada

# Descripción
- Localizo la factura origen mediante loadFromCode y añado la fecha junto al número de la factura origen en el PDF de la factura rectificativa.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

![FacRectif](https://github.com/NeoRazorX/facturascripts/assets/87418020/7a61a305-9bfe-4e45-be5f-55d38f90211a)
