### PR TITLE
Correcciones clase Translator, idioma a null

### DIFF
--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -201,7 +201,7 @@ class Tools
         return empty($date) ? date(self::HOUR_STYLE) : date(self::HOUR_STYLE, strtotime($date));
     }
 
-    public static function lang(string $lang = ''): Translator
+    public static function lang(?string $lang = ''): Translator
     {
         return new Translator($lang);
     }

--- a/Core/Translator.php
+++ b/Core/Translator.php
@@ -35,13 +35,14 @@ final class Translator
     /** @var array */
     private static $translations = [];
 
-    public function __construct(string $langCode = '')
+    public function __construct(?string $langCode = '')
     {
         $this->setLang($langCode);
     }
 
-    public function customTrans(string $langCode, ?string $txt, array $parameters = []): string
+    public function customTrans(?string $langCode, ?string $txt, array $parameters = []): string
     {
+        $langCode = empty($langCode) ? $this->getDefaultLang() : $langCode;
         $this->load($langCode);
 
         $key = $this->getTransKey($txt) . '@' . $langCode;
@@ -158,7 +159,7 @@ final class Translator
         self::$defaultLang = $langCode;
     }
 
-    public function setLang(string $langCode): void
+    public function setLang(?string $langCode): void
     {
         $this->lang = empty($langCode) ? $this->getDefaultLang() : $langCode;
 

--- a/Core/Translator.php
+++ b/Core/Translator.php
@@ -154,9 +154,9 @@ final class Translator
         self::$translations = [];
     }
 
-    public static function setDefaultLang(string $langCode): void
+    public static function setDefaultLang(?string $langCode): void
     {
-        self::$defaultLang = $langCode;
+        self::$defaultLang = empty($langCode) ? constant('FS_LANG') : $langCode;
     }
 
     public function setLang(?string $langCode): void


### PR DESCRIPTION
Los clientes, proveedores y contactos pueden tener un idioma establecido o no. Si cogemos el modelo contacto y mandamos a traducir algo con el idioma del contacto, si antes comprobar si tiene idioma o no, se le esta pasando null a la clase Translator. Ahora la clase Translator admite null, y al recibir null coge el idioma por defecto del sistema. Pero de este modo nos quitamos el estar comprobando si el contacto tiene idioma o no. Más limpio y rápido.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.