### PR TITLE
Corregidas las formas de pago mostradas de los recibos

### DIFF
--- a/Core/XMLView/EditReciboCliente.xml
+++ b/Core/XMLView/EditReciboCliente.xml
@@ -68,8 +68,8 @@
                 </widget>
             </column>
             <column name="payment" title="method-payment" order="130">
-                <widget type="select" fieldname="codpago" onclick="EditFormaPago" required="true">
-                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
+                <widget type="select" fieldname="codpago" parent="idempresa" onclick="EditFormaPago" required="true">
+                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion" fieldfilter="idempresa"/>
                 </widget>
             </column>
             <column name="payment-date" order="140">

--- a/Core/XMLView/EditReciboProveedor.xml
+++ b/Core/XMLView/EditReciboProveedor.xml
@@ -65,8 +65,8 @@
                 </widget>
             </column>
             <column name="payment" title="method-payment" order="120">
-                <widget type="select" fieldname="codpago" onclick="EditFormaPago" required="true">
-                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
+                <widget type="select" fieldname="codpago" parent="idempresa" onclick="EditFormaPago" required="true">
+                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion" fieldfilter="idempresa"/>
                 </widget>
             </column>
             <column name="payment-date" order="130">


### PR DESCRIPTION
Cuando se crea una recibo este lleva el idempresa del documento, pero el widgetSelect de las formas de pago está mostrando todas, y debe mostrar solo las formas de pago de la empresa del recibo.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.