### PR TITLE
Tarea #2719 - contador adjuntos

### DIFF
--- a/Core/Model/AttachedFile.php
+++ b/Core/Model/AttachedFile.php
@@ -59,12 +59,16 @@ class AttachedFile extends Base\ModelOnChangeClass
     /** @var int */
     public $size;
 
+    /** @var int */
+    public $downloads;
+
     public function clear()
     {
         parent::clear();
         $this->date = Tools::date();
         $this->hour = Tools::hour();
         $this->size = 0;
+        $this->downloads = 0;
     }
 
     public function delete(): bool

--- a/Core/Table/attached_files.xml
+++ b/Core/Table/attached_files.xml
@@ -39,6 +39,11 @@
         <type>integer</type>
         <null>NO</null>
     </column>
+    <column>
+        <name>downloads</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
     <constraint>
         <name>attached_files_pkey</name>
         <type>PRIMARY KEY (idfile)</type>

--- a/Core/View/Tab/AttachedFilePreview.html.twig
+++ b/Core/View/Tab/AttachedFilePreview.html.twig
@@ -22,12 +22,12 @@
     {% elseif file.getExtension() == 'mp4' %}
         <div class="embed-responsive embed-responsive-16by9">
             <video width="320" height="240" controls>
-                <source src="{{ asset(file.url('download-permanent')) }}" type="video/mp4" />
+                <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/mp4" />
             </video>
         </div>
     {% elseif file.getExtension() == 'pdf' %}
         <div class="embed-responsive embed-responsive-16by9">
-            <embed src="{{ asset(file.url('download-permanent')) }}" type="application/pdf" />
+            <embed src="{{ asset(file.url('download-permanent')) }}&embed=true" type="application/pdf" />
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
# Descripción
- Añadir contador de descargas a los archivos adjuntos, para poder saber cuantas descargas ha habido del archivo.
- Se añade input embed a las peticiones que se hacen desde el elemento html 'embed' para que solo cuente las descargas reales y no la previsualización de los archivos en las vistas.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

