### PR TITLE
Tarea #1380 - conservar nombre archivo como slug

### DIFF
--- a/Core/Lib/Widget/WidgetFile.php
+++ b/Core/Lib/Widget/WidgetFile.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Lib\Widget;
 
 use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Tools;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -97,7 +98,11 @@ class WidgetFile extends BaseWidget
 
             // check if the file already exists
             $destiny = FS_FOLDER . '/MyFiles/';
-            $destinyName = $uploadFile->getClientOriginalName();
+
+            $filename = Tools::slug(pathinfo($uploadFile->getClientOriginalName(), PATHINFO_FILENAME), '_');
+            $extension = pathinfo($uploadFile->getClientOriginalName(), PATHINFO_EXTENSION);
+            $destinyName = $filename . '.' . $extension;
+
             if (file_exists($destiny . $destinyName)) {
                 $destinyName = mt_rand(1, 999999) . '_' . $destinyName;
             }

--- a/Core/Lib/Widget/WidgetLibrary.php
+++ b/Core/Lib/Widget/WidgetLibrary.php
@@ -217,7 +217,11 @@ class WidgetLibrary extends BaseWidget
 
         // check if the file already exists
         $destiny = FS_FOLDER . '/MyFiles/';
-        $destinyName = $uploadFile->getClientOriginalName();
+
+        $filename = Tools::slug(pathinfo($uploadFile->getClientOriginalName(), PATHINFO_FILENAME), '_');
+        $extension = pathinfo($uploadFile->getClientOriginalName(), PATHINFO_EXTENSION);
+        $destinyName = $filename . '.' . $extension;
+
         if (file_exists($destiny . $destinyName)) {
             $destinyName = mt_rand(1, 999999) . '_' . $destinyName;
         }

--- a/Core/Model/AttachedFile.php
+++ b/Core/Model/AttachedFile.php
@@ -296,11 +296,11 @@ class AttachedFile extends ModelOnChangeClass
         }
 
         if (empty($this->path) ||
-            false === rename($currentPath, $newFolderPath . '/' . $this->idfile . '.' . $this->getExtension())) {
+            false === rename($currentPath, $newFolderPath . '/' . $this->filename)) {
             return false;
         }
 
-        $this->path = $newFolder . '/' . $this->idfile . '.' . $this->getExtension();
+        $this->path = $newFolder . '/' . $this->filename;
         $this->size = filesize($this->getFullPath());
         $info = new finfo();
         $this->mimetype = $info->file($this->getFullPath(), FILEINFO_MIME_TYPE);


### PR DESCRIPTION
# Descripción
Al añadir un archivo a la biblioteca, conservar parcialmente el nombre original.

Ejemplo
Si el archivo original se llama:

mi archivo súper "importante".PDF
Se debe almacenar con el nombre:

1234_mi_archivo_super__importante.pdf


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
