### PR TITLE
Tarea #707 - Agregar columna numdocs

### DIFF
--- a/Core/Lib/ExtendedController/ListBusinessDocument.php
+++ b/Core/Lib/ExtendedController/ListBusinessDocument.php
@@ -106,6 +106,7 @@ abstract class ListBusinessDocument extends ListController
         $this->addFilterCheckbox($viewName, 'totalrecargo', 'surcharge', 'totalrecargo', '!=', 0);
         $this->addFilterCheckbox($viewName, 'totalirpf', 'retention', 'totalirpf', '!=', 0);
         $this->addFilterCheckbox($viewName, 'totalsuplidos', 'supplied-amount', 'totalsuplidos', '!=', 0);
+        $this->addFilterCheckbox($viewName, 'numdocs', 'has-attachments', 'numdocs', '!=', 0);
     }
 
     protected function createViewLines(string $viewName, string $modelName): void

--- a/Core/Model/Base/BusinessDocument.php
+++ b/Core/Model/Base/BusinessDocument.php
@@ -137,6 +137,13 @@ abstract class BusinessDocument extends ModelOnChangeClass
     public $numero;
 
     /**
+     * Number of attached documents.
+     *
+     * @var int
+     */
+    public $numdocs;
+
+    /**
      * Notes of the document.
      *
      * @var string
@@ -253,6 +260,7 @@ abstract class BusinessDocument extends ModelOnChangeClass
         $this->totaliva = 0.0;
         $this->totalrecargo = 0.0;
         $this->totalsuplidos = 0.0;
+        $this->numdocs = 0;
     }
 
     public static function dontCopyField(string $field): void

--- a/Core/Table/albaranescli.xml
+++ b/Core/Table/albaranescli.xml
@@ -197,6 +197,12 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>albaranescli_pkey</name>
         <type>PRIMARY KEY (idalbaran)</type>

--- a/Core/Table/albaranesprov.xml
+++ b/Core/Table/albaranesprov.xml
@@ -150,6 +150,12 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>albaranesprov_pkey</name>
         <type>PRIMARY KEY (idalbaran)</type>

--- a/Core/Table/facturascli.xml
+++ b/Core/Table/facturascli.xml
@@ -224,6 +224,12 @@
         <type>boolean</type>
         <default>false</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>facturascli_pkey</name>
         <type>PRIMARY KEY (idfactura)</type>

--- a/Core/Table/facturasprov.xml
+++ b/Core/Table/facturasprov.xml
@@ -176,6 +176,12 @@
         <type>boolean</type>
         <default>false</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>facturasprov_pkey</name>
         <type>PRIMARY KEY (idfactura)</type>

--- a/Core/Table/pedidoscli.xml
+++ b/Core/Table/pedidoscli.xml
@@ -201,6 +201,12 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>pedidoscli_pkey</name>
         <type>PRIMARY KEY (idpedido)</type>

--- a/Core/Table/pedidosprov.xml
+++ b/Core/Table/pedidosprov.xml
@@ -149,6 +149,12 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>pedidosprov_pkey</name>
         <type>PRIMARY KEY (idpedido)</type>

--- a/Core/Table/presupuestoscli.xml
+++ b/Core/Table/presupuestoscli.xml
@@ -200,6 +200,12 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>presupuestoscli_pkey</name>
         <type>PRIMARY KEY (idpresupuesto)</type>

--- a/Core/Table/presupuestosprov.xml
+++ b/Core/Table/presupuestosprov.xml
@@ -149,6 +149,12 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>numdocs</name>
+        <type>integer</type>
+        <null>NO</null>
+        <default>0</default>
+    </column>
     <constraint>
         <name>presupuestosprov_pkey</name>
         <type>PRIMARY KEY (idpresupuesto)</type>

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -660,6 +660,7 @@
     "group-or-split-p": "Este asistente permite generar un nuevo documento a partir de las líneas de otros. Seleccione las cantidades que desea usar, la fecha del nuevo documento y pulse el botón generar.",
     "grouping-type": "Agrupación",
     "groups": "Grupos",
+    "has-attachments": "¿Tiene adjuntos?",
     "has-parent": "Tiene padre",
     "hash": "Hash",
     "heading-account-group-id": "ID grupo epígrafes",

--- a/Test/Core/Base/Lib/ExtendedController/DocFilesTraitTest.php
+++ b/Test/Core/Base/Lib/ExtendedController/DocFilesTraitTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Lib\ExtendedController;
+
+use FacturaScripts\Core\App\AppController;
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Model\AttachedFile;
+use FacturaScripts\Core\Model\RoleUser;
+use FacturaScripts\Core\Model\Stock;
+use FacturaScripts\Core\Model\User;
+use FacturaScripts\Core\Model\Variante;
+use FacturaScripts\Dinamic\Model\AttachedFileRelation;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class DocFilesTraitTest extends TestCase
+{
+    use LogErrorsTrait;
+    use RandomDataTrait;
+    use DefaultSettingsTrait;
+
+    private static string $seed = '';
+
+    protected function setUp(): void
+    {
+        $db = new DataBase();
+        $db->connect();
+
+        new User();
+        new RoleUser();
+        new Variante();
+        new Stock();
+
+        self::setDefaultSettings();
+    }
+
+    public function businessDocumentProvider(): array
+    {
+        return [
+            ['AlbaranCliente'],
+            ['AlbaranProveedor'],
+            ['FacturaCliente'],
+            ['FacturaProveedor'],
+            ['PedidoCliente'],
+            ['PedidoProveedor'],
+            ['PresupuestoCliente'],
+            ['PresupuestoProveedor'],
+        ];
+    }
+
+    /**
+     * @dataProvider businessDocumentProvider
+     * @param string $modelName
+     */
+    public function testUpdateNumberAttachedDocuments(string $modelName)
+    {
+        if (str_contains($modelName, 'Cliente')) {
+            // creamos un cliente
+            $subject = $this->getRandomCustomer();
+            static::assertTrue($subject->save());
+        } else {
+            // creamos un proveedor
+            $subject = $this->getRandomSupplier();
+            static::assertTrue($subject->save());
+        }
+
+        // creamos un documento y le asignamos el subject
+        $docClass = '\\FacturaScripts\\Core\\Model\\' . $modelName;
+        $doc = new $docClass();
+
+        $doc->setSubject($subject);
+        static::assertTrue($doc->save());
+
+        // Comprobamos que se inicia a 0
+        self::assertEquals(0, $doc->numdocs);
+
+        // Añadimos el primer adjunto
+        $get = ['code' => $doc->primaryColumnValue()];
+        $post = ['action' => 'add-file'];
+        $files = ['new-file' => $this->createFile('attached_file1.txt')];
+        $this->controllerGet('/Edit' . $modelName, $get, $post, $files);
+
+        $doc->loadFromCode($doc->primaryColumnValue());
+        self::assertEquals(1, $doc->numdocs);
+
+        // Añadimos el segundo adjunto
+        $files = ['new-file' => $this->createFile('attached_file2.txt')];
+        $this->controllerGet('/Edit' . $modelName, [], [], $files);
+
+        $doc->loadFromCode($doc->primaryColumnValue());
+        self::assertEquals(2, $doc->numdocs);
+
+        // Añadimos el tercer adjunto
+        $files = ['new-file' => $this->createFile('attached_file3.txt')];
+        $this->controllerGet('/Edit' . $modelName, [], [], $files);
+
+        $doc->loadFromCode($doc->primaryColumnValue());
+        self::assertEquals(3, $doc->numdocs);
+
+        // Obtenemos los adjuntos para usar el 'id'
+        $attachedFileRelation = new AttachedFileRelation();
+        $where = [
+            new DataBaseWhere('model', $doc->modelClassName()),
+            new DataBaseWhere('modelid', $doc->primaryColumnValue())
+        ];
+        $adjuntos = $attachedFileRelation->all($where);
+
+        // Borramos el segundo adjunto
+        $segundoAdjunto = $adjuntos[1];
+        $post = [
+            'action' => 'delete-file',
+            'id' => $segundoAdjunto->id,
+        ];
+        $this->controllerGet('/Edit' . $modelName, [], $post, []);
+
+        $doc->loadFromCode($doc->primaryColumnValue());
+        self::assertEquals(2, $doc->numdocs);
+
+        // Desvinculamos el tercer adjunto
+        $tercerAdjunto = $adjuntos[2];
+        $post = [
+            'action' => 'unlink-file',
+            'id' => $tercerAdjunto->id,
+        ];
+        $this->controllerGet('/Edit' . $modelName, [], $post, []);
+
+        $doc->loadFromCode($doc->primaryColumnValue());
+        self::assertEquals(1, $doc->numdocs);
+
+
+        // eliminamos
+        static::assertTrue($doc->delete());
+        static::assertTrue($subject->getDefaultAddress()->delete());
+        static::assertTrue($subject->delete());
+
+        // Eliminamos las relaciones de los adjuntos en los documentos
+        $attachedFileRelation = new AttachedFileRelation();
+        $where = [
+            new DataBaseWhere('model', $doc->modelClassName()),
+            new DataBaseWhere('modelid', $doc->primaryColumnValue())
+        ];
+        $adjuntosRelacionados = $attachedFileRelation->all($where);
+        foreach ($adjuntosRelacionados as $adjuntoRelacionados)
+        {
+            $adjuntoRelacionados->delete();
+        }
+
+        // Eliminamos los archivos creados
+        $attachedFile = new AttachedFile();
+        $adjuntos = $attachedFile->all();
+        foreach ($adjuntos as $adjunto)
+        {
+            $adjunto->delete();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+
+    /**
+     * @param string $nick
+     * @return string
+     */
+    protected function getTokenTest(string $nick)
+    {
+        self::$seed .= $nick;
+
+        $pathMultiRequestProtectionFile = FS_FOLDER . DIRECTORY_SEPARATOR . 'Core' . DIRECTORY_SEPARATOR . 'Lib' . DIRECTORY_SEPARATOR . 'MultiRequestProtection.php';
+        $frase = PHP_VERSION . $pathMultiRequestProtectionFile . FS_DB_NAME . FS_DB_PASS . self::$seed;
+
+        $num = intval(date('YmdH')) + strlen($frase);
+        $value = $frase . $num;
+
+        return sha1($value) . '|test';
+    }
+
+    /**
+     * @param string $uri
+     * @param array $get
+     * @param array $post
+     * @param array $files
+     */
+    protected function controllerGet(string $uri, array $get, array $post, array $files): void
+    {
+        $fsNick = 'admin';
+        $fsPassword = 'admin';
+
+        foreach ($get as $key => $value) {
+            $_GET[$key] = $value;
+        }
+
+        foreach ($post as $key => $value) {
+            $_POST[$key] = $value;
+        }
+
+        foreach ($files as $key => $value) {
+            $_FILES[$key] = $value;
+        }
+
+        $_POST["fsNick"] = $fsNick;
+        $_POST["fsPassword"] = $fsPassword;
+        $_POST["multireqtoken"] = $this->getTokenTest($fsNick);
+
+        $app = new AppController($uri);
+        $app->run();
+    }
+
+    /**
+     * @param string $nombre
+     * @return UploadedFile
+     */
+    protected function createFile(string $nombre)
+    {
+        $pathAbsoluto = FS_FOLDER . '/Test/__files/' . $nombre;
+
+        file_put_contents($pathAbsoluto, 'test');
+        return new UploadedFile(
+            FS_FOLDER . '/Test/__files/' . $nombre,
+            $nombre,
+            'image/jpeg', 0, true);
+    }
+}


### PR DESCRIPTION
# Descripción
Añadir columna numdocs a albaranes, facturas, pedidos y presupuestos, para guardar el número de documentos adjuntos. Añadir también el correspondiente filtro a los listados:

- Filtro checkbox "tiene adjuntos".
- Al añadir un adjunto, aumentar el numdocs del modelo.
- Al eliminar un adjunto, reducir el numdocs.
- Creamos tests correspontientes

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
