### PR TITLE
Necesitamos saber cuando estamos renderizando un bloque para el footer del email

### DIFF
--- a/Core/Lib/Email/BaseBlock.php
+++ b/Core/Lib/Email/BaseBlock.php
@@ -30,13 +30,16 @@ abstract class BaseBlock
     /** @var string */
     protected $css;
 
+    /** @var bool */
+    protected $footer = false;
+
     /** @var string */
     protected $style;
 
     /** @var string */
     protected $verificode;
 
-    abstract public function render(): string;
+    abstract public function render(bool $footer = false): string;
 
     public function setVerificode(string $code): void
     {

--- a/Core/Lib/Email/BoxBlock.php
+++ b/Core/Lib/Email/BoxBlock.php
@@ -52,7 +52,7 @@ class BoxBlock extends BaseBlock
         $html = '';
         foreach ($this->blocks as $block) {
             if ($block instanceof BaseBlock) {
-                $html .= $block->render();
+                $html .= $block->render($footer);
             }
         }
 

--- a/Core/Lib/Email/BoxBlock.php
+++ b/Core/Lib/Email/BoxBlock.php
@@ -41,8 +41,9 @@ class BoxBlock extends BaseBlock
         $this->blocks = $blocks;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         if ($return) {
             return $return;

--- a/Core/Lib/Email/ButtonBlock.php
+++ b/Core/Lib/Email/ButtonBlock.php
@@ -45,8 +45,9 @@ class ButtonBlock extends BaseBlock
         $this->link = $link;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ?? '<span class="' . (empty($this->css) ? 'btn w-100' : $this->css) . '">'
         . '<a href="' . $this->link() . '">' . $this->label . '</a></span>';

--- a/Core/Lib/Email/HtmlBlock.php
+++ b/Core/Lib/Email/HtmlBlock.php
@@ -39,8 +39,9 @@ class HtmlBlock extends BaseBlock
         $this->html = $html;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ?? $this->html;
     }

--- a/Core/Lib/Email/SpaceBlock.php
+++ b/Core/Lib/Email/SpaceBlock.php
@@ -33,8 +33,9 @@ class SpaceBlock extends BaseBlock
         $this->height = $height;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ??
             '<div style="width: 100%; height: ' . $this->height . 'px;"></div>';

--- a/Core/Lib/Email/TableBlock.php
+++ b/Core/Lib/Email/TableBlock.php
@@ -45,8 +45,9 @@ class TableBlock extends BaseBlock
         $this->rows = $rows;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ??
             '<table class="' . (empty($this->css) ? 'table mb-15 w-100' : $this->css) . '">'

--- a/Core/Lib/Email/TextBlock.php
+++ b/Core/Lib/Email/TextBlock.php
@@ -41,8 +41,9 @@ class TextBlock extends BaseBlock
         $this->text = $text;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ?? '<p class="' . (empty($this->css) ? 'text' : $this->css) . '">'
         . nl2br($this->text) . '</p>';

--- a/Core/Lib/Email/TitleBlock.php
+++ b/Core/Lib/Email/TitleBlock.php
@@ -45,8 +45,9 @@ class TitleBlock extends BaseBlock
         $this->type = $type;
     }
 
-    public function render(): string
+    public function render(bool $footer = false): string
     {
+        $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ?? '<' . $this->type . ' class="' . (empty($this->css) ? 'title' : $this->css) . '">'
         . $this->text . '</' . $this->type . '>';

--- a/Core/View/Email/NewTemplate.html.twig
+++ b/Core/View/Email/NewTemplate.html.twig
@@ -115,7 +115,7 @@
                         <td>&nbsp;&nbsp;&nbsp;</td>
                         <td class="footer" style="font-size:10px; color:black; padding:10px">
                             {% for block in footerBlocks %}
-                                {{ block.render() | raw }}
+                                {{ block.render(true) | raw }}
                             {% endfor %}
                         </td>
                         <td>&nbsp;&nbsp;&nbsp;</td>


### PR DESCRIPTION
Cuando renderizamos un email cada bloque tiene su estilo, pero el email tiene 2 secciones Main y Footer, por defecto es footer, pero en ocasiones queremos renderizar un bloque en el footer que tenga un estilo diferente. Con esto podemos indicar al renderizar el bloque si es para el Main (por defecto) o es para el Footer.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.