### PR TITLE
excluir logs de debug en los tests

### DIFF
--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -107,7 +107,7 @@ final class MiniLog
      */
     public function debug(string $message, array $context = [])
     {
-        if (FS_DEBUG) {
+        if (FS_DEBUG && FS_ENV != 'testing') {
             $this->log('debug', $message, $context);
         }
     }

--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -107,7 +107,7 @@ final class MiniLog
      */
     public function debug(string $message, array $context = [])
     {
-        if (FS_DEBUG && FS_ENV != 'testing') {
+        if (FS_DEBUG && defined('FS_ENV') && FS_ENV != 'testing') {
             $this->log('debug', $message, $context);
         }
     }

--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -107,7 +107,11 @@ final class MiniLog
      */
     public function debug(string $message, array $context = [])
     {
-        if (FS_DEBUG && defined('FS_ENV') && FS_ENV != 'testing') {
+        if (defined('FS_ENV') && FS_ENV == 'testing'){
+            return;
+        }
+
+        if (FS_DEBUG) {    
             $this->log('debug', $message, $context);
         }
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -55,4 +55,7 @@
             </directory>
         </testsuite>
     </testsuites>
+    <php>
+        <const name="FS_ENV" value="testing"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
# Descripción
- Creamos una constante para determinar en el entorno donde se ejecuta el script y si este entorno es "testing" se excluyen los logs del tipo DEBUG cuando lanzamos los tests.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
