### PR TITLE
Tarea #721 - mostrar guardar solo ListController

### DIFF
--- a/Core/Html.php
+++ b/Core/Html.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of FacturaScripts
  * Copyright (C) 2017-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
@@ -319,6 +319,14 @@ final class Html
         });
     }
 
+    private static function isInstanceofFunction(): TwigFunction
+    {
+        return new TwigFunction('isInstanceof', function ($var, $instance) {
+            $instance = '\\FacturaScripts\\Core\\Lib\\ExtendedController\\' . $instance;
+            return $var instanceof $instance;
+        });
+    }
+
     /**
      * @throws LoaderError
      */
@@ -363,6 +371,7 @@ final class Html
         self::$twig->addFunction(self::settingsFunction());
         self::$twig->addFunction(self::transFunction());
         self::$twig->addFunction(self::bytesFunction());
+        self::$twig->addFunction(self::isInstanceofFunction());
         foreach (self::$functions as $function) {
             self::$twig->addFunction($function);
         }

--- a/Core/View/Master/ListView.html.twig
+++ b/Core/View/Master/ListView.html.twig
@@ -262,7 +262,7 @@
             <button type="button" class="btn btn-light" onclick="listViewShowFilters('{{ viewName }}');">
                 <i class="fas fa-filter fa-fw"></i> {{ trans('filters') }}
             </button>
-            {% if currentView.showFilters %}
+            {% if currentView.showFilters and isInstanceof(fsc, 'ListController') %}
                 {# -- Save user filters -- #}
                 <button type="button" class="btn btn-success" data-toggle="modal"
                         data-target="#savefilter{{ viewName }}"


### PR DESCRIPTION
# Descripción
- En los listview, ocultar el botón de guardar filtros cuando no es un list controller
1. Ir al menú ventas, clientes, pestaña grupos, crear un grupo y guardar.
2. En la parte de abajo pulsar el botón filtros y seleccionar una serie.
3. No debe aparecer el botón guardar YA QUE NO SE TRATA DE UN LISTCONTROLLER.
4. Ir al menú ventas, clientes, pulsar el botón filtros y filtrar por series. En este casi SI que debe aparecer el botón guardar.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [X] He probado que funciona correctamente con una base de datos vacía.
- [X] He ejecutado los tests unitarios.
