### PR TITLE
Tarea #2771 - IVA0 cliente extento y serie con imp

### DIFF
--- a/Core/Base/Calculator.php
+++ b/Core/Base/Calculator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of FacturaScripts
  * Copyright (C) 2018-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
@@ -255,6 +255,13 @@ final class Calculator
                     $line->recargo = $line->getTax()->recargo;
                     break;
                 }
+            }
+
+            // ¿La serie es CON impuestos y el régimen exento?
+            if (false === $sinIva && $regimen === RegimenIVA::TAX_SYSTEM_EXEMPT) {
+                $line->codimpuesto = 'IVA0';
+                $line->iva = $line->recargo = 0.0;
+                continue;
             }
 
             // ¿La serie es sin impuestos o el régimen exento?


### PR DESCRIPTION
# Descripción
- Cuando un cliente tiene iva exento y la serie escogida no tiene marcado "sin impuestos", al crear un documento debe poner `IVA0` en vez de `IVA ---` en cada una de las líneas del documento.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
