### PR TITLE
add-dynamic-where

### DIFF
--- a/Core/DbQuery.php
+++ b/Core/DbQuery.php
@@ -446,4 +446,42 @@ final class DbQuery
 
         return self::$db;
     }
+
+    /**
+     * Incluimos where dinámico
+     *
+     * @param $method
+     * @param $parameters
+     * @return $this
+     * @throws Exception
+     */
+    public function __call($method, $parameters)
+    {
+        // Si se llama al where dinamicamente
+        // whereNombre(), whereCiudad()
+        if (str_starts_with($method, 'where')) {
+            return $this->dynamicWhere($method, $parameters);
+        }
+
+        if(false === method_exists($this, $method)){
+            throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+        }
+    }
+
+    /**
+     * Implementamos un where dinámico para que se pueda incluir
+     * el nombre del campo en el propio metodo where y así
+     * acortar código.
+     * ej. whereNombre(), whereCiudad()
+     *
+     * @param $method
+     * @param $parameters
+     * @return $this
+     * @throws Exception
+     */
+    protected function dynamicWhere($method, $parameters)
+    {
+        $field = strtolower(substr($method, 5));
+        return static::where([Where::column($field, $parameters[0])]);
+    }
 }

--- a/Test/Core/Base/Template/ModelTest.php
+++ b/Test/Core/Base/Template/ModelTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace FacturaScripts\Test\Core\Base\Template;
+
+use FacturaScripts\Core\Template\Model;
+use FacturaScripts\Core\Where;
+use PHPUnit\Framework\TestCase;
+
+class ModelTest extends TestCase
+{
+
+    /**
+     * Comprobamos el método where dinámico
+     */
+    public function testDynamicWhere()
+    {
+        $model = new class extends Model {
+            public const TABLE_NAME = 'ciudades';
+        };
+
+        $result = $model::table()->where([Where::column('ciudad', 'Amurrio')])->get();
+        static::assertEquals(2, $result[0]['idciudad']);
+
+        $result = $model::table()->whereCiudad('Amurrio')->get();
+        static::assertEquals(2, $result[0]['idciudad']);
+
+        $result = $model::table()->whereIdprovincia(1)->get();
+        static::assertCount(54, $result);
+    }
+}


### PR DESCRIPTION
Implementamos un where dinámico para que se pueda incluir
el nombre del campo en el propio metodo where y así
acortar código.
ej. whereNombre(), whereCiudad()