### PR TITLE
agregar modo mantenimiento

### DIFF
--- a/Core/Controller/Down.php
+++ b/Core/Controller/Down.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Base\Controller;
+use FacturaScripts\Core\Kernel;
+use FacturaScripts\Core\KernelException;
+use FacturaScripts\Core\Tools;
+
+class Down extends Controller
+{
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['showonmenu'] = false;
+        return $data;
+    }
+
+    public function privateCore(&$response, $user, $permissions)
+    {
+        parent::privateCore($response, $user, $permissions);
+
+        $this->setTemplate(false);
+
+        if (false === $this->user->admin) {
+            throw new KernelException('AccessDenied', Tools::lang()->trans('access-denied'));
+        }
+
+        Kernel::down();
+
+        $this->redirect('/');
+    }
+}

--- a/Core/Controller/Up.php
+++ b/Core/Controller/Up.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Base\Controller;
+use FacturaScripts\Core\Kernel;
+use FacturaScripts\Core\KernelException;
+use FacturaScripts\Core\Tools;
+
+class Up extends Controller
+{
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['showonmenu'] = false;
+        return $data;
+    }
+
+    public function privateCore(&$response, $user, $permissions)
+    {
+        parent::privateCore($response, $user, $permissions);
+
+        $this->setTemplate(false);
+
+        if (false === $this->user->admin) {
+            throw new KernelException('AccessDenied', Tools::lang()->trans('access-denied'));
+        }
+
+        Kernel::up();
+
+        $this->redirect('/');
+    }
+}

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -237,6 +237,8 @@ final class Kernel
             '/node_modules/*' => 'Files',
             '/Plugins/*' => 'Files',
             '/Updater' => 'Updater',
+            '/Up' => 'Up',
+            '/Down' => 'Down',
         ];
 
         foreach ($routes as $route => $controller) {
@@ -311,5 +313,27 @@ final class Kernel
         }
 
         throw new KernelException('PageNotFound', $url);
+    }
+
+    /**
+     * Desactiva el modo mantenimiento de la aplicación.
+     */
+    public static function up()
+    {
+        $filePath = Tools::folder('MyFiles', 'down');
+        if (true === file_exists($filePath)) {
+            unlink($filePath);
+        }
+    }
+
+    /**
+     * Activa el modo mantenimiento de la aplicación.
+     */
+    public static function down()
+    {
+        $filePath = Tools::folder('MyFiles', 'down');
+        if (false === file_exists($filePath)) {
+            touch($filePath);
+        }
     }
 }

--- a/index.php
+++ b/index.php
@@ -34,6 +34,11 @@ if (file_exists(__DIR__ . '/config.php')) {
     require_once __DIR__ . '/config.php';
 }
 
+$url = parse_url($_SERVER["REQUEST_URI"] ?? '', PHP_URL_PATH);
+if(true === file_exists(Tools::folder('MyFiles', 'down')) && $url !== '/Up'){
+    die('APLICACIÓN EN MANTENIMIENTO');
+}
+
 // desactivamos el tiempo de ejecución y el aborto de la conexión
 @set_time_limit(0);
 ignore_user_abort(true);


### PR DESCRIPTION
# Descripción
- Se añade el modo mantenimiento que impide que se use la aplicación durante tareas de mantenimiento.
- Esto puede ser util para tareas de backup, migraciones, etc.
- Se añaden el el Kernel dos metodos para que puedan ser usados por los Plugins y así poder activar o desactivar el modo mantenimiento.
- Igualmente se añaden dos rutas privadas y solo accesibles a los administradores para que puedan gestionar el modo mantenimiento.
- Quedaria pendiente si este idea gusta y se añade al codigo, la posibilidad de salir del modo mantenimiento añadiendo un secret por si la aplicacion está caida completamente( if(filter_input(INPUT_GET, 'secret') === FS_SECRET_MAINTENANCE)).
- No obstante de quedarse la aplicación en modo mantenimiento y no poder desactivarlo, solo con borrar el archivo MyFiles/down se desactivaria este modo.
- Quedaria pendiente tambien el renderizar una pagina bonita de APLICACIÓN EN MANTENIMIENTO.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
