### PR TITLE
cachear consultas a base de datos habituales a modelos poco modificables

### DIFF
--- a/Core/Model/Ciudad.php
+++ b/Core/Model/Ciudad.php
@@ -72,8 +72,6 @@ class Ciudad extends Base\ModelClass
 
     public function test(): bool
     {
-        Cache::delete('DataModel.' . $this->modelClassName());
-
         $this->ciudad = Tools::noHtml($this->ciudad);
 
         return parent::test();
@@ -86,7 +84,7 @@ class Ciudad extends Base\ModelClass
 
     public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
     {
-        if ($where === []) {
+        if ($where === [] && $order === [] && $offset === 0 && $limit === 50) {
             return Cache::remember(
                 'DataModel.' . $this->modelClassName(),
                 function () use ($where, $order, $offset, $limit) {
@@ -96,5 +94,16 @@ class Ciudad extends Base\ModelClass
         }
 
         return parent::all($where, $order, $offset, $limit);
+    }
+
+    public function save(): bool
+    {
+        $isSaved = parent::save();
+
+        if($isSaved){
+            Cache::delete('DataModel.' . $this->modelClassName());
+        }
+
+        return $isSaved;
     }
 }

--- a/Core/Model/Ciudad.php
+++ b/Core/Model/Ciudad.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Cache;
 use FacturaScripts\Core\Tools;
 
 /**
@@ -71,6 +72,8 @@ class Ciudad extends Base\ModelClass
 
     public function test(): bool
     {
+        Cache::delete('DataModel.' . $this->modelClassName());
+
         $this->ciudad = Tools::noHtml($this->ciudad);
 
         return parent::test();
@@ -79,5 +82,19 @@ class Ciudad extends Base\ModelClass
     public function url(string $type = 'auto', string $list = 'ListPais?activetab=List'): string
     {
         return parent::url($type, $list);
+    }
+
+    public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
+    {
+        if ($where === []) {
+            return Cache::remember(
+                'DataModel.' . $this->modelClassName(),
+                function () use ($where, $order, $offset, $limit) {
+                    return parent::all($where, $order, $offset, $limit);
+                }
+            );
+        }
+
+        return parent::all($where, $order, $offset, $limit);
     }
 }

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Cache;
 use FacturaScripts\Core\DataSrc\Empresas;
 use FacturaScripts\Core\DataSrc\Paises;
 use FacturaScripts\Core\Lib\Vies;
@@ -194,6 +195,8 @@ class Empresa extends Base\Contact
 
     public function test(): bool
     {
+        Cache::delete('DataModel.' . $this->modelClassName());
+
         $this->administrador = Tools::noHtml($this->administrador);
         $this->apartado = Tools::noHtml($this->apartado);
         $this->ciudad = Tools::noHtml($this->ciudad);
@@ -238,5 +241,19 @@ class Empresa extends Base\Contact
         }
 
         return parent::saveInsert($values) && $this->createPaymentMethods() && $this->createWarehouse();
+    }
+
+    public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
+    {
+        if ($where === []) {
+            return Cache::remember(
+                'DataModel.' . $this->modelClassName(),
+                function () use ($where, $order, $offset, $limit) {
+                    return parent::all($where, $order, $offset, $limit);
+                }
+            );
+        }
+
+        return parent::all($where, $order, $offset, $limit);
     }
 }

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -179,13 +179,14 @@ class Empresa extends Base\Contact
 
     public function save(): bool
     {
-        if (parent::save()) {
-            // limpiamos la caché
+        $isSaved = parent::save();
+
+        if($isSaved){
             Empresas::clear();
-            return true;
+            Cache::delete('DataModel.' . $this->modelClassName());
         }
 
-        return false;
+        return $isSaved;
     }
 
     public static function tableName(): string
@@ -195,8 +196,6 @@ class Empresa extends Base\Contact
 
     public function test(): bool
     {
-        Cache::delete('DataModel.' . $this->modelClassName());
-
         $this->administrador = Tools::noHtml($this->administrador);
         $this->apartado = Tools::noHtml($this->apartado);
         $this->ciudad = Tools::noHtml($this->ciudad);
@@ -245,7 +244,7 @@ class Empresa extends Base\Contact
 
     public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
     {
-        if ($where === []) {
+        if ($where === [] && $order === [] && $offset === 0 && $limit === 50) {
             return Cache::remember(
                 'DataModel.' . $this->modelClassName(),
                 function () use ($where, $order, $offset, $limit) {

--- a/Core/Model/LogMessage.php
+++ b/Core/Model/LogMessage.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Cache;
 use FacturaScripts\Core\Tools;
 
 /**

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -95,13 +95,14 @@ class Pais extends ModelClass
 
     public function save(): bool
     {
-        if (parent::save()) {
-            // limpiamos la caché
+        $isSaved = parent::save();
+
+        if($isSaved){
             Paises::clear();
-            return true;
+            Cache::delete('DataModel.' . $this->modelClassName());
         }
 
-        return false;
+        return $isSaved;
     }
 
     public static function tableName(): string
@@ -111,8 +112,6 @@ class Pais extends ModelClass
 
     public function test(): bool
     {
-        Cache::delete('DataModel.' . $this->modelClassName());
-        
         $this->codpais = Tools::noHtml($this->codpais);
         if ($this->codpais && 1 !== preg_match('/^[A-Z0-9]{1,20}$/i', $this->codpais)) {
             Tools::log()->error(
@@ -129,7 +128,7 @@ class Pais extends ModelClass
 
     public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
     {
-        if ($where === []) {
+        if ($where === [] && $order === [] && $offset === 0 && $limit === 50) {
             return Cache::remember(
                 'DataModel.' . $this->modelClassName(),
                 function () use ($where, $order, $offset, $limit) {

--- a/Core/Model/Pais.php
+++ b/Core/Model/Pais.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Cache;
 use FacturaScripts\Core\DataSrc\Paises;
 use FacturaScripts\Core\Model\Base\ModelClass;
 use FacturaScripts\Core\Model\Base\ModelTrait;
@@ -110,6 +111,8 @@ class Pais extends ModelClass
 
     public function test(): bool
     {
+        Cache::delete('DataModel.' . $this->modelClassName());
+        
         $this->codpais = Tools::noHtml($this->codpais);
         if ($this->codpais && 1 !== preg_match('/^[A-Z0-9]{1,20}$/i', $this->codpais)) {
             Tools::log()->error(
@@ -122,5 +125,19 @@ class Pais extends ModelClass
         $this->nombre = Tools::noHtml($this->nombre);
 
         return parent::test();
+    }
+
+    public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
+    {
+        if ($where === []) {
+            return Cache::remember(
+                'DataModel.' . $this->modelClassName(),
+                function () use ($where, $order, $offset, $limit) {
+                    return parent::all($where, $order, $offset, $limit);
+                }
+            );
+        }
+
+        return parent::all($where, $order, $offset, $limit);
     }
 }

--- a/Core/Model/Provincia.php
+++ b/Core/Model/Provincia.php
@@ -20,6 +20,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Cache;
 use FacturaScripts\Core\Model\Base\ModelClass;
 use FacturaScripts\Core\Model\Base\ModelTrait;
 use FacturaScripts\Core\Tools;
@@ -97,6 +98,8 @@ class Provincia extends ModelClass
 
     public function test(): bool
     {
+        Cache::delete('DataModel.' . $this->modelClassName());
+
         $this->provincia = Tools::noHtml($this->provincia);
         return parent::test();
     }
@@ -114,5 +117,19 @@ class Provincia extends ModelClass
         }
 
         return parent::saveInsert($values);
+    }
+
+    public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
+    {
+        if ($where === []) {
+            return Cache::remember(
+                'DataModel.' . $this->modelClassName(),
+                function () use ($where, $order, $offset, $limit) {
+                    return parent::all($where, $order, $offset, $limit);
+                }
+            );
+        }
+
+        return parent::all($where, $order, $offset, $limit);
     }
 }

--- a/Core/Model/Provincia.php
+++ b/Core/Model/Provincia.php
@@ -98,8 +98,6 @@ class Provincia extends ModelClass
 
     public function test(): bool
     {
-        Cache::delete('DataModel.' . $this->modelClassName());
-
         $this->provincia = Tools::noHtml($this->provincia);
         return parent::test();
     }
@@ -121,7 +119,7 @@ class Provincia extends ModelClass
 
     public function all(array $where = [], array $order = [], int $offset = 0, int $limit = 50): array
     {
-        if ($where === []) {
+        if ($where === [] && $order === [] && $offset === 0 && $limit === 50) {
             return Cache::remember(
                 'DataModel.' . $this->modelClassName(),
                 function () use ($where, $order, $offset, $limit) {
@@ -131,5 +129,16 @@ class Provincia extends ModelClass
         }
 
         return parent::all($where, $order, $offset, $limit);
+    }
+
+    public function save(): bool
+    {
+        $isSaved = parent::save();
+
+        if($isSaved){
+            Cache::delete('DataModel.' . $this->modelClassName());
+        }
+
+        return $isSaved;
     }
 }


### PR DESCRIPTION
# Descripción
- Durante el uso diario se realizan consultas a base de datos en cada vista y en ocasiones son consultas a modelos que habitualmente no se modifican. Añadiendo a la Cache estas consultas se evita cargar la base de datos de este tipo de consultas que en algunos casos demoran el tiempo de respuesta notablemente.
- Solo se aplica cuando la consulta es al método all(), sin ningún parámetro modificado como, where, order, limit,.....
- Se tendría que revisar cuales son los modelos que seria bueno cachear no sé si Pages, .....

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
