### PR TITLE
No permitir eliminar productos o variantes ya compradas o vendidas

### DIFF
--- a/Core/Model/Producto.php
+++ b/Core/Model/Producto.php
@@ -208,6 +208,27 @@ class Producto extends ModelClass
 
     public function delete(): bool
     {
+        //desactivamos la compra y la venta para poder eliminar las variantes
+        $this->secompra = false;
+        $this->sevende = false;
+        $this->save();
+
+        $whereVar = [
+            new DataBaseWhere('idproducto', $this->idproducto)
+        ];
+
+        // comprobar si está en algún albarán de ventas
+        $var = new Variante();
+        $variantes = $var->all($whereVar, [], 0, 0);
+        if (!empty($variantes)) {
+            foreach ($variantes as $variante) {
+                $res = $variante->delete();
+                if(false === $res) {
+                    return $res;
+                }
+            }
+        }
+
         // eliminamos las imágenes del producto
         foreach ($this->getImages() as $image) {
             $image->delete();

--- a/Core/Model/Producto.php
+++ b/Core/Model/Producto.php
@@ -208,11 +208,6 @@ class Producto extends ModelClass
 
     public function delete(): bool
     {
-        //desactivamos la compra y la venta para poder eliminar las variantes
-        $this->secompra = false;
-        $this->sevende = false;
-        $this->save();
-
         $whereVar = [
             new DataBaseWhere('idproducto', $this->idproducto)
         ];
@@ -222,7 +217,7 @@ class Producto extends ModelClass
         $variantes = $var->all($whereVar, [], 0, 0);
         if (!empty($variantes)) {
             foreach ($variantes as $variante) {
-                $res = $variante->delete();
+                $res = $variante->delete(true);
                 if(false === $res) {
                     return $res;
                 }

--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -176,7 +176,7 @@ class Variante extends Base\ModelClass
         );
     }
 
-    public function delete(): bool
+    public function delete($complete = false): bool
     {
         $whereVar = [
             new DataBaseWhere('idproducto', $this->idproducto),
@@ -217,7 +217,7 @@ class Variante extends Base\ModelClass
 
         // no se puede eliminar la variante principal, salvo que no se compre ni se venda (para poder eliminar el producto)
         $producto = $this->getProducto();
-        if ($this->referencia === $producto->referencia && !(false === $producto->secompra && false === $producto->sevende)) {
+        if ($this->referencia === $producto->referencia && (false === $complete)) {
             Tools::log()->warning('you-cant-delete-primary-variant');
             return false;
         }


### PR DESCRIPTION
# Descripción
- No permite eliminar un producto o sus variantes si este está en un albarán/factura de cliente o albarán/factura de proveedor.
- En el modelo del producto, al borrarlo, se eliminan todas las variantes
- En el modelo de la variante se comprueba si está en algún documento. Si no está se borra.

https://youtu.be/SdiGdBCBLpo

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [ X ] He revisado mi código antes de enviarlo.
- [ X ] He probado que funciona correctamente en mi PC.
- [ X ] He probado que funciona correctamente con una base de datos vacía.
- [ X ] He ejecutado los tests unitarios.
- [ X ] He añadido 2 test unitarios para probar un producto sin movimientos y otro con movimientos.