### PR TITLE
Corrección para la carga de información de otros paises

### DIFF
--- a/Core/Controller/Wizard.php
+++ b/Core/Controller/Wizard.php
@@ -245,12 +245,12 @@ class Wizard extends Controller
         $defaultValues = json_decode($fileContent, true) ?? [];
         foreach ($defaultValues as $group => $values) {
             foreach ($values as $key => $value) {
-                Tools::settings($group, $key, $value);
+                Tools::settingsSet($group, $key, $value);
             }
         }
 
-        Tools::settings('default', 'codpais', $codpais);
-        Tools::settings('default', 'homepage', 'AdminPlugins');
+        Tools::settingsSet('default', 'codpais', $codpais);
+        Tools::settingsSet('default', 'homepage', 'AdminPlugins');
         Tools::settingsSave();
     }
 


### PR DESCRIPTION
# Descripción
- Se corrigio una llamada incorrecta a Tools:settings por Tool::settingsSet en las lineas 248, 252 y 253 en el archivo Wizard.php de los Controladores, esta configuración impedia que en el siguiente paso se llenaran los datos de configuración de un pais que se eligiera de forma diferente a España.

## ¿Cómo has probado los cambios?
- [x] Se descargo el ultimo zip estable de FS2024 y se eligió país República Dominicana, cargó el plan contable, pero no la moneda, ni los impuestos ni la configuración regional.
- [x] Se descargo el ultimo zip estable de FS2024 y se eligió país Guatemala, cargó el plan contable, pero no la moneda, ni los impuestos ni la configuración regional.
- [x] Se descargo el ultimo zip estable de FS2024 y se hizo la modificación del wizard en esta implementación en las lineas mencionadas y al concluir con el Wizard se vio que las configuraciones por defecto estaban correctamente cargadas al igual que la información de provincias, monedas e impuestos.
- [x] La prueba fue en MariaDB con php 7.4 y apache 2.4 server en macos
