### PR TITLE
actualizar y configurar phpstan

### DIFF
--- a/.ci/code-analysers-autoload.php
+++ b/.ci/code-analysers-autoload.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/code-analysers-config.php';

--- a/.ci/code-analysers-config.php
+++ b/.ci/code-analysers-config.php
@@ -1,0 +1,34 @@
+<?php
+
+
+define('FS_COOKIES_EXPIRE', 604800);
+
+define('FS_LANG', 'es_ES');
+define('FS_TIMEZONE', 'Europe/Madrid');
+define('FS_FOLDER', '');
+define('FS_ROUTE', '');
+
+define('FS_DB_TYPE', 'mysql');
+define('FS_DB_HOST', 'localhost');
+define('FS_DB_PORT', '3306');
+define('FS_DB_NAME', 'facturascripts');
+define('FS_DB_USER', 'root');
+define('FS_DB_PASS', 'toor');
+define('FS_DB_FOREIGN_KEYS', true);
+define('FS_DB_TYPE_CHECK', true);
+define('FS_MYSQL_CHARSET', 'utf8');
+define('FS_MYSQL_COLLATE', 'utf8_bin');
+
+define('FS_HIDDEN_PLUGINS', '');
+define('FS_DEBUG', false);
+define('FS_DISABLE_ADD_PLUGINS', false);
+define('FS_DISABLE_RM_PLUGINS', false);
+
+define('FS_NF0', 2);
+define('FS_NF1', ',');
+define('FS_NF2', ' ');
+
+define('FS_CURRENCY_POS', 'right');
+
+define('FS_ITEM_LIMIT', 50);
+

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ https://facturascripts.com/traducciones
 ## Tests
 ```
 vendor/bin/phpunit
-vendor/bin/phpstan analyse Core
+vendor/bin/phpstan analyse
 ```
 
 ## Links

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "require-dev": {
     "phpunit/phpunit": "8.*",
     "squizlabs/php_codesniffer": "3.*",
-    "phpstan/phpstan": "^0.12.93"
+    "phpstan/phpstan": "1.*"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+  bootstrapFiles:
+    - .ci/code-analysers-autoload.php
+  phpVersion: 70300
+  level: 0
+  paths:
+    - Core
+  ignoreErrors:
+    - '#Unsafe usage of new static#'


### PR DESCRIPTION
# Descripción
- Se actualiza la versión de phpstan a la versión 1
- Se añade el archivo de configuración phpstan.neon indicando:
  - ruta de archivo autoload
  - versión de php
  - nivel de analisis
  - directorios a analizar
  - errores a ignorar
- Se incluye en el archivo autoload el requerimiento del archivo de config para que las constantes no den error en el analisis, más adelante veremos si tambien seria bueno incluir el archivo vendor/autoload.php de composer para que no den error otras herramientas.

Inicialmente he puesto el nivel de analisis a 0 que es el mas bajo, y según se vayan corrigiendo errores vamos subiendo de nivel.
Actualmente solo que hay corregir estos errores que solo poniendo `private $logLevels = ['critical', 'error', 'info', 'notice', 'warning'];` en las dos clases ya se corregirían ya que ahora mismo no encontraría esa propiedad por herencia.
```bash
 ------ ------------------------------------------------------------------------------------------------------------
  Line   Lib\ExtendedController\DocFilesTrait.php (in context of class FacturaScripts\Core\Controller\EditContacto)
 ------ ------------------------------------------------------------------------------------------------------------
  208    Access to an undefined property FacturaScripts\Core\Controller\EditContacto::$logLevels.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ ------------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------
  Line   Lib\ExtendedController\DocFilesTrait.php (in context of class FacturaScripts\Core\Lib\ExtendedController\ComercialContactController)
 ------ --------------------------------------------------------------------------------------------------------------------------------------
  208    Access to an undefined property FacturaScripts\Core\Lib\ExtendedController\ComercialContactController::$logLevels.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ --------------------------------------------------------------------------------------------------------------------------------------

```


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

