### PR TITLE
crear factura en una sola request

### DIFF
--- a/Core/Lib/API/FacturaCliente.php
+++ b/Core/Lib/API/FacturaCliente.php
@@ -1,0 +1,104 @@
+<?php
+
+
+namespace FacturaScripts\Core\Lib\API;
+
+
+use FacturaScripts\Core\Model\Cliente;
+use FacturaScripts\Core\Tools;
+
+class FacturaCliente extends APIModel
+{
+    /**
+     * Returns an associative array with the resources, where the index is
+     * the public name of the resource.
+     *
+     * @return array
+     */
+    public function getResources(): array
+    {
+        return [
+            'facturacliente' => [
+                'API' => 'FacturaScripts\Dinamic\Lib\API\FacturaCliente',
+                'Name' => 'FacturaCliente'
+            ]
+        ];
+    }
+
+    public function doPOST(): bool
+    {
+        $model = new \FacturaScripts\Core\Model\FacturaCliente();
+        $field = 'idfactura';
+        $values = $this->request->request->all();
+
+        $param0 = empty($this->params) ? '' : $this->params[0];
+        $code = $values[$field] ?? $param0;
+        if ($model->loadFromCode($code)) {
+            $this->setError(Tools::lang()->trans('duplicate-record'), $model->toArray());
+            return false;
+        } elseif (empty($values)) {
+            $this->setError(Tools::lang()->trans('no-data-received-form'));
+            return false;
+        }
+
+        foreach ($values as $key => $value) {
+            $model->{$key} = $value;
+        }
+
+        // Asignamos Subject
+        if ($this->request->request->has('codcliente')) {
+            $cliente = new Cliente();
+            $cliente->loadFromCode($this->request->request->get('codcliente'));
+            if ($cliente) {
+                $model->setSubject($cliente);
+            }
+        }
+
+        // GUARDAMOS MODELO
+        if (false === $model->save()) {
+            $message = Tools::lang()->trans('record-save-error');
+            foreach (Tools::log()->read('', ['critical', 'error', 'info', 'notice', 'warning']) as $log) {
+                $message .= ' - ' . $log['message'];
+            }
+
+            $this->setError($message, $model->toArray());
+            return false;
+        }
+
+        // GUARDAMOS LINEAS
+        if ($this->request->request->has('lineas')) {
+            foreach ($this->request->request->get('lineas') as $linea) {
+                $datosLinea = json_decode($linea, true);
+
+                $linea = null;
+
+                if (isset($datosLinea['referencia'])) {
+                    $linea = $model->getNewProductLine($datosLinea['referencia']);
+                } else {
+                    $linea = $model->getNewLine();
+                    $linea->pvpunitario = $datosLinea['pvpunitario'];
+                    $linea->descripcion = $datosLinea['descripcion'];
+                }
+
+                if (!is_null($linea)) {
+                    $linea->idfactura = $model->primaryColumnValue();
+                    $linea->cantidad = $datosLinea['cantidad'];
+
+                    if (false === $linea->save()) {
+                        $message = Tools::lang()->trans('line-save-error');
+                        foreach (Tools::log()->read('', ['critical', 'error', 'info', 'notice', 'warning']) as $log) {
+                            $message .= ' - ' . $log['message'];
+                        }
+
+                        $this->setError($message, $model->toArray());
+                        return false;
+                    }
+                }
+            }
+        }
+
+
+        $this->setOk(Tools::lang()->trans('record-updated-correctly'), $model->toArray());
+        return true;
+    }
+}


### PR DESCRIPTION
esta es la idea para implementar la creación de una factura en un solo request

está muy verde pero es para saber si voy por el buen camino o lo enfocamos de otra forma..

con esta forma se le pasa solo el código del cliente y las lineas en json y ya lo crea todo de una sola vez

si te gusta la idea deberiamos enfocarlo de una forma que creemos un metodo que usemos tanto en el controlador normal como el la api para no duplicar codigo. por ejemplo FacturaCliente::save(string $codcliente, array $lineas)

![image](https://github.com/NeoRazorX/facturascripts/assets/2836337/101150b4-01c0-4b59-a713-1c67cd232d60)
