### PR TITLE
Abrir enlace en pestaña nueva desde la vista del email enviado

### DIFF
--- a/Core/View/Tab/EmailSentHtml.html.twig
+++ b/Core/View/Tab/EmailSentHtml.html.twig
@@ -46,6 +46,10 @@
 
             // añadimos el html al shadow
             shadow.appendChild(html);
+
+            // al hacer clic en cualquier enlace dentro del email
+            // se debe abrir en una nueva pestaña
+            $(shadow).find('a').attr('target', '_blank');
         }
     }).catch(function (error) {
         alert('error getHtml');


### PR DESCRIPTION
En ocasiones los enlaces del html del email no se le añade el target="_blank", por lo que al abrirlo lo hace en la misma pestaña, sacándote del programa. Con este cambio cualquier enlace del email se abrirá en una nueva pestaña.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.