### PR TITLE
#2149 Permisos de grupos

### DIFF
--- a/Core/Controller/EditRole.php
+++ b/Core/Controller/EditRole.php
@@ -40,7 +40,8 @@ class EditRole extends EditController
         $i18n = Tools::lang();
         foreach ($this->getAllPages() as $page) {
             $rules[$page->name] = [
-                'menu' => $i18n->trans($page->menu) . ' » ' . $i18n->trans($page->title),
+                'menu' => $i18n->trans($page->menu),
+                'page' => $i18n->trans($page->title),
                 'show' => false,
                 'onlyOwner' => false,
                 'update' => false,

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -306,7 +306,7 @@ final class Kernel
 
     public static function version(): float
     {
-        return 2023.14;
+        return 2023.15;
     }
 
     private static function cleanErrorMessage(string $message): string

--- a/Core/View/Tab/RoleAccess.html.twig
+++ b/Core/View/Tab/RoleAccess.html.twig
@@ -37,161 +37,145 @@
                 </tr>
                 </thead>
                 <tbody>
-                <tr class="table-warning">
-                    <td></td>
+                {% set menu = 'TodosMenus' %}
+                <tr class="table-warning" id="tr{{menu}}">
+                    <td><b>{{ trans('all') }}</b></td>
                     <td class="text-center">
                         <div class="custom-control-lg custom-control custom-checkbox">
-                            <input class="all-permission custom-control-input" id="checkbox-all-show" value="show"
-                                   type="checkbox"/>
-                            <label class="custom-control-label" for="checkbox-all-show">&nbsp</label>
+                            <input class="all-permission custom-control-input" id="checkbox-all-show" value="show" type="checkbox" data-menu="{{ menu }}" data-type="show"/>
+                            <label class="custom-control-label" for="checkbox-all-show">&nbsp;</label>
                         </div>
                     </td>
                     <td class="text-center">
                         <div class="custom-control-lg custom-control custom-checkbox">
-                            <input class="all-permission custom-control-input" id="checkbox-all-onlyOwner"
-                                   value="only-owner" type="checkbox"/>
-                            <label class="custom-control-label" for="checkbox-all-onlyOwner">&nbsp</label>
+                            <input class="all-permission custom-control-input" id="checkbox-all-onlyOwner" value="only-owner" type="checkbox" data-menu="{{ menu }}" data-type="only-owner"/>
+                            <label class="custom-control-label" for="checkbox-all-onlyOwner">&nbsp;</label>
                         </div>
                     </td>
                     <td class="text-center">
                         <div class="custom-control-lg custom-control custom-checkbox">
-                            <input class="all-permission custom-control-input" id="checkbox-all-update" value="update"
-                                   type="checkbox"/>
-                            <label class="custom-control-label" for="checkbox-all-update">&nbsp</label>
+                            <input class="all-permission custom-control-input" id="checkbox-all-update" value="update" type="checkbox" data-menu="{{ menu }}" data-type="update"/>
+                            <label class="custom-control-label" for="checkbox-all-update">&nbsp;</label>
                         </div>
                     </td>
                     <td class="text-center">
                         <div class="custom-control-lg custom-control custom-checkbox">
-                            <input class="all-permission custom-control-input" id="checkbox-all-import" value="import"
-                                   type="checkbox"/>
-                            <label class="custom-control-label" for="checkbox-all-import">&nbsp</label>
+                            <input class="all-permission custom-control-input" id="checkbox-all-import" value="import" type="checkbox" data-menu="{{ menu }}" data-type="import"/>
+                            <label class="custom-control-label" for="checkbox-all-import">&nbsp;</label>
                         </div>
                     </td>
                     <td class="text-center">
                         <div class="custom-control-lg custom-control custom-checkbox">
-                            <input class="all-permission custom-control-input" id="checkbox-all-export" value="export"
-                                   type="checkbox"/>
-                            <label class="custom-control-label" for="checkbox-all-export">&nbsp</label>
+                            <input class="all-permission custom-control-input" id="checkbox-all-export" value="export" type="checkbox" data-menu="{{ menu }}" data-type="export"/>
+                            <label class="custom-control-label" for="checkbox-all-export">&nbsp;</label>
                         </div>
                     </td>
                     <td class="text-center">
                         <div class="custom-control-lg custom-control custom-checkbox">
-                            <input class="all-permission custom-control-input" id="checkbox-all-delete" value="delete"
-                                   type="checkbox"/>
-                            <label class="custom-control-label" for="checkbox-all-delete">&nbsp</label>
+                            <input class="all-permission custom-control-input" id="checkbox-all-delete" value="delete" type="checkbox" data-menu="{{ menu }}" data-type="delete"/>
+                            <label class="custom-control-label" for="checkbox-all-delete">&nbsp;</label>
                         </div>
                     </td>
                 </tr>
                 {% for pageName, rule in fsc.getAccessRules() %}
-                    <tr>
+                    {% if rule.menu|replace({' ': ''}) != menu %}
+                        {% set menu = rule.menu|replace({' ': ''}) %}
+                        <tr class="table-warning" id="tr{{menu}}">
+                            <td><span style="cursor:pointer" onclick="toggleMenu('{{ menu }}')"><i id="plus{{ menu }}" class="far fa-plus-square"></i><i id="minus{{ menu }}" class="far fa-minus-square d-none"></i> <b>{{ trans('menu') }} {{ menu }}</b></span></td>
+                            <td class="text-center">
+                                <div class="custom-control-lg custom-control custom-checkbox">
+                                    <input class="all-menu-permission show-menu-permission custom-control-input" id="checkbox-all-menu-show-{{ menu }}" value="show-{{ menu }}" type="checkbox" data-menu="{{ menu }}" data-type="show"/>
+                                    <label class="custom-control-label label-contador" for="checkbox-all-menu-show-{{ menu }}" data-menu="{{ menu }}" data-type="show">&nbsp;</label>
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <div class="custom-control-lg custom-control custom-checkbox">
+                                    <input class="all-menu-permission only-owner-menu-permission custom-control-input" id="checkbox-all-menu-only-owner-{{ menu }}" value="only-owner-{{ menu }}" type="checkbox" data-menu="{{ menu }}" data-type="only-owner"/>
+                                    <label class="custom-control-label label-contador" for="checkbox-all-menu-only-owner-{{ menu }}" data-menu="{{ menu }}" data-type="only-owner">&nbsp;</label>
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <div class="custom-control-lg custom-control custom-checkbox">
+                                    <input class="all-menu-permission update-menu-permission custom-control-input" id="checkbox-all-menu-update-{{ menu }}" value="update-{{ menu }}" type="checkbox" data-menu="{{ menu }}" data-type="update"/>
+                                    <label class="custom-control-label label-contador" for="checkbox-all-menu-update-{{ menu }}" data-menu="{{ menu }}" data-type="update">&nbsp;</label>
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <div class="custom-control-lg custom-control custom-checkbox">
+                                    <input class="all-menu-permission import-menu-permission custom-control-input" id="checkbox-all-menu-import-{{ menu }}" value="import-{{ menu }}" type="checkbox" data-menu="{{ menu }}" data-type="import"/>
+                                    <label class="custom-control-label label-contador" for="checkbox-all-menu-import-{{ menu }}" data-menu="{{ menu }}" data-type="import">&nbsp;</label>
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <div class="custom-control-lg custom-control custom-checkbox">
+                                    <input class="all-menu-permission export-menu-permission custom-control-input" id="checkbox-all-menu-export-{{ menu }}" value="export-{{ menu }}" type="checkbox" data-menu="{{ menu }}" data-type="export"/>
+                                    <label class="custom-control-label label-contador" for="checkbox-all-menu-export-{{ menu }}" data-menu="{{ menu }}" data-type="export">&nbsp;</label>
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <div class="custom-control-lg custom-control custom-checkbox">
+                                    <input class="all-menu-permission delete-menu-permission custom-control-input" id="checkbox-all-menu-delete-{{ menu }}" value="delete-{{ menu }}" type="checkbox" data-menu="{{ menu }}" data-type="delete"/>
+                                    <label class="custom-control-label label-contador" for="checkbox-all-menu-delete-{{ menu }}" data-menu="{{ menu }}" data-type="delete">&nbsp;</label>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endif %}
+                    <tr class="d-none tr{{menu}}" >
                         <td>
-                            {{ rule.menu }}
+                            {{ ' » ' ~ rule.page }}
                             {% if 'List' in pageName %}
                                 <span class="badge badge-info ml-1">{{ trans('list') }}</span>
                             {% endif %}
                         </td>
                         <td class="text-center">
                             <div class="custom-control-lg custom-control custom-checkbox">
-                                {% if rule.show %}
-                                    <input class="show-permission custom-control-input"
-                                           id="checkbox-large-show-{{ pageName }}" type="checkbox" name="show[]"
-                                           value="{{ pageName }}" checked/>
-                                {% else %}
-                                    <input class="show-permission custom-control-input"
-                                           id="checkbox-large-show-{{ pageName }}" type="checkbox" name="show[]"
-                                           value="{{ pageName }}"/>
-                                {% endif %}
-                                <label class="custom-control-label"
-                                       for="checkbox-large-show-{{ pageName }}">&nbsp</label>
+                                <input class="permission show-permission show-menu-permission show-{{menu}}-permission custom-control-input" id="checkbox-large-show-{{ pageName }}" type="checkbox" name="show[]" data-menu="{{ menu }}" data-type="show" value="{{ pageName }}" {% if rule.show %}checked="" {% endif %}/>
+                                <label class="custom-control-label" for="checkbox-large-show-{{ pageName }}">&nbsp</label>
                             </div>
                         </td>
                         <td class="text-center">
                             <div class="custom-control-lg custom-control custom-checkbox">
-                                {% if rule.onlyOwner %}
-                                    <input class="only-owner-permission custom-control-input"
-                                           id="checkbox-large-onlyOwner-{{ pageName }}" type="checkbox"
-                                           name="onlyOwner[]" value="{{ pageName }}" checked/>
-                                {% else %}
-                                    <input class="only-owner-permission custom-control-input"
-                                           id="checkbox-large-onlyOwner-{{ pageName }}" type="checkbox"
-                                           name="onlyOwner[]"
-                                           value="{{ pageName }}"/>
-                                {% endif %}
-                                <label class="custom-control-label"
-                                       for="checkbox-large-onlyOwner-{{ pageName }}">&nbsp</label>
+                                <input class="permission only-owner-permission only-owner-menu-permission only-owner-{{menu}}-permission custom-control-input" id="checkbox-large-onlyOwner-{{ pageName }}" type="checkbox" name="onlyOwner[]" data-menu="{{ menu }}" data-type="only-owner" value="{{ pageName }}" {% if rule.onlyOwner %}checked="" {% endif %}/>
+                                <label class="custom-control-label" for="checkbox-large-onlyOwner-{{ pageName }}">&nbsp</label>
                             </div>
                         </td>
                         <td class="text-center">
                             <div class="custom-control-lg custom-control custom-checkbox">
-                                {% if rule.update %}
-                                    <input class="update-permission custom-control-input"
-                                           id="checkbox-large-update-{{ pageName }}" type="checkbox" name="update[]"
-                                           value="{{ pageName }}" checked/>
-                                {% else %}
-                                    <input class="update-permission custom-control-input"
-                                           id="checkbox-large-update-{{ pageName }}" type="checkbox" name="update[]"
-                                           value="{{ pageName }}"/>
-                                {% endif %}
-                                <label class="custom-control-label"
-                                       for="checkbox-large-update-{{ pageName }}">&nbsp</label>
+                                <input class="permission update-permission update-menu-permission update-{{menu}}-permission custom-control-input" id="checkbox-large-update-{{ pageName }}" type="checkbox" name="update[]" data-menu="{{ menu }}" data-type="update" value="{{ pageName }}" {% if rule.update %} checked="" {% endif %}/>
+                                <label class="custom-control-label" for="checkbox-large-update-{{ pageName }}">&nbsp</label>
                             </div>
                         </td>
                         <td class="text-center">
                             <div class="custom-control-lg custom-control custom-checkbox">
-                                {% if rule.import %}
-                                    <input class="import-permission custom-control-input"
-                                           id="checkbox-large-import-{{ pageName }}" type="checkbox" name="import[]"
-                                           value="{{ pageName }}" checked/>
-                                {% else %}
-                                    <input class="import-permission custom-control-input"
-                                           id="checkbox-large-import-{{ pageName }}" type="checkbox" name="import[]"
-                                           value="{{ pageName }}"/>
-                                {% endif %}
-                                <label class="custom-control-label"
-                                       for="checkbox-large-import-{{ pageName }}">&nbsp</label>
+                                <input class="permission import-permission import-menu-permission import-{{menu}}-permission custom-control-input" id="checkbox-large-import-{{ pageName }}" type="checkbox" name="import[]" data-menu="{{ menu }}" data-type="import" value="{{ pageName }}" {% if rule.import %} checked="" {% endif %}/>
+                                <label class="custom-control-label" for="checkbox-large-import-{{ pageName }}">&nbsp</label>
                             </div>
                         </td>
                         <td class="text-center">
                             <div class="custom-control-lg custom-control custom-checkbox">
-                                {% if rule.export %}
-                                    <input class="export-permission custom-control-input"
-                                           id="checkbox-large-export-{{ pageName }}" type="checkbox" name="export[]"
-                                           value="{{ pageName }}" checked/>
-                                {% else %}
-                                    <input class="export-permission custom-control-input"
-                                           id="checkbox-large-export-{{ pageName }}" type="checkbox" name="export[]"
-                                           value="{{ pageName }}"/>
-                                {% endif %}
-                                <label class="custom-control-label"
-                                       for="checkbox-large-export-{{ pageName }}">&nbsp</label>
+                                <input class="permission export-permission export-menu-permission export-{{menu}}-permission custom-control-input" id="checkbox-large-export-{{ pageName }}" type="checkbox" name="export[]" data-menu="{{ menu }}" data-type="export" value="{{ pageName }}" {% if rule.export %} checked="" {% endif %}/>
+                                <label class="custom-control-label" for="checkbox-large-export-{{ pageName }}">&nbsp</label>
                             </div>
                         </td>
                         <td class="text-center">
                             <div class="custom-control-lg custom-control custom-checkbox">
-                                {% if rule.delete %}
-                                    <input class="delete-permission custom-control-input"
-                                           id="checkbox-large-delete-{{ pageName }}" type="checkbox" name="delete[]"
-                                           value="{{ pageName }}" checked/>
-                                {% else %}
-                                    <input class="delete-permission custom-control-input"
-                                           id="checkbox-large-delete-{{ pageName }}" type="checkbox" name="delete[]"
-                                           value="{{ pageName }}"/>
-                                {% endif %}
-                                <label class="custom-control-label"
-                                       for="checkbox-large-delete-{{ pageName }}">&nbsp</label>
+                                <input class="permission delete-permission delete-menu-permission delete-{{menu}}-permission custom-control-input" id="checkbox-large-delete-{{ pageName }}" type="checkbox" name="delete[]" data-menu="{{ menu }}" data-type="delete" value="{{ pageName }}" {% if rule.delete %} checked="" {% endif %}/>
+                                <label class="custom-control-label" for="checkbox-large-delete-{{ pageName }}">&nbsp</label>
                             </div>
                         </td>
                     </tr>
                 {% else %}
                     <tr class="table-warning">
-                        <td colspan="7">{{ trans('no-data') }}</td>
+                        <td colspan="7">
+                            {{ trans('no-data') }}
+                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>
             </table>
         </div>
         <div class="card-body text-right">
-            <button type="submit" class="btn btn-sm btn-primary btn-spin-action">
+            <button type="submit" class="btn btn-sm btn-primary">
                 <i class="fas fa-save fa-fw"></i> {{ trans('save') }}
             </button>
         </div>
@@ -200,28 +184,90 @@
 
 <script>
     $(document).ready(function () {
-        $('input.only-owner-permission, input.update-permission, input.import-permission, input.export-permission, input.delete-permission')
-            .change(function () {
-                if (this.checked) {
-                    $(this).parent().parent().parent().find('input.show-permission').prop('checked', true);
-                }
-            });
 
-        $('input.show-permission').change(function () {
-            if (!this.checked) {
-                $(this).parent().parent().parent().find('input.only-owner-permission').prop('checked', false);
-                $(this).parent().parent().parent().find('input.update-permission').prop('checked', false);
-                $(this).parent().parent().parent().find('input.import-permission').prop('checked', false);
-                $(this).parent().parent().parent().find('input.export-permission').prop('checked', false);
-                $(this).parent().parent().parent().find('input.delete-permission').prop('checked', false);
+        //Individuales
+        $('input[type="checkbox"].permission').change(function () {
+            if(this.checked && 'show' !== $(this).data('type')) {
+                $(this).parent().parent().parent().find('input.show-permission').prop('checked', true).change();
+            }
+            if(!this.checked && $(this).data('type') === 'show') {
+                $("#tr" + $(this).data("menu")).find('input').prop('checked', false)
+                $(this).parent().parent().parent().find('input.only-owner-permission, input.update-permission, input.import-permission, input.export-permission, input.delete-permission').prop('checked', false).change();
+            }
+            if(!this.checked && 'show' !== $(this).data('type')) {
+                $("#trTodosMenus").find('input[data-type=' + $(this).data('type') + ']').prop('checked', false)
+                $("#tr" + $(this).data("menu")).find('input[data-type=' + $(this).data('type') + ']').prop('checked', false)
+            }
+            let cuenta = countChecked($(this).data('type'), $(this).data('menu'));
+            let selector = "label[for='checkbox-all-menu-" + $(this).data('type') + "-" + $(this).data('menu') + "']";
+            if ('' !== cuenta) {
+                $(selector).html('<span class="badge badge-info">' + cuenta + '</span>');
+                if(cuenta === '{{ trans('all') }}') {
+                    $(selector).parent().parent().parent().find('input.' + $(this).data('type') + '-menu-permission').prop('checked', true);
+                }
+            }
+            else {
+                $(selector).html('&nbsp;');
+            }
+
+            if($("#tr" + $(this).data("menu")).find('input:not(:checked())').length === 0) {
+                $("#tr" + $(this).data("menu")).removeClass('table-warning').addClass('table-success');
+            }
+            else {
+                $("#tr" + $(this).data("menu")).removeClass('table-success').addClass('table-warning');
             }
         });
 
-        $('input.all-permission').change(function () {
+        //Todo el menú
+        $('input[type="checkbox"].all-menu-permission').change(function () {
             $('input.' + this.value + '-permission').prop('checked', this.checked).change();
-            if (!this.checked && this.value === 'show') {
-                $('input.all-permission').prop('checked', false);
+        });
+
+        //Todos
+        $('input[type="checkbox"].all-permission').change(function () {
+            $('input.' + this.value + '-menu-permission').prop('checked', this.checked).change();
+        });
+
+        $('label.label-contador').each(function () {
+            let cuenta = countChecked($(this).data('type'), $(this).data('menu'));
+            if ('' !== cuenta) {
+                $(this).html('<span class="badge badge-info">' + cuenta + '</span>');
+                if(cuenta === '{{ trans('all') }}') {
+                    $(this).parent().parent().parent().find('input.' + $(this).data('type') + '-menu-permission').prop('checked', true);
+                }
+            }
+            else {
+                $(this).html('&nbsp;');
+            }
+
+        });
+
+        $('tr.table-warning').each(function () {
+            if($(this).find('input:not(:checked())').length === 0) {
+                $(this).removeClass('table-warning');
+                $(this).addClass('table-success');
+            }
+            else {
+                $(this).removeClass('table-success');
+                $(this).addClass('table-warning');
             }
         });
     });
+
+    function countChecked(type, menu) {
+        let numchecked = $("input[data-type='" + type + "'][data-menu='" + menu + "'].permission:checked()").length;
+        let numunchecked = $("input[data-type='" + type + "'][data-menu='" + menu + "'].permission").length;
+        if(numchecked === 0) {
+            return '';
+        }
+        if(numchecked === numunchecked) {
+            return '{{ trans('all') }}';
+        }
+        return numchecked + '/' + numunchecked;
+    }
+
+    function toggleMenu(menu) {
+        $('#plus' + menu + ', #minus' + menu + ', tr.tr' + menu ).toggleClass('d-none');
+    }
+
 </script>


### PR DESCRIPTION
Agrupa los permisos por el nombre del menú añadiendo una fila por cada uno de ellos permitiendo asignar y desasignar todos los permisos de una vez. En cada grupo, indica el número de permisos que tiene asignados así como el total de los disponibles. Si tiene todos los permisos asignados la fila se pone de color "success".

Enlace al video para ver como funciona: https://youtu.be/TxU4x28gLo4

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [ X ] He revisado mi código antes de enviarlo.
- [ X ] He probado que funciona correctamente en mi PC.
- [ X ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

