### PR TITLE
Tarea #2770 - Validar fecha en rango ejercicio.

### DIFF
--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -358,6 +358,7 @@
     "date-of-the-document": "Fecha del documento a generar",
     "date-out": "Fecha salida",
     "date-out-of-exercise-range": "La fecha está fuera del rango del ejercicio %exerciseName%",
+    "date-out-of-exercises-range": "No existe ningún ejercicio que coincida con la fecha del documento. Debe crear un ejercicio acorde con la fecha del documento.",
     "date-wildcard-info": "Fecha actual (fecha del ordenador)",
     "dateentry-wildcard-info": "Fecha indicada en la cabecera del asiento contable",
     "day": "Día",

--- a/Test/Core/Model/FacturaClienteTest.php
+++ b/Test/Core/Model/FacturaClienteTest.php
@@ -145,7 +145,7 @@ final class FacturaClienteTest extends TestCase
         MiniLog::clear();
         $invoice->fecha = '11-01-2039';
         $this->assertFalse($invoice->save());
-        $this->assertEquals('date-out-of-exercises-range', MiniLog::read()[0]['original']);
+        $this->assertEquals('date-out-of-exercises-range', MiniLog::read('master', ['error'])[0]['original']);
 
         // eliminamos
         $this->assertTrue($invoice->delete());


### PR DESCRIPTION
# Descripción
- Al modificar la fecha de un documento, verificamos si se encuentra en el rango de fechas del ejercicio actual o en algún ejercicio existente para asignar al documento el ejercicio correspondiente o lanzar un error.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
