### PR TITLE
Añadir filtro de trimestre actual y anterior

### DIFF
--- a/Core/Lib/ListFilter/PeriodTools.php
+++ b/Core/Lib/ListFilter/PeriodTools.php
@@ -106,6 +106,18 @@ class PeriodTools
                 static::applyFormatToPeriod($startDate, $endDate, 'first day of October', 'last day of December');
                 break;
 
+            case 'previous-quarter':
+                $trimestre = ceil(date('n', strtotime("-3 month")) / 3);
+                $startDate = "01-" . str_pad((($trimestre - 1) * 3) + 1, 2, "0", STR_PAD_LEFT) . "-" . date('Y', strtotime("-3 month"));
+                $endDate = date("t-m-Y", strtotime("01" . "-" . str_pad((($trimestre - 1) * 3) + 3, 2, "0", STR_PAD_LEFT) . "-" . date('Y', strtotime("-3 month"))));
+                break;
+
+            case 'current-quarter':
+                $trimestre = ceil(date('n') / 3);
+                $startDate = "01-" . str_pad((($trimestre - 1) * 3) + 1, 2, "0", STR_PAD_LEFT) . "-" . date('Y');
+                $endDate = date("t-m-Y", strtotime("01" . "-" . str_pad((($trimestre - 1) * 3) + 3, 2, "0", STR_PAD_LEFT) . "-" . date('Y')));
+                break;
+
             case 'this-year':
                 static::applyFormatToPeriod($startDate, $endDate, 'first day of january', 'last day of December');
                 break;
@@ -162,6 +174,8 @@ class PeriodTools
             'second-quarter',
             'third-quarter',
             'fourth-quarter',
+            'previous-quarter',
+            'current-quarter',
             '',
             'this-year',
             'this-last-year',


### PR DESCRIPTION
# Descripción
- Añade dos opciones al selector de períodos: "Trimestre anterior" y "Trimestre actual"

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [ X ] He revisado mi código antes de enviarlo.
- [ X ] He probado que funciona correctamente en mi PC.
- [ X ] He probado que funciona correctamente con una base de datos vacía.
