### PR TITLE
evitar solapar trabajos del cron

### DIFF
--- a/Core/Model/CronJob.php
+++ b/Core/Model/CronJob.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of FacturaScripts
  * Copyright (C) 2018-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
@@ -171,7 +171,7 @@ class CronJob extends ModelClass
                 new DataBaseWhere('jobname', $name),
             ];
             if (false === $job->loadFromCode('', $where)) {
-                break;
+                continue;
             }
 
             if(false === $job->done){


### PR DESCRIPTION
# Descripción
- Se añade el método `withoutOverlapping` para que se añadan los nombres de los trabajos que no se pueden solapar con el trabajo en cuestión.

```php
$this->job('mi-trabajo-DOS')
  ->every('1 hour')
  ->withoutOverlapping(['mi-trabajo-UNO', 'mi-trabajo-TRES'])
  ->run(function () {
      sleep(5);
  });
```
En este ejemplo aunque el trabajo DOS le toque ejecutarse no lo hará hasta que el trabajo UNO y el trabajo TRES hayan terminado.


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
