### PR TITLE
reconstruir rutas si el archivo routes.json no existe

### DIFF
--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -263,7 +263,8 @@ final class Kernel
         // añadimos las rutas del archivo MyFiles/routes.json file
         $routesFile = Tools::folder('MyFiles', 'routes.json');
         if (false === file_exists($routesFile)) {
-            return;
+            self::rebuildRoutes();
+            self::saveRoutes();
         }
 
         $routes = json_decode(file_get_contents($routesFile), true);


### PR DESCRIPTION
# Descripción
- reconstruir rutas si el archivo routes.json no existe
- Esta modificación evita el error 404 cuando se actualiza a la versión que implementa las rutas en el archivo routes.json

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
