### PR TITLE
En la página del agente el idioma no estaba apareciendo

### DIFF
--- a/Core/Controller/EditAgente.php
+++ b/Core/Controller/EditAgente.php
@@ -185,6 +185,7 @@ class EditAgente extends ComercialContactController
                 }
                 $where = [new DataBaseWhere('idcontacto', $idcontacto)];
                 $view->loadData('', $where);
+                $this->loadLanguageValues($viewName);
                 break;
 
             case 'ListAlbaranCliente':
@@ -223,6 +224,22 @@ class EditAgente extends ComercialContactController
                     $view->disableColumn('contact');
                 }
                 break;
+        }
+    }
+
+    /**
+     * Load the available language values from translator.
+     */
+    protected function loadLanguageValues(string $viewName)
+    {
+        $columnLangCode = $this->views[$viewName]->columnForName('language');
+        if ($columnLangCode && $columnLangCode->widget->getType() === 'select') {
+            $langs = [];
+            foreach (Tools::lang()->getAvailableLanguages() as $key => $value) {
+                $langs[] = ['value' => $key, 'title' => $value];
+            }
+
+            $columnLangCode->widget->setValuesFromArray($langs, false, true);
         }
     }
 


### PR DESCRIPTION
El agente tiene su contacto, y en la páginda de EditAgente si vas a la pestaña Contacto aparecen los datos del contacto del agente, pero en el select de idioma no se están cargando los idiomas, este pr corrige ese problema.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.