### PR TITLE
Añadir AnimateSpinner() en todas partes de forma predeterminada.

### DIFF
--- a/Core/Assets/JS/ListView.js
+++ b/Core/Assets/JS/ListView.js
@@ -35,11 +35,12 @@ function listViewDelete(viewName) {
         closeButton: false,
         buttons: {
             cancel: {
-                label: '<i class="fas fa-times"></i> ' + listViewDeleteCancel
+                label: '<i class="fas fa-times"></i> ' + listViewDeleteCancel,
+                className: "btn-spin-action btn-secondary"
             },
             confirm: {
                 label: '<i class="fas fa-check"></i> ' + listViewDeleteConfirm,
-                className: "btn-danger"
+                className: "btn-spin-action btn-danger"
             }
         },
         callback: function (result) {
@@ -72,6 +73,7 @@ function listViewPrintAction(viewName, option) {
     $("#form" + viewName).submit();
     $("#form" + viewName + " :input[name=\"action\"]").val('');
     $("#form" + viewName).attr("target", "");
+    animateSpinner('remove');
 }
 
 function listViewSetAction(viewName, value) {

--- a/Core/Base/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Base/AjaxForms/CommonSalesPurchases.php
@@ -219,7 +219,7 @@ trait CommonSalesPurchases
     protected static function deleteBtn(Translator $i18n, BusinessDocument $model, string $jsName): string
     {
         return $model->primaryColumnValue() && $model->editable ?
-            '<button type="button" class="btn btn-danger mb-3" data-toggle="modal" data-target="#deleteDocModal">'
+            '<button type="button" class="btn-spin-action btn btn-danger mb-3" data-toggle="modal" data-target="#deleteDocModal">'
             . '<i class="fas fa-trash-alt fa-fw"></i> ' . $i18n->trans('delete')
             . '</button>'
             . '<div class="modal fade" id="deleteDocModal" tabindex="-1" aria-hidden="true">'
@@ -237,8 +237,8 @@ trait CommonSalesPurchases
             . '<p class="mb-0">' . $i18n->trans('are-you-sure') . '</p>'
             . '</div>'
             . '<div class="modal-footer">'
-            . '<button type="button" class="btn btn-secondary" data-dismiss="modal">' . $i18n->trans('cancel') . '</button>'
-            . '<button type="button" class="btn btn-danger" onclick="return ' . $jsName . '(\'delete-doc\', \'0\');">' . $i18n->trans('delete') . '</button>'
+            . '<button type="button" class="btn btn-spin-action btn-secondary" data-dismiss="modal">' . $i18n->trans('cancel') . '</button>'
+            . '<button type="button" class="btn btn-spin-action btn-danger" onclick="return ' . $jsName . '(\'delete-doc\', \'0\');">' . $i18n->trans('delete') . '</button>'
             . '</div>'
             . '</div>'
             . '</div>'
@@ -536,7 +536,7 @@ trait CommonSalesPurchases
 
         return '<div class="col-sm-auto">'
             . '<div class="form-group">'
-            . '<button class="btn btn-outline-danger dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">'
+            . '<button class="btn-spin-action btn btn-outline-danger dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">'
             . '<i class="fas fa-times fa-fw"></i> ' . $i18n->trans('unpaid') . '</button>'
             . '<div class="dropdown-menu"><a class="dropdown-item text-success" href="#" onclick="return ' . $jsName . '(\'save-paid\', \'1\');">'
             . '<i class="fas fa-check-square fa-fw"></i> ' . $i18n->trans('paid') . '</a></div>'

--- a/Core/Lib/ListFilter/AutocompleteFilter.php
+++ b/Core/Lib/ListFilter/AutocompleteFilter.php
@@ -104,7 +104,7 @@ class AutocompleteFilter extends BaseFilter
                 . '</span>';
         } else {
             $html .= '<span class="input-group-prepend" title="' . $label . '">'
-                . '<button class="btn btn-warning" type="button" onclick="this.form.' . $this->name() . '.value = \'\'; this.form.submit();">'
+                . '<button class="btn-spin-action btn btn-warning" type="button" onclick="this.form.' . $this->name() . '.value = \'\'; this.form.onsubmit(); this.form.submit();">'
                 . '<i class="fas fa-times fa-fw" aria-hidden="true"></i>'
                 . '</button>'
                 . '</span>';

--- a/Core/Lib/ListFilter/BaseFilter.php
+++ b/Core/Lib/ListFilter/BaseFilter.php
@@ -159,7 +159,7 @@ abstract class BaseFilter
      */
     protected function onChange(): string
     {
-        return $this->autosubmit ? ' onchange="this.form.submit();"' : '';
+        return $this->autosubmit ? ' onchange="this.form.onsubmit(); this.form.submit();"' : '';
     }
 
     /**

--- a/Core/Lib/Widget/GroupItem.php
+++ b/Core/Lib/Widget/GroupItem.php
@@ -128,7 +128,7 @@ class GroupItem extends VisualItem
     public function modal($model, string $viewName): string
     {
         $icon = empty($this->icon) ? '' : '<i class="' . $this->icon . ' fa-fw"></i> ';
-        $html = '<form id="formModal' . $this->getUniqueId() . '" method="post" enctype="multipart/form-data">'
+        $html = '<form id="formModal' . $this->getUniqueId() . '" method="post" enctype="multipart/form-data" onsubmit="animateSpinner(\'add\')">'
             . '<input type="hidden" name="activetab" value="' . $viewName . '"/>'
             . '<input type="hidden" name="code" value=""/>'
             . '<input type="hidden" name="multireqtoken" value="' . static::getToken() . '"/>'
@@ -151,10 +151,10 @@ class GroupItem extends VisualItem
         $html .= '</div>'
             . '</div>'
             . '<div class="modal-footer">'
-            . '<button type="button" class="btn btn-secondary" data-dismiss="modal">'
+            . '<button type="button" class="btn-spin-action btn btn-secondary" data-dismiss="modal">'
             . static::$i18n->trans('cancel')
             . '</button>'
-            . '<button type="submit" name="action" value="' . $this->name . '" class="btn btn-primary">'
+            . '<button type="submit" name="action" value="' . $this->name . '" class="btn-spin-action  btn btn-primary">'
             . static::$i18n->trans('accept')
             . '</button>'
             . '</div>'

--- a/Core/Lib/Widget/RowButton.php
+++ b/Core/Lib/Widget/RowButton.php
@@ -96,23 +96,23 @@ class RowButton extends VisualItem
 
         switch ($this->type) {
             case 'js':
-                return '<button type="button"' . $divID . ' class="' . $cssClass . '" onclick="' . $this->action
+                return '<button type="button"' . $divID . ' class="btn-spin-action ' . $cssClass . '" onclick="' . $this->action
                     . '" title="' . $title . '">' . $icon . $label . '</button>';
 
             case 'link':
                 $target = empty($this->target) ? '' : ' target="' . $this->target . '"';
-                return '<a ' . $target . $divID . ' class="' . $cssClass . '" href="' . $this->asset($this->action) . '"'
+                return '<a ' . $target . $divID . ' class="btn-spin-action ' . $cssClass . '" href="' . $this->asset($this->action) . '"'
                     . ' title="' . $title . '">' . $icon . $label . '</a>';
 
             case 'modal':
                 $modal = 'modal' . $this->action;
-                return '<button type="button"' . $divID . ' class="' . $cssClass . '" data-toggle="modal" data-target="#'
+                return '<button type="button"' . $divID . ' class="btn-spin-action ' . $cssClass . '" data-toggle="modal" data-target="#'
                     . $modal . '" title="' . $title . '" onclick="setModalParentForm(\'' . $modal . '\', this.form)">'
                     . $icon . $label . '</button>';
 
             default:
                 $onclick = $this->getOnClickValue($viewName, $jsFunction);
-                return '<button type="button"' . $divID . ' class="' . $cssClass . '" onclick="' . $onclick
+                return '<button type="button"' . $divID . ' class="btn-spin-action ' . $cssClass . '" onclick="' . $onclick
                     . '" title="' . $title . '">' . $icon . $label . '</button>';
         }
     }
@@ -140,12 +140,12 @@ class RowButton extends VisualItem
 
         switch ($this->type) {
             case 'js':
-                return '<button type="button"' . $divID . ' class="' . $cssClass . '" onclick="' . $this->action
+                return '<button type="button"' . $divID . ' class="btn-spin-action ' . $cssClass . '" onclick="' . $this->action
                     . '" title="' . $title . '">' . $icon . $label . '</button> ';
 
             case 'link':
                 $target = empty($this->target) ? '' : ' target="' . $this->target . '"';
-                return '<a ' . $target . $divID . ' class="' . $cssClass . '" href="' . $this->asset($this->action) . '"'
+                return '<a ' . $target . $divID . ' class="btn-spin-action ' . $cssClass . '" href="' . $this->asset($this->action) . '"'
                     . ' title="' . $title . '">' . $icon . $label . '</a> ';
         }
 
@@ -177,7 +177,8 @@ class RowButton extends VisualItem
         }
 
         if (empty($jsFunction)) {
-            return 'this.form.action.value=\'' . $this->action . '\';this.form.submit();';
+            $onsubmit = $this->action  === 'download' ? '' : 'this.form.onsubmit();';
+            return 'this.form.action.value=\'' . $this->action . '\';' . $onsubmit . 'this.form.submit();';
         }
 
         return $jsFunction . '(\'' . $viewName . '\',\'' . $this->action . '\');';

--- a/Core/Lib/Widget/RowFooter.php
+++ b/Core/Lib/Widget/RowFooter.php
@@ -67,7 +67,7 @@ class RowFooter extends VisualItem
         }
 
         if (empty($jsFunction)) {
-            return '<form method="post">'
+            return '<form method="post" onsubmit="animateSpinner(\'add\')">'
                 . '<input type="hidden" name="action"/>'
                 . '<input type="hidden" name="activetab" value="' . $viewName . '"/>'
                 . $html

--- a/Core/Lib/Widget/WidgetAutocomplete.php
+++ b/Core/Lib/Widget/WidgetAutocomplete.php
@@ -134,7 +134,7 @@ class WidgetAutocomplete extends WidgetSelect
         }
 
         return '<div class="' . $this->css('input-group-prepend') . '">'
-            . '<button class="btn btn-warning" type="button" onclick="this.form.' . $this->fieldname . '.value = \'\'; this.form.submit();">'
+            . '<button class="btn-spin-action btn btn-warning" type="button" onclick="this.form.' . $this->fieldname . '.value = \'\'; this.form.onsubmit(); this.form.submit();">'
             . '<i class="fas fa-times" aria-hidden="true"></i>'
             . '</button>'
             . '</div>';

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -41,15 +41,15 @@
                     {% endif %}
                 </div>
                 {% if not constant('FS_DISABLE_ADD_PLUGINS') %}
-                    <button class="btn btn-sm btn-success" type="button" data-toggle="modal"
+                    <button class="btn-spin-action btn btn-sm btn-success" type="button" data-toggle="modal"
                             data-target="#modalAddPlugin">
                         <i class="fas fa-plus fa-fw" aria-hidden="true"></i>
                         <span class="d-none d-sm-inline-block">{{ trans('add') }}</span>
                     </button>
                 {% endif %}
                 <div class="btn-group">
-                    <a href="{{ fsc.url() }}?action=rebuild&multireqtoken={{ formToken(false) }}"
-                       class="btn btn-sm btn-warning">
+                    <a href="{{ fsc.url() }}?action=rebuild&multireqtoken={{ formToken(false) }}" onclick="animateSpinner('add')"
+                       class="btn-spin-action btn btn-sm btn-warning">
                         <i class="fas fa-hammer fa-fw" aria-hidden="true"></i>
                         <span class="d-none d-sm-inline-block">{{ trans('rebuild') }}</span>
                     </a>
@@ -101,7 +101,7 @@
 
     {# Modal for add new plugins #}
     {% if not constant('FS_DISABLE_ADD_PLUGINS') %}
-        <form action="{{ fsc.url() }}" name="upload-plugins" method="post" class="form" enctype="multipart/form-data">
+        <form action="{{ fsc.url() }}" name="upload-plugins" method="post" class="form" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
             {{ formToken() }}
             <input type="hidden" name="action" value="upload"/>
             <div class="modal fade" id="modalAddPlugin" tabindex="-1" role="dialog" aria-hidden="true">
@@ -130,9 +130,9 @@
                                 {% endif %}
                             </div>
                             <div class="text-right mt-5">
-                                <button type="button" class="btn btn-secondary"
+                                <button type="button" class="btn-spin-action btn btn-secondary"
                                         data-dismiss="modal">{{ trans('cancel') }}</button>
-                                <button type="submit" class="btn btn-primary">{{ trans('continue') }}</button>
+                                <button type="submit" class="btn-spin-action btn btn-primary">{{ trans('continue') }}</button>
                             </div>
                         </div>
                     </div>
@@ -285,7 +285,7 @@
                     </td>
                     <td class="text-right text-nowrap">
                         {% if plugin.hasUpdate() %}
-                            <a href="Updater" class="btn btn-sm btn-info mr-1" title="{{ trans('updater') }}">
+                            <a href="Updater" class="btn-spin-action btn btn-sm btn-info mr-1" title="{{ trans('updater') }}">
                                 <i class="fas fa-cloud-download-alt" aria-hidden="true"></i>
                             </a>
                         {% endif %}

--- a/Core/View/CopyAsiento.html.twig
+++ b/Core/View/CopyAsiento.html.twig
@@ -8,7 +8,7 @@
                     <i class="fas fa-cut"></i> {{ fsc.title }}
                 </h1>
                 <p>{{ trans('copy-p') }}</p>
-                <form method="post">
+                <form method="post" onsubmit="animateSpinner('add')">
                     {{ formToken() }}
                     <input type="hidden" name="action" value="save"/>
                     <input type="hidden" name="code" value="{{ fsc.modelCode }}"/>
@@ -97,7 +97,7 @@
                         </div>
                         <div class="card-footer">
                             <div class="text-right">
-                                <button type="submit" class="btn btn-primary">
+                                <button type="submit" class="btn-spin-action btn btn-primary">
                                     <i class="fas fa-save"></i> {{ trans('save') }}
                                 </button>
                             </div>

--- a/Core/View/CopyModel.html.twig
+++ b/Core/View/CopyModel.html.twig
@@ -8,7 +8,7 @@
                     <i class="fas fa-cut"></i> {{ fsc.title }}
                 </h1>
                 <p>{{ trans('copy-p') }}</p>
-                <form method="post">
+                <form method="post" onsubmit="animateSpinner('add')">
                     {{ formToken() }}
                     <input type="hidden" name="action" value="save"/>
                     <input type="hidden" name="code" value="{{ fsc.modelCode }}"/>
@@ -219,7 +219,7 @@
                         </div>
                         <div class="card-footer">
                             <div class="text-right">
-                                <button type="submit" class="btn btn-primary">
+                                <button type="submit" class="btn-spin-action btn btn-primary">
                                     <i class="fas fa-save"></i> {{ trans('save') }}
                                 </button>
                             </div>

--- a/Core/View/CopyProducto.html.twig
+++ b/Core/View/CopyProducto.html.twig
@@ -8,7 +8,7 @@
                     <i class="fas fa-cut"></i> {{ fsc.title }}
                 </h1>
                 <p>{{ trans('copy-p') }}</p>
-                <form method="post">
+                <form method="post" onsubmit="animateSpinner('add')">
                     {{ formToken() }}
                     <input type="hidden" name="action" value="save"/>
                     <input type="hidden" name="code" value="{{ fsc.modelCode }}"/>
@@ -63,7 +63,7 @@
                         </div>
                         <div class="card-footer">
                             <div class="text-right">
-                                <button type="submit" class="btn btn-primary">
+                                <button type="submit" class="btn-spin-action btn btn-primary">
                                     <i class="fas fa-save"></i> {{ trans('save') }}
                                 </button>
                             </div>

--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -21,7 +21,7 @@
 {% set pageData = fsc.getPageData() %}
 
 {% block body %}
-    <form action="{{ fsc.url() }}" method="post" name="formDocStitcher">
+    <form action="{{ fsc.url() }}" method="post" name="formDocStitcher" onsubmit="animateSpinner('add')">
         {{ formToken() }}
         <input type="hidden" name="model" value="{{ fsc.modelName }}"/>
         <input type="hidden" name="status"/>
@@ -61,7 +61,7 @@
                 </div>
                 <div class="col mb-2">
                     <div class="dropdown">
-                        <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown"
+                        <button class="btn-spin-action btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown"
                                 aria-haspopup="true" aria-expanded="false">
                             <i class="fas fa-magic fa-fw"></i> {{ trans('generate') }}
                         </button>
@@ -78,7 +78,7 @@
                 </div>
                 <div class="col text-right mb-2">
                     <div class="dropdown">
-                        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown"
+                        <button class="btn-spin-action btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown"
                                 aria-haspopup="true" aria-expanded="false">
                             <i class="fas fa-check-square fa-fw"></i> {{ trans('selected-quantity') }}
                         </button>
@@ -114,7 +114,7 @@
                 <div class="col mt-3">
                     <div class="card border-success shadow mb-2">
                         <div class="card-body p-2">
-                            <button class="btn btn-sm btn-outline-success" type="button" data-toggle="collapse"
+                            <button class="btn-spin-action btn btn-sm btn-outline-success" type="button" data-toggle="collapse"
                                     data-target="#moreDocsCollapse" aria-expanded="false">
                                 <i class="fas fa-plus-square fa-fw" aria-hidden="true"></i>
                                 {{ trans('more') }}
@@ -122,7 +122,7 @@
                             &nbsp; {{ trans('group-more-docs-p') }}
                         </div>
                         <div class="collapse" id="moreDocsCollapse">
-                            <form action="{{ fsc.url() }}" method="post">
+                            <form action="{{ fsc.url() }}" method="post" onsubmit="animateSpinner('add')">
                                 <input type="hidden" name="model" value="{{ fsc.modelName }}">
                                 <input type="hidden" name="codes" value="{{ fsc.codes | join(',') }}">
                                 <div class="table-responsive">
@@ -162,7 +162,7 @@
                                     </table>
                                 </div>
                                 <div class="card-body">
-                                    <button type="submit" class="btn btn-success">
+                                    <button type="submit" class="btn-spin-action btn btn-success">
                                         {{ trans('add') }}
                                     </button>
                                 </div>
@@ -216,6 +216,7 @@
 
         function sendFormData(status) {
             document.formDocStitcher.status.value = status;
+            document.formDocStitcher.onsubmit();
             document.formDocStitcher.submit();
         }
     </script>

--- a/Core/View/EditPageOption.html.twig
+++ b/Core/View/EditPageOption.html.twig
@@ -54,7 +54,7 @@
                         <span class="text-info">{{ fsc.selectedViewName }}</span>
                     </div>
                     <div class="card-body">
-                        <form method="post">
+                        <form method="post" onsubmit="animateSpinner('add')">
                             <input type="hidden" name="code" value="{{ fsc.selectedViewName }}"/>
                             <div class="form-row">
                                 <div class="col">
@@ -81,7 +81,7 @@
                             </div>
                         </form>
                     </div>
-                    <form method="post" name="main_form">
+                    <form method="post" name="main_form" onsubmit="animateSpinner('add')">
                         {{ formToken() }}
                         <input type="hidden" name="action" value="save"/>
                         <input type="hidden" name="code" value="{{ fsc.selectedViewName }}"/>
@@ -112,7 +112,7 @@
                             <div class="form-row">
                                 {% if fsc.model.exists() %}
                                     <div class="col">
-                                        <button class="btn btn-sm btn btn-danger" type="button"
+                                        <button class="btn-spin-action btn btn-sm btn btn-danger" type="button"
                                                 onclick="deleteOptions();">
                                             <i class="fas fa-trash-alt fa-fw" aria-hidden="true"></i>
                                             {{ trans('delete') }}
@@ -120,10 +120,10 @@
                                     </div>
                                 {% endif %}
                                 <div class="col text-right">
-                                    <button class="btn btn-sm btn btn-secondary" type="reset">
+                                    <button class="btn-spin-action btn btn-sm btn btn-secondary" type="reset">
                                         <i class="fas fa-undo fa-fw" aria-hidden="true"></i> {{ trans('undo') }}
                                     </button>
-                                    <button class="btn btn-sm btn-primary" type="submit">
+                                    <button class="btn-spin-action btn btn-sm btn-primary" type="submit">
                                         <i class="fas fa-save fa-fw" aria-hidden="true"></i> {{ trans('save') }}
                                     </button>
                                 </div>
@@ -165,6 +165,7 @@
                 callback: function (result) {
                     if (result) {
                         document.main_form.action.value = 'delete';
+                        document.main_form.onsubmit();
                         document.main_form.submit();
                     }
                 }

--- a/Core/View/Master/EditListView.html.twig
+++ b/Core/View/Master/EditListView.html.twig
@@ -42,13 +42,13 @@
     {# -- New form -- #}
     {% if currentView.settings.btnNew %}
         {% set formName = 'form' ~ currentView.getViewName() ~ 'New' %}
-        <form id="{{ formName }}" method="post" enctype="multipart/form-data">
+        <form id="{{ formName }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
             {{ formToken() }}
             <input type="hidden" name="action" value="insert"/>
             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
             <div class="card border-success shadow mb-2">
                 <div class="card-body p-2">
-                    <button class="btn btn-sm btn-outline-success mr-1" type="button" data-toggle="collapse"
+                    <button class="btn-spin-action btn btn-sm btn-outline-success mr-1" type="button" data-toggle="collapse"
                             data-target="#{{ formName }}Collapse" aria-expanded="false">
                         <i class="fas fa-plus-square fa-fw" aria-hidden="true"></i>
                         {{ trans('add') }}
@@ -64,7 +64,7 @@
                         </div>
                     </div>
                     <div class="card-footer text-right p-2">
-                        <button class="btn btn-sm btn-success" type="submit">
+                        <button class="btn-spin-action btn btn-sm btn-success" type="submit">
                             <i class="fas fa-save fa-fw" aria-hidden="true"></i>
                             <span class="d-none d-sm-inline-block">{{ trans('save') }}</span>
                         </button>
@@ -77,7 +77,7 @@
     {# -- Forms -- #}
     {% for counter, model in currentView.cursor %}
         {% set formName = 'form' ~ currentView.getViewName() ~ counter %}
-        <form id="{{ formName }}" method="post" enctype="multipart/form-data">
+        <form id="{{ formName }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
             {{ formToken() }}
             <input type="hidden" name="action" value="edit"/>
             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
@@ -94,7 +94,7 @@
                     <div class="form-row">
                         {% if currentView.settings.btnDelete %}
                             <div class="col-auto">
-                                <button type="button" class="btn btn-sm btn-danger"
+                                <button type="button" class="btn-spin-action btn btn-sm btn-danger"
                                         onclick="editListViewDelete('{{ currentView.getViewName() ~ counter }}');">
                                     <i class="fas fa-trash-alt fa-fw" aria-hidden="true"></i>
                                     <span class="d-none d-sm-inline-block">{{ trans('delete') }}</span>
@@ -108,13 +108,13 @@
                         </div>
                         <div class="col-auto">
                             {% if currentView.settings.btnUndo %}
-                                <button class="btn btn-sm btn-secondary" type="reset">
+                                <button class="btn-spin-action btn btn-sm btn-secondary" type="reset">
                                     <i class="fas fa-undo fa-fw" aria-hidden="true"></i>
                                     <span class="d-none d-sm-inline-block">{{ trans('undo') }}</span>
                                 </button>
                             {% endif %}
                             {% if currentView.settings.btnSave %}
-                                <button class="btn btn-sm btn-primary" type="submit">
+                                <button class="btn-spin-action btn btn-sm btn-primary" type="submit">
                                     <i class="fas fa-save fa-fw" aria-hidden="true"></i>
                                     <span class="d-none d-sm-inline-block">{{ trans('save') }}</span>
                                 </button>
@@ -129,14 +129,14 @@
     {# -- Pagination -- #}
     {% if currentView.getPagination() | length > 0 %}
         {% set formName = 'form' ~ currentView.getViewName() ~ 'Offset' %}
-        <form id="{{ formName }}" method="post">
+        <form id="{{ formName }}" method="post" onsubmit="animateSpinner('add')">
             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
             <input type="hidden" name="offset" value="{{ currentView.offset }}"/>
             <div class="text-center pt-3">
                 <div class="btn-group">
                     {% for page in currentView.getPagination() %}
                         {% set btnClass = page.active ? 'btn btn-outline-dark active' : 'btn btn-outline-dark' %}
-                        <button type="button" class="{{ btnClass }}"
+                        <button type="button" class="btn-spin-action {{ btnClass }}"
                                 onclick="editListViewSetOffset('{{ currentView.getViewName() }}', '{{ page.offset }}');">
                             {{ page.num }}
                         </button>

--- a/Core/View/Master/EditListViewInLine.html.twig
+++ b/Core/View/Master/EditListViewInLine.html.twig
@@ -42,13 +42,13 @@
     {# -- New form -- #}
     {% if currentView.settings.btnNew %}
         {% set formName = 'form' ~ currentView.getViewName() ~ 'New' %}
-        <form id="{{ formName }}" method="post" enctype="multipart/form-data">
+        <form id="{{ formName }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
             {{ formToken() }}
             <input type="hidden" name="action" value="insert"/>
             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
             <div class="card border-success shadow mb-2">
                 <div class="card-body p-2">
-                    <button class="btn btn-sm btn-outline-success" type="button" data-toggle="collapse" data-target="#{{ formName }}Collapse" aria-expanded="false">
+                    <button class="btn-spin-action btn btn-sm btn-outline-success" type="button" data-toggle="collapse" data-target="#{{ formName }}Collapse" aria-expanded="false">
                         <i class="fas fa-plus-square fa-fw" aria-hidden="true"></i>
                         {{ trans('add') }}
                     </button>
@@ -64,7 +64,7 @@
                                 {% endfor %}
                             </div>
                             <div class="col-sm-2 text-right">
-                                <button class="btn btn-sm btn-success" type="submit">
+                                <button class="btn-spin-action btn btn-sm btn-success" type="submit">
                                     <i class="fas fa-save fa-fw" aria-hidden="true"></i>
                                     <span class="d-none d-sm-inline-block">{{ trans('save') }}</span>
                                 </button>
@@ -79,7 +79,7 @@
     {# -- Forms -- #}
     {% for counter, model in currentView.cursor %}
         {% set formName = 'form' ~ currentView.getViewName() ~ counter %}
-        <form id="{{ formName }}" method="post" enctype="multipart/form-data">
+        <form id="{{ formName }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
             {{ formToken() }}
             <input type="hidden" name="action" value="edit"/>
             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
@@ -93,7 +93,7 @@
                     </div>
                     <div class="col-sm-2 text-right pb-2 pr-3">
                         {% if currentView.settings.btnDelete %}
-                            <button type="button" class="btn btn-sm btn-danger" title="{{ trans('delete') }}"
+                            <button type="button" class="btn-spin-action btn btn-sm btn-danger" title="{{ trans('delete') }}"
                                     onclick="editListViewDelete('{{ currentView.getViewName() ~ counter }}');">
                                 <i class="fas fa-trash-alt fa-fw" aria-hidden="true"></i>
                             </button>
@@ -102,12 +102,12 @@
                         {% set row = currentView.getRow('actions') %}
                         {{ row.render(false, currentView.getViewName() ~ counter) | raw }}
                         {% if currentView.settings.btnUndo %}
-                            <button class="btn btn-sm btn-secondary" type="reset" title="{{ trans('undo') }}">
+                            <button class="btn-spin-action btn btn-sm btn-secondary" type="reset" title="{{ trans('undo') }}">
                                 <i class="fas fa-undo fa-fw" aria-hidden="true"></i>
                             </button>
                         {% endif %}
                         {% if currentView.settings.btnSave %}
-                            <button class="btn btn-sm btn-primary" type="submit" title="{{ trans('save') }}">
+                            <button class="btn-spin-action btn btn-sm btn-primary" type="submit" title="{{ trans('save') }}">
                                 <i class="fas fa-save fa-fw" aria-hidden="true"></i>
                             </button>
                         {% endif %}
@@ -120,14 +120,14 @@
     {# -- Pagination -- #}
     {% if currentView.getPagination() | length > 0 %}
         {% set formName = 'form' ~ currentView.getViewName() ~ 'Offset' %}
-        <form id="{{ formName }}" method="post">
+        <form id="{{ formName }}" method="post" onsubmit="animateSpinner('add')">
             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
             <input type="hidden" name="offset" value="{{ currentView.offset }}"/>
             <div class="text-center pt-3">
                 <div class="btn-group">
                     {% for page in currentView.getPagination() %}
                         {% set btnClass = page.active ? 'btn btn-outline-dark active' : 'btn btn-outline-dark' %}
-                        <button type="button" class="{{ btnClass }}" onclick="editListViewSetOffset('{{ currentView.getViewName() }}', '{{ page.offset }}');">
+                        <button type="button" class="btn-spin-action {{ btnClass }}" onclick="editListViewSetOffset('{{ currentView.getViewName() }}', '{{ page.offset }}');">
                             {{ page.num }}
                         </button>
                     {% endfor %}

--- a/Core/View/Master/EditView.html.twig
+++ b/Core/View/Master/EditView.html.twig
@@ -57,7 +57,7 @@
     {{ row.render(currentView.getViewName(), '', fsc) | raw }}
 </div>
 
-<form id="form{{ currentView.getViewName() }}" method="post" enctype="multipart/form-data">
+<form id="form{{ currentView.getViewName() }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
     {{ formToken() }}
     <input type="hidden" name="action" value="{{ action }}"/>
     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>

--- a/Core/View/Master/EditViewReadOnly.html.twig
+++ b/Core/View/Master/EditViewReadOnly.html.twig
@@ -25,7 +25,7 @@
     {{ row.render(currentView.getViewName(), '', fsc) | raw }}
 </div>
 
-<form id="form{{ currentView.getViewName() }}" method="post" enctype="multipart/form-data">
+<form id="form{{ currentView.getViewName() }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
     <input type="hidden" name="action" value="edit"/>
     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
     <input type="hidden" name="code" value="{{ currentView.model.primaryColumnValue() }}"/>

--- a/Core/View/Master/ListView.html.twig
+++ b/Core/View/Master/ListView.html.twig
@@ -27,7 +27,7 @@
     var listViewDeleteTitle = "{{ trans('confirm-delete') }}";
 </script>
 
-<form id="{{ formName }}" method="post">
+<form id="{{ formName }}" method="post" onsubmit="animateSpinner('add')">
     {{ formToken() }}
     <input type="hidden" name="action"/>
     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>

--- a/Core/View/Master/PanelController.html.twig
+++ b/Core/View/Master/PanelController.html.twig
@@ -224,7 +224,7 @@
             {% endif %}
         </div>
     </div>
-    <form action="{{ firstView.model.url() }}" method="post" target="_blank">
+    <form action="{{ firstView.model.url() }}" method="post" target="_blank" onsubmit="animateSpinner('add')">
         <input type="hidden" name="action" value="export"/>
         <div class="modal fade" id="advancedExportModal" tabindex="-1" aria-hidden="true">
             <div class="modal-dialog">

--- a/Core/View/Master/PanelControllerTop.html.twig
+++ b/Core/View/Master/PanelControllerTop.html.twig
@@ -208,7 +208,7 @@
             {% endif %}
         </div>
     </div>
-    <form action="{{ firstView.model.url() }}" method="post" target="_blank">
+    <form action="{{ firstView.model.url() }}" method="post" target="_blank" onsubmit="animateSpinner('add')">
         <input type="hidden" name="action" value="export"/>
         <div class="modal fade" id="advancedExportModal" tabindex="-1" aria-hidden="true">
             <div class="modal-dialog">

--- a/Core/View/MegaSearch.html.twig
+++ b/Core/View/MegaSearch.html.twig
@@ -31,13 +31,13 @@
         <div class="row">
             <div class="col-sm-3"></div>
             <div class="col-sm-6">
-                <form action="{{ fsc.url() }}" method="post" class="form">
+                <form action="{{ fsc.url() }}" method="post" class="form" onsubmit="animateSpinner('add')">
                     <div class="form-group">
                         <div class="input-group">
                             <input type="text" name="query" value="{{ fsc.query }}" class="form-control form-control-lg"
                                    autocomplete="off" autofocus=""/>
                             <span class="input-group-append">
-                                <button type="submit" class="btn btn-primary">
+                                <button type="submit" class="btn-spin-action btn btn-primary">
                                     <i class="fas fa-search" aria-hidden="true"></i>
                                 </button>
                             </span>

--- a/Core/View/ReportTaxes.html.twig
+++ b/Core/View/ReportTaxes.html.twig
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block body %}
-    <form id="fReportTaxes" method="post">
+    <form id="fReportTaxes" method="post" onsubmit="animateSpinner('add')">
         {{ formToken() }}
         <input type="hidden" name="action" value="export"/>
         <input type="hidden" name="source" value="sales"/>
@@ -145,13 +145,13 @@
                             <div class="form-row">
                                 <div class="col-sm">
                                     <button type="button" onclick="sendReportTaxes('purchases')"
-                                            class="btn btn-block btn-secondary btn-spin-action">
+                                            class="btn-spin-action btn btn-block btn-secondary btn-spin-action">
                                         {{ trans('purchases') }}
                                     </button>
                                 </div>
                                 <div class="col-sm">
                                     <button type="button" onclick="sendReportTaxes('sales')"
-                                            class="btn btn-block btn-primary btn-spin-action">
+                                            class="btn-spin-action btn btn-block btn-primary btn-spin-action">
                                         {{ trans('sales') }}
                                     </button>
                                 </div>
@@ -170,9 +170,8 @@
         function sendReportTaxes(source) {
             let form = document.getElementById('fReportTaxes');
             form.source.value = source;
+            form.onsubmit();
             form.submit();
-
-            animateSpinner('add');
         }
     </script>
 {% endblock %}

--- a/Core/View/Tab/ApiAccess.html.twig
+++ b/Core/View/Tab/ApiAccess.html.twig
@@ -1,4 +1,4 @@
-<form action="" method="post">
+<form action="" method="post" onsubmit="animateSpinner('add')">
     {{ formToken() }}
     <input type="hidden" name="action" value="edit-rules"/>
     <input type="hidden" name="activetab" value="{{ fsc.getCurrentView().getViewName() }}"/>

--- a/Core/View/Tab/DocFiles.html.twig
+++ b/Core/View/Tab/DocFiles.html.twig
@@ -6,9 +6,11 @@
     <div class="row">
         <div class="col">
             {% for docfile in currentView.cursor %}
-                <form action="{{ doc.url() }}" method="post" enctype="multipart/form-data">
+                <form action="{{ doc.url() }}" method="post" enctype="multipart/form-data"
+                      onsubmit="animateSpinner('add')">
                     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
                     <input type="hidden" name="id" value="{{ docfile.id }}"/>
+                    <input type="hidden" name="action" value=""/>
                     {{ formToken() }}
                     <div class="card shadow mb-3">
                         <div class="card-body">
@@ -32,8 +34,8 @@
                                     </p>
                                 </div>
                                 <div class="col text-right">
-                                    <button type="submit" name="action" value="edit-file"
-                                            class="btn btn-sm btn-primary">
+                                    <button type="button" class="btn btn-sm btn-primary"
+                                            onclick="this.form.action.value='edit-file';this.form.onsubmit();this.form.submit();">
                                         <i class="fas fa-save fa-fw" aria-hidden="true"></i> {{ trans('save') }}
                                     </button>
                                     {% if fsc.permissions.allowDelete %}
@@ -45,11 +47,13 @@
                                                     <i class="fas fa-trash-alt"></i>
                                                 </button>
                                                 <div class="dropdown-menu dropdown-menu-right">
-                                                    <button type="submit" name="action" value="delete-file"
+                                                    <button type="button"
+                                                            onclick="this.form.action.value='delete-file';this.form.submit();"
                                                             class="dropdown-item" href="#">
                                                         <i class="far fa-trash-alt fa-fw"></i> {{ trans('delete-file') }}
                                                     </button>
-                                                    <button type="submit" name="action" value="unlink-file"
+                                                    <button type="button"
+                                                            onclick="this.form.action.value='unlink-file';this.form.onsubmit();this.form.submit();"
                                                             class="dropdown-item" href="#">
                                                         <i class="fas fa-unlink fa-fw"></i> {{ trans('unlink-file') }}
                                                     </button>
@@ -64,7 +68,8 @@
                 </form>
             {% endfor %}
             {% if fsc.permissions.allowUpdate %}
-                <form action="{{ doc.url() }}" method="post" enctype="multipart/form-data">
+                <form action="{{ doc.url() }}" method="post" enctype="multipart/form-data"
+                      onsubmit="animateSpinner('add')">
                     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
                     <input type="hidden" name="action" value="add-file"/>
                     {{ formToken() }}

--- a/Core/View/Tab/PreviewFiles.html.twig
+++ b/Core/View/Tab/PreviewFiles.html.twig
@@ -17,7 +17,7 @@
     {# -- New form -- #}
     <div class="row">
         <div class="col">
-            <form id="{{ 'form' ~ currentView.getViewName() ~ '0' }}" action="{{ doc.url() }}" method="post" enctype="multipart/form-data">
+            <form id="{{ 'form' ~ currentView.getViewName() ~ '0' }}" action="{{ doc.url() }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
                 {{ formToken() }}
                 <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}" />
                 <input type="hidden" name="action" value="add-file" />
@@ -57,7 +57,7 @@
                 {% set formName = currentView.getViewName() ~ (counter + 1) %}
                 {% set file = docfile.getFile() %}
                 {% set urlDownload = file.url('download') %}
-                <form id="{{ 'form' ~ formName }}" action="{{ doc.url() }}" method="post" enctype="multipart/form-data">
+                <form id="{{ 'form' ~ formName }}" action="{{ doc.url() }}" method="post" enctype="multipart/form-data" onsubmit="animateSpinner('add')">
                     {{ formToken() }}
                     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}" />
                     <input type="hidden" name="id" value="{{ docfile.id }}" />

--- a/Core/View/Tab/ProductoImagen.html.twig
+++ b/Core/View/Tab/ProductoImagen.html.twig
@@ -28,7 +28,7 @@
     <div class="row">
         <div class="col">
             <form id="{{ 'form' ~ currentView.getViewName() ~ '0' }}" action="{{ product.url() }}" method="post"
-                  enctype="multipart/form-data">
+                  enctype="multipart/form-data" onsubmit="animateSpinner('add')">
                 {{ formToken() }}
                 <input type="hidden" name="action" value="add-image"/>
                 <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
@@ -78,7 +78,7 @@
                     <div class="card-footer">
                         {% set formName = currentView.getViewName() ~ (counter + 1) %}
                         <form id="{{ 'form' ~ formName }}" action="{{ product.url() }}" method="post"
-                              enctype="multipart/form-data">
+                              enctype="multipart/form-data" onsubmit="animateSpinner('add')">
                             {{ formToken() }}
                             <input type="hidden" name="action" value=""/>
                             <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>

--- a/Core/View/Tab/RefundFacturaCliente.html.twig
+++ b/Core/View/Tab/RefundFacturaCliente.html.twig
@@ -66,7 +66,7 @@
     </div>
 {% endif %}
 
-<form action="{{ firstView.model.url() }}" method="post">
+<form action="{{ firstView.model.url() }}" method="post" onsubmit="animateSpinner('add')">
     {{ formToken() }}
     <input type="hidden" name="action" value="new-refund"/>
     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
@@ -124,7 +124,7 @@
                                     </div>
                                 </div>
                                 <div class="btn-group mb-3 ml-3">
-                                    <button type="submit" class="btn btn-warning">
+                                    <button type="submit" class="btn-spin-action btn btn-warning">
                                         <i class="fas fa-save fa-fw" aria-hidden="true"></i> {{ trans('save') }}
                                     </button>
                                 </div>

--- a/Core/View/Tab/RefundFacturaProveedor.html.twig
+++ b/Core/View/Tab/RefundFacturaProveedor.html.twig
@@ -66,7 +66,7 @@
     </div>
 {% endif %}
 
-<form action="{{ firstView.model.url() }}" method="post">
+<form action="{{ firstView.model.url() }}" method="post" onsubmit="animateSpinner('add')">
     {{ formToken() }}
     <input type="hidden" name="action" value="new-refund"/>
     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
@@ -130,7 +130,7 @@
                                     </div>
                                 </div>
                                 <div class="btn-group mb-3">
-                                    <button type="submit" class="btn btn-warning ml-3">
+                                    <button type="submit" class="btn-spin-action btn btn-warning ml-3">
                                         <i class="fas fa-save fa-fw" aria-hidden="true"></i> {{ trans('save') }}
                                     </button>
                                 </div>

--- a/Core/View/Tab/RoleAccess.html.twig
+++ b/Core/View/Tab/RoleAccess.html.twig
@@ -13,7 +13,7 @@
     }
 </style>
 
-<form action="" method="post">
+<form action="" method="post" onsubmit="animateSpinner('add')">
     {{ formToken() }}
     <input type="hidden" name="action" value="edit-rules"/>
     <input type="hidden" name="activetab" value="{{ fsc.getCurrentView().getViewName() }}"/>

--- a/Core/View/Updater.html.twig
+++ b/Core/View/Updater.html.twig
@@ -20,6 +20,7 @@
 {% extends "Master/MenuTemplate.html.twig" %}
 
 {% block messages %}
+    {% include 'Macro/Toasts.html.twig' %}
     {% from 'Macro/Utils.html.twig' import messageCompat as showMessage %}
     <div class="container-fluid">
         <div class="row">
@@ -87,23 +88,23 @@
                         {% if item.mincore > fsc.getCoreVersion() %}
                             {{ trans('requires-core', {'%version%': item.mincore}) }}
                         {% elseif item.downloaded %}
-                            <a href="{{ fsc.url() }}?action=update&item={{ item.id }}" class="btn btn-sm btn-success">
+                            <a href="{{ fsc.url() }}?action=update&item={{ item.id }}" class="btn-spin-action btn btn-sm btn-success" onclick="animateSpinner('add')">
                                 <i class="fas fa-rocket fa-fw" aria-hidden="true"></i> {{ trans('update') }}
                             </a>
-                            <a href="{{ fsc.url() }}?action=cancel&item={{ item.id }}" class="btn btn-sm btn-warning">
+                            <a href="{{ fsc.url() }}?action=cancel&item={{ item.id }}" class="btn-spin-action btn btn-sm btn-warning" onclick="animateSpinner('add')">
                                 <i class="fas fa-times fa-fw" aria-hidden="true"></i> {{ trans('cancel') }}
                             </a>
                         {% elseif item.name == 'CORE' and fsc.coreUpdateWarnings %}
-                            <button type="button" class="btn btn-warning" data-toggle="modal"
+                            <button type="button" class="btn-spin-action btn btn-warning" data-toggle="modal"
                                     data-target="#coreWarningModal">{{ trans('download') }}
                             </button>
                         {% elseif item.stable %}
                             <a href="{{ fsc.url() }}?action=download&item={{ item.id }}"
-                               class="btn btn-sm btn-secondary">{{ trans('download') }}
+                               class="btn-spin-action btn btn-sm btn-secondary" onclick="animateSpinner('add')">{{ trans('download') }}
                             </a>
                         {% else %}
                             <a href="{{ fsc.url() }}?action=download&item={{ item.id }}"
-                               class="btn btn-sm btn-outline-warning">{{ trans('beta') }}
+                               class="btn-spin-action btn btn-sm btn-outline-warning" onclick="animateSpinner('add')">{{ trans('beta') }}
                             </a>
                         {% endif %}
                     </td>
@@ -136,9 +137,9 @@
                                 </a>
                             </div>
                             <div class="col text-right">
-                                <form action="{{ fsc.url() }}" method="post">
+                                <form action="{{ fsc.url() }}" method="post" onsubmit="animateSpinner('add')">
                                     <input type="hidden" name="action" value="unlink"/>
-                                    <button type="submit" class="btn btn-danger">
+                                    <button type="submit" class="btn-spin-action btn btn-danger">
                                         {{ trans('unlink') }}
                                     </button>
                                 </form>
@@ -146,7 +147,7 @@
                         </div>
                     </div>
                 {% else %}
-                    <form action="{{ fsc.url() }}" method="post">
+                    <form action="{{ fsc.url() }}" method="post" onsubmit="animateSpinner('add')">
                         <input type="hidden" name="action" value="register"/>
                         <div class="modal-header">
                             <h5 class="modal-title">{{ trans('register-installation') }}</h5>
@@ -158,7 +159,7 @@
                         <div class="modal-body">
                             <p>{{ trans('register-installation-p') }}</p>
                             <p>{{ trans('telemetry-data-to-send') }}</p>
-                            <button type="submit" class="btn btn-primary">
+                            <button type="submit" class="btn-spin-action btn btn-primary">
                                 {{ trans('register-installation') }}
                             </button>
                         </div>
@@ -192,15 +193,15 @@
                             {% if item.name == 'CORE' and fsc.coreUpdateWarnings %}
                                 <div class="btn-group">
                                     <a href="{{ fsc.url() }}?action=download&item={{ item.id }}&disable={{ fsc.coreUpdateWarnings | keys | join(',') }}"
-                                       class="btn btn-warning">{{ trans('download') }}
+                                       class="btn-spin-action btn btn-warning" onclick="animateSpinner('add')">{{ trans('download') }}
                                     </a>
-                                    <button type="button" class="btn btn-warning dropdown-toggle dropdown-toggle-split"
+                                    <button type="button" class="btn-spin-action btn btn-warning dropdown-toggle dropdown-toggle-split"
                                             data-toggle="dropdown" aria-expanded="false">
                                         <span class="sr-only">{{ trans('options') }}</span>
                                     </button>
                                     <div class="dropdown-menu">
                                         <a href="{{ fsc.url() }}?action=download&item={{ item.id }}"
-                                           class="btn btn-warning">{{ trans('do-not-disable-plugins') }}
+                                           class="btn btn-warning" onclick="animateSpinner('add')">{{ trans('do-not-disable-plugins') }}
                                         </a>
                                     </div>
                                 </div>


### PR DESCRIPTION
Una ejecución puede tardar muchos segundos en algunos casos, y no hay anda que indique que se esta ejecutando. Con este cambio añadimos el animateSpinner() en los formularios por defecto, de tal forma que se indica bien claro que se esta ejecutando la petición, además de desactivar el resto de botones para evitar clic problemáticos.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.