### PR TITLE
Tarea #1455 - Nuevos campo en cabecera de los docs

### DIFF
--- a/Core/Base/AjaxForms/PurchasesHeaderHTML.php
+++ b/Core/Base/AjaxForms/PurchasesHeaderHTML.php
@@ -39,9 +39,13 @@ class PurchasesHeaderHTML
     /** @var PurchasesModInterface[] */
     private static $mods = [];
 
+    /** @var array */
+    private static $newFields = [];
+
     public static function addMod(PurchasesModInterface $mod)
     {
         self::$mods[] = $mod;
+        self::getNewFields();
     }
 
     public static function apply(PurchaseDocument &$model, array $formData, User $user)
@@ -118,6 +122,7 @@ class PurchasesHeaderHTML
             . '</div>'
             . '<div class="form-row align-items-end">'
             . self::renderField($i18n, $model, '_detail')
+            . self::renderNewHeaderFields($i18n, $model)
             . self::renderField($i18n, $model, '_parents')
             . self::renderField($i18n, $model, '_children')
             . self::renderField($i18n, $model, '_email')
@@ -204,7 +209,7 @@ class PurchasesHeaderHTML
             . self::renderField($i18n, $model, 'coddivisa')
             . self::renderField($i18n, $model, 'tasaconv')
             . self::renderField($i18n, $model, 'user')
-            . self::renderNewFields($i18n, $model)
+            . self::renderNewModalFields($i18n, $model)
             . '</div>'
             . '</div>'
             . '<div class="modal-footer">'
@@ -335,6 +340,84 @@ class PurchasesHeaderHTML
         // renderizamos los campos
         $html = '';
         foreach ($newFields as $field) {
+            foreach (self::$mods as $mod) {
+                $fieldHtml = $mod->renderField($i18n, $model, $field);
+                if ($fieldHtml !== null) {
+                    $html .= $fieldHtml;
+                    break;
+                }
+            }
+        }
+        return $html;
+    }
+
+    /**
+     * Cargamos los nuevos campos agrupandolos por la posición donde
+     * deben aparecer.
+     */
+    private static function getNewFields(): void
+    {
+        foreach (self::$mods as $mod) {
+            foreach ($mod->newFields() as $field => $position) {
+                $positions = [
+                    PurchasesModInterface::HEADER_POSITION,
+                    PurchasesModInterface::MODAL_POSITION,
+                ];
+
+                // Este if es para conservar la compatibilidad con versiones anteriores
+                // donde solo se pasaba el nombre del campo sin la posición.
+                if (in_array($position, $positions)) {
+                    // $field => $position
+                    if (false === in_array($field, self::$newFields[$position] ?? [])) {
+                        self::$newFields[$position][] = $field;
+                    }
+                } else {
+                    // Al no pasar una posición la variable $field es la $key del array
+                    // y la variable $position es el nombre del campo.
+                    // $arrayKey => $position(field) -> 0 => field
+                    if (false === in_array($position, self::$newFields[PurchasesModInterface::MODAL_POSITION] ?? [])) {
+                        self::$newFields[PurchasesModInterface::MODAL_POSITION][] = $position;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Renderiza los campos dentro del Modal Detalles
+     */
+    private static function renderNewModalFields(Translator $i18n, PurchaseDocument $model): ?string
+    {
+        $fields = self::$newFields[PurchasesModInterface::MODAL_POSITION] ?? null;
+
+        if ($fields && count($fields) > 0) {
+            return self::renderNF($fields, $i18n, $model);
+        }
+
+        return null;
+    }
+
+    /**
+     * Renderiza los campos dentro del PurchasesHeader
+     */
+    private static function renderNewHeaderFields(Translator $i18n, PurchaseDocument $model): ?string
+    {
+        $fields = self::$newFields[PurchasesModInterface::HEADER_POSITION] ?? null;
+
+        if ($fields && count($fields) > 0) {
+            return self::renderNF($fields, $i18n, $model);
+        }
+
+        return null;
+    }
+
+    /**
+     * Renderiza los nuevos campos pasados en el array.
+     */
+    private static function renderNF(array $fields, Translator $i18n, PurchaseDocument $model): string
+    {
+        $html = '';
+        foreach ($fields as $field) {
             foreach (self::$mods as $mod) {
                 $fieldHtml = $mod->renderField($i18n, $model, $field);
                 if ($fieldHtml !== null) {

--- a/Core/Base/Contract/PurchasesModInterface.php
+++ b/Core/Base/Contract/PurchasesModInterface.php
@@ -25,6 +25,9 @@ use FacturaScripts\Core\Model\User;
 
 interface PurchasesModInterface
 {
+    public const HEADER_POSITION = 'header_position';
+    public const MODAL_POSITION = 'modal_position';
+
     public function apply(PurchaseDocument &$model, array $formData, User $user);
 
     public function applyBefore(PurchaseDocument &$model, array $formData, User $user);

--- a/Core/Base/Contract/SalesModInterface.php
+++ b/Core/Base/Contract/SalesModInterface.php
@@ -25,6 +25,9 @@ use FacturaScripts\Core\Model\User;
 
 interface SalesModInterface
 {
+    public const HEADER_POSITION = 'header_position';
+    public const MODAL_POSITION = 'modal_position';
+
     public function apply(SalesDocument &$model, array $formData, User $user);
 
     public function applyBefore(SalesDocument &$model, array $formData, User $user);


### PR DESCRIPTION
# Descripción
- He creado dos constantes para poder elegir la posición donde renderizar el nuevo campo.
- Ahora se puede renderizar el nuevo campo, tanto en el modal(por defecto si no se pasa ninguna posición), como en el header.
- Se mantiene la compatibilidad con versiones anteriores.
- Usar de la siguinte forma:
```php
public function newFields(): array
{
    return ['proyecto', 'proyecto2' => self::HEADER_POSITION, 'proyecto3' => self::MODAL_POSITION];
}
```
 
## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

![imagen](https://github.com/NeoRazorX/facturascripts/assets/2836337/c26ada38-19fd-4812-ad40-22f3b6a514bb)
