### PR TITLE
Añadido el tipo notice al toast

### DIFF
--- a/Core/View/Macro/Toasts.html.twig
+++ b/Core/View/Macro/Toasts.html.twig
@@ -40,6 +40,7 @@
                 title = title !== '' ? title : '{{ trans('processing') }}';
                 break;
 
+            case 'notice':
             case 'success':
                 styleHeader = 'bg-success text-white';
                 styleBorder = 'border border-success';


### PR DESCRIPTION
Al mostrar un mensaje de "notice" junto con el toast no estaba cogiendo el estilo, ahora se pone el estilo de success.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.