### PR TITLE
filtrar lineas totalmente servidas

### DIFF
--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -635,6 +635,7 @@
     "from-subaccount": "Desde subcuenta",
     "full-access": "Acceso completo",
     "full-path": "Ruta completa",
+    "fully-served-lines": "Lineas totalmente servidas",
     "gap-found": "Hueco encontrado para el número %numero%, día %fecha%, %codserie% y empresa %idempresa%",
     "general": "General",
     "general-concepts": "Conceptos generales",

--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -262,7 +262,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                {% for line in doc.getLines() %}
+                {% for line in doc.getLines()|filter(line => (line.cantidad - line.servido) > 0) %}
                     <tr>
                         <td class="align-middle">{{ line.referencia }}</td>
                         <td class="align-middle">{{ line.descripcion | raw | nl2br }}</td>
@@ -282,11 +282,26 @@
                                    class="form-control text-right to_be_served" autocomplete="off"/>
                         </td>
                     </tr>
-                {% else %}
+                {% endfor %}
+                {% if (doc.getLines()|filter(line => (line.cantidad - line.servido) == 0))|length > 0 %}
+                <tr>
+                    <td colspan="5" class="text-center table-secondary">{{ trans('fully-served-lines') }}:</td>
+                </tr>
+                {% endif %}
+                {% for line in doc.getLines()|filter(line => (line.cantidad - line.servido) == 0) %}
+                    <tr>
+                        <td class="align-middle">{{ line.referencia }}</td>
+                        <td class="align-middle">{{ line.descripcion | raw | nl2br }}</td>
+                        <td class="align-middle text-right" style="padding-right: 2.1rem">{{ line.cantidad }}</td>
+                        <td class="align-middle text-right" style="padding-right: 2.1rem">{{ line.servido }}</td>
+                        <td class="align-middle text-right" style="padding-right: 2.1rem">0</td>
+                    </tr>
+                {% endfor %}
+                {% if doc.getLines()|length == 0 %}
                     <tr class="table-warning">
                         <td colspan="5">{{ trans('no-data') }}</td>
                     </tr>
-                {% endfor %}
+                {% endif %}
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
# Descripción
- En agrupar o partir, se filtran las líneas totalmente servidas para que aparezcan al final de la tabla.
- De esta forma también se evita enviar por el formulario las líneas a cero ya que cuando una lineal se encuentra servida completamente se muestra como texto y no como un input.

![image](https://github.com/NeoRazorX/facturascripts/assets/2836337/ddd752c7-99bd-401d-917a-f8cf2ee2e659)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
