### PR TITLE
Corregido bug al redirigir SendMail

### DIFF
--- a/Core/Controller/SendMail.php
+++ b/Core/Controller/SendMail.php
@@ -227,7 +227,7 @@ class SendMail extends Controller
         $className = self::MODEL_NAMESPACE . $this->request->get('modelClassName');
         if (false === class_exists($className)) {
             Tools::log()->notice('reloading');
-            $this->redirect('/SendMail', 3);
+            $this->redirect('SendMail', 3);
             return;
         }
 


### PR DESCRIPTION
Cuando enviamos un email en blanco, al redirigir está fallando en factura.city, ya que pone una / delante y entonces elimina el código de la instancia.

[issue](https://factura.city/issues/654bbe1f546e9)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.