### PR TITLE
Añadir soporte dump a twig

### DIFF
--- a/Core/Html.php
+++ b/Core/Html.php
@@ -31,6 +31,7 @@ use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
 use Twig\TwigFunction;
 
@@ -355,6 +356,10 @@ final class Html
             $options['auto_reload'] = true;
         }
         self::$twig = new Environment(self::$loader, $options);
+
+        if (FS_DEBUG) {
+            self::$twig->addExtension(new DebugExtension());
+        }
 
         // cargamos las funciones de twig
         self::$twig->addFunction(self::assetFunction());


### PR DESCRIPTION
La función de dump() en twig no funciona por que falta cargar la clase correspondiente.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.