### PR TITLE
Tarea #957 - no permitir estado pred y no editable

### DIFF
--- a/Core/Model/EstadoDocumento.php
+++ b/Core/Model/EstadoDocumento.php
@@ -105,6 +105,12 @@ class EstadoDocumento extends Base\ModelOnChangeClass
 
     public function test(): bool
     {
+        // No permitimos que un estado predeterminado sea no editable.
+        if (true === $this->predeterminado && false === $this->editable){
+            Tools::log()->error('non-editable-default-not-allowed');
+            return false;
+        }
+
         // escapamos el html
         $this->color = Tools::noHtml($this->color);
         $this->generadoc = Tools::noHtml($this->generadoc);

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -969,6 +969,7 @@
     "no-stock": "No controlar stock",
     "non-editable-accounting-entry": "Asiento no editable",
     "non-editable-columns": "Columnas no editables: %columns%",
+    "non-editable-default-not-allowed": "Un estado predeterminado y no editable no esta permitido.",
     "non-editable-document": "Documento no editable",
     "none": "Ninguno",
     "normal": "Normal",

--- a/Test/Core/Model/EstadoDocumentoTest.php
+++ b/Test/Core/Model/EstadoDocumentoTest.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Base\MiniLog;
 use FacturaScripts\Core\Model\EstadoDocumento;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
@@ -146,6 +147,25 @@ final class EstadoDocumentoTest extends TestCase
         $status->generadoc = 'PedidoProveedor';
         $status->tipodoc = 'FacturaProveedor';
         $this->assertFalse($status->save(), 'invalid-estado-documento-for-purchase-invoice-can-save');
+    }
+
+    /**
+     * No permitir crear estados predeterminados y no editables.
+     */
+    public function testNonEditableDefaultNotAllowed()
+    {
+        MiniLog::clear();
+
+        // Crear nuevo estado predeterminado y no editable
+        $status = new EstadoDocumento();
+        $status->nombre = 'Test default';
+        $status->predeterminado = true;
+        $status->editable = false;
+        $status->tipodoc = 'PresupuestoProveedor';
+
+        // Comprobamos que no se pueda guardar un estado que sea predeterminado y no editable.
+        $this->assertFalse($status->save());
+        $this->assertEquals('non-editable-default-not-allowed', MiniLog::read('master', ['error'])[0]['original']);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
# Descripción
- No permitir crear estados predeterminados y no editables.
- Incluimos test para comprobar que no se puede guardar un estado predeterminado y no editable.
- Incluimos el mensaje de error al fichero de traducciones.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

![imagen](https://github.com/NeoRazorX/facturascripts/assets/2836337/3c6d4e40-f821-4660-8d65-14306646a589)

