### PR TITLE
Corregido bug en los modales con animateSpinner

### DIFF
--- a/Core/Lib/Widget/GroupItem.php
+++ b/Core/Lib/Widget/GroupItem.php
@@ -154,7 +154,8 @@ class GroupItem extends VisualItem
             . '<button type="button" class="btn btn-spin-action btn-secondary" data-dismiss="modal">'
             . static::$i18n->trans('cancel')
             . '</button>'
-            . '<button type="submit" name="action" value="' . $this->name . '" class="btn-spin-action  btn btn-primary">'
+            . '<input type="hidden" name="action" value="' . $this->name . '"/>'
+            . '<button type="submit" class="btn-spin-action btn btn-primary">'
             . static::$i18n->trans('accept')
             . '</button>'
             . '</div>'


### PR DESCRIPTION
Los modales que llevan un formulario dentro no se estaban enviado, con este cambio soluciona ese problema con el animateSpinner()

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.