### PR TITLE
#2475: evitar guardar patrones que generen códigos de más de 20 caracteres

### DIFF
--- a/Core/Model/SecuenciaDocumento.php
+++ b/Core/Model/SecuenciaDocumento.php
@@ -22,6 +22,8 @@ namespace FacturaScripts\Core\Model;
 use FacturaScripts\Core\Model\Base\ModelClass;
 use FacturaScripts\Core\Model\Base\ModelTrait;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Lib\CodePatterns;
 
 /**
  * Personalize the numeration and code of sale and purchase documents.
@@ -144,6 +146,15 @@ class SecuenciaDocumento extends ModelClass
         // si el patrón no tiene serie, mostramos un aviso
         if (false === strpos($this->patron, '{SERIE}')) {
             Tools::log()->warning('pattern-without-serie');
+        }
+
+        $factura = new FacturaCliente();
+        $factura->codejercicio = $this->codejercicio;
+        $factura->numero = $this->numero;
+        $longitudPatron = strlen(CodePatterns::trans($this->patron, $factura, ['long' => $this->longnumero]));
+        if(20 < $longitudPatron) {
+            Tools::log()->warning('pattern-too-long');
+            return false;
         }
 
         return true;

--- a/Test/Core/Model/SecuenciaDocumentoTest.php
+++ b/Test/Core/Model/SecuenciaDocumentoTest.php
@@ -79,6 +79,32 @@ final class SecuenciaDocumentoTest extends TestCase
         $this->assertTrue($company->delete(), 'document-sequence-cant-delete');
     }
 
+
+    public function testCantCreateLongPattern(): void
+    {
+        // creamos una empresa
+        $company = $this->getRandomCompany();
+        $this->assertTrue($company->save(), 'company-cant-save');
+
+        // creamos una serie
+        $serie = $this->getRandomSerie();
+        $this->assertTrue($serie->save(), 'serie-cant-save');
+
+        // creamos una secuencia
+        $sequence = new SecuenciaDocumento();
+        $sequence->codserie = $serie->codserie;
+        $sequence->idempresa = $company->idempresa;
+        $sequence->codejercicio = 2023;
+        $sequence->longnumero = 12;
+        $sequence->numero = 1;
+        $sequence->patron = 'FACTURA_{EJE}_{SERIE}_{0NUM}';
+        $sequence->tipodoc = 'FacturaCliente';
+        $sequence->usarhuecos = false;
+        $this->assertFalse($sequence->save(), 'document-sequence-can-save-long-patterns');
+        $this->assertTrue($serie->delete(), 'document-sequence-cant-delete');
+        $this->assertTrue($company->delete(), 'document-sequence-cant-delete');
+    }
+
     public function testCantCreateEmptyOrInvalid(): void
     {
         // creamos una empresa


### PR DESCRIPTION
# Descripción
- Comprueba al guardar la secuencia que un documento con ese patrón, longitud de número, ejercicio y fecha no generen un código de más de 20 caracteres.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [ X ] He revisado mi código antes de enviarlo.
- [ X ] He probado que funciona correctamente en mi PC.
- [ X ] He probado que funciona correctamente con una base de datos vacía.
- [ X ] He ejecutado los tests unitarios.