### PR TITLE
identificar vistas mediante clases css

### DIFF
--- a/Core/View/Master/EditListView.html.twig
+++ b/Core/View/Master/EditListView.html.twig
@@ -26,7 +26,7 @@
     var editListViewDeleteTitle = "{{ trans('confirm-delete') }}";
 </script>
 
-<div class="{{ currentView.settings.card ? '' : 'container-fluid' }}">
+<div class="{{ currentView.settings.card ? '' : 'container-fluid' }} View-Master-EditListView">
     {# -- Row header -- #}
     <div class="row">
         {% set row = currentView.getRow('header') %}

--- a/Core/View/Master/EditListViewInLine.html.twig
+++ b/Core/View/Master/EditListViewInLine.html.twig
@@ -26,7 +26,7 @@
     var editListViewDeleteTitle = "{{ trans('confirm-delete') }}";
 </script>
 
-<div class="{{ currentView.settings.card ? '' : 'container-fluid' }}">
+<div class="{{ currentView.settings.card ? '' : 'container-fluid' }} View-Master-EditListViewInLine">
     {# -- Row header -- #}
     <div class="row">
         {% set row = currentView.getRow('header') %}

--- a/Core/View/Master/EditView.html.twig
+++ b/Core/View/Master/EditView.html.twig
@@ -52,7 +52,7 @@
 </script>
 
 {# -- Row header -- #}
-<div class="row">
+<div class="row View-Master-EditView">
     {% set row = currentView.getRow('header') %}
     {{ row.render(currentView.getViewName(), '', fsc) | raw }}
 </div>

--- a/Core/View/Master/EditViewReadOnly.html.twig
+++ b/Core/View/Master/EditViewReadOnly.html.twig
@@ -20,7 +20,7 @@
 {% set currentView = fsc.getCurrentView() %}
 
 {# -- Row header -- #}
-<div class="row">
+<div class="row View-Master-EditViewReadOnly">
     {% set row = currentView.getRow('header') %}
     {{ row.render(currentView.getViewName(), '', fsc) | raw }}
 </div>

--- a/Core/View/Master/ListController.html.twig
+++ b/Core/View/Master/ListController.html.twig
@@ -23,7 +23,7 @@
     {{ parent() }}
     {% set pageData = fsc.getPageData() %}
     {% set firstView = fsc.views | first %}
-    <div class="container-fluid mb-3 d-print-none">
+    <div class="container-fluid mb-3 d-print-none View-Master-ListController">
         <div class="row">
             <div class="col-md-7">
                 {# -- Page data for small devices -- #}

--- a/Core/View/Master/ListView.html.twig
+++ b/Core/View/Master/ListView.html.twig
@@ -27,7 +27,7 @@
     var listViewDeleteTitle = "{{ trans('confirm-delete') }}";
 </script>
 
-<form id="{{ formName }}" method="post" onsubmit="animateSpinner('add')">
+<form id="{{ formName }}" method="post" onsubmit="animateSpinner('add')" class="View-Master-ListView-{{ currentView.getViewName() }}">
     {{ formToken() }}
     <input type="hidden" name="action"/>
     <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>

--- a/Core/View/Master/MenuBgTemplate.html.twig
+++ b/Core/View/Master/MenuBgTemplate.html.twig
@@ -20,7 +20,7 @@
 {% extends "Master/MenuTemplate.html.twig" %}
 
 {% block fullBody %}
-    <body class="bg-light">
+    <body class="bg-light View-Master-MenuBgTemplate">
     {% block navbar %}
         {{ parent() }}
     {% endblock %}

--- a/Core/View/Master/MenuBghTemplate.html.twig
+++ b/Core/View/Master/MenuBghTemplate.html.twig
@@ -20,7 +20,7 @@
 {% extends "Master/MenuTemplate.html.twig" %}
 
 {% block fullBody %}
-    <body>
+    <body class="View-Master-MenuBghTemplate">
     {% block navbar %}
         {{ parent() }}
     {% endblock %}

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -79,7 +79,7 @@
     {% endfor %}
 </head>
 {% block fullBody %}
-    <body>
+    <body class="View-Master-MenuTemplate">
     {% for item in getIncludeViews('MenuTemplate', 'BodyFirst') %}
         {% include item['path'] %}
     {% endfor %}

--- a/Core/View/Master/MicroTemplate.html.twig
+++ b/Core/View/Master/MicroTemplate.html.twig
@@ -55,7 +55,7 @@
         {% endif %}
     </head>
     {% block fullBody %}
-        <body>
+        <body class="View-Master-MicroTemplate">
             {% block messages %}
                 {% include 'Macro/Toasts.html.twig' %}
                 {% from 'Macro/Utils.html.twig' import message as showMessage %}

--- a/Core/View/Master/PanelController.html.twig
+++ b/Core/View/Master/PanelController.html.twig
@@ -23,7 +23,7 @@
     {{ parent() }}
     {% set pageData = fsc.getPageData() %}
     {% set firstView = fsc.views | first %}
-    <div class="container-fluid d-print-none">
+    <div class="container-fluid d-print-none View-Master-PanelController">
         <div class="form-row">
             <div class="col-md-12">
                 {# -- Hidden alternative page info -- #}

--- a/Core/View/Master/PanelControllerBottom.html.twig
+++ b/Core/View/Master/PanelControllerBottom.html.twig
@@ -20,7 +20,7 @@
 {% extends "Master/PanelController.html.twig" %}
 
 {% block body %}
-    <div class="container-fluid">
+    <div class="container-fluid View-Master-PanelControllerBottom">
         <div class="form-row">
             <div class="col">
                 {# -- First view -- #}

--- a/Core/View/Master/PanelControllerLeftBottom.html.twig
+++ b/Core/View/Master/PanelControllerLeftBottom.html.twig
@@ -20,7 +20,7 @@
 {% extends "Master/PanelController.html.twig" %}
 
 {% block body %}
-    <div class="container-fluid">
+    <div class="container-fluid View-Master-PanelControllerLeftBottom">
         <div class="form-row">
             <div class="col">
                 {# -- First view -- #}

--- a/Core/View/Master/PanelControllerTop.html.twig
+++ b/Core/View/Master/PanelControllerTop.html.twig
@@ -23,7 +23,7 @@
     {{ parent() }}
     {% set pageData = fsc.getPageData() %}
     {% set firstView = fsc.views | first %}
-    <div class="container-fluid d-print-none">
+    <div class="container-fluid d-print-none View-Master-PanelControllerTop">
         <div class="form-row">
             <div class="col-md-12">
                 {# -- Hidden alternative page info -- #}
@@ -53,7 +53,7 @@
         </div>
         <div class="form-row">
             {# -- Top left buttons -- #}
-            <div class="col-md-8 mb-2">
+            <div class="col-md-8 mb-2 top-left-buttons">
                 <div class="btn-group">
                     <a href="{{ firstView.model.url('list') }}" class="btn btn-sm btn-secondary">
                         <i class="fas fa-list fa-fw" aria-hidden="true"></i>


### PR DESCRIPTION
# Descripción
- Añadimos la ruta de la vista a la clase del primer elemento para poder identificar del archivo twig del que proviene y además posibilita el acceso mediante javascript o css a vistas que no son fácilmente modificables(por ejemplo vistas de controladores extendidos)
- Posibilita añadir botones, inputs o dinámicas varias, desde plugins mediante el uso de javascripts accediendo a los elementos deseados y añadiendo o modificando funcionalidades(añadir botón, cambiar orden de elementos, ocultar/añadir elementos, etc).

- También viene bien para los programadores que se inician a colaborar en el proyecto saber de donde vienen los html, igualmente este método puede servir para soporte y localizar bugs.

- Por ejemplo seria muy fácil añadir un botón en la vista PanelControllerTop sin tener que modificar ningún archivo php, solo creas un plugin con un archivo javascripts.

![Captura1](https://github.com/NeoRazorX/facturascripts/assets/2836337/41a0d9ee-1e6e-4c64-a905-de157eca5196)

![Captura2](https://github.com/NeoRazorX/facturascripts/assets/2836337/82f7880c-675b-47e3-8b99-dbd1114eb225)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.