### PR TITLE
Tarea #2682 - country() del modelo Contacto debe devolver string o null

### DIFF
--- a/Core/Model/Contacto.php
+++ b/Core/Model/Contacto.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of FacturaScripts
  * Copyright (C) 2015-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
@@ -162,7 +162,10 @@ class Contacto extends Base\Contact
         return $results;
     }
 
-    public function country(): string
+    /**
+     * @return string|null
+     */
+    public function country(): ?string
     {
         $country = new DinPais();
         $where = [new DataBaseWhere('codiso', $this->codpais)];

--- a/Test/Core/Model/ContactoTest.php
+++ b/Test/Core/Model/ContactoTest.php
@@ -25,6 +25,7 @@ use FacturaScripts\Core\Model\Contacto;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 final class ContactoTest extends TestCase
 {
@@ -376,6 +377,14 @@ final class ContactoTest extends TestCase
 
         $result = $contacto->verifyLogkey('fake-logkey-2');
         static::assertFalse($result);
+    }
+
+    public function testCountryMethodReturnStringOrNull()
+    {
+        $reflectionMethod = new ReflectionMethod(Contacto::class, 'country');
+
+        self::assertEquals('string', $reflectionMethod->getReturnType()->getName());
+        self::assertTrue($reflectionMethod->getReturnType()->allowsNull());
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
# Descripción
La función country() del modelo Contacto exige que se devuelva un string, pero la columna codpais de la tabla contactos, permite null, por lo que la función country() debería de poder permitir devolver string o null.

- Se cambia el tipo de datos que devuelve el método `country()` para que permita devolver string o null.
- Se incluye el test correspondiente.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
