### PR TITLE
Mantener filtros aplicados en ListView

### DIFF
--- a/Core/Lib/ExtendedController/ListView.php
+++ b/Core/Lib/ExtendedController/ListView.php
@@ -31,6 +31,7 @@ use FacturaScripts\Dinamic\Lib\Widget\RowStatus;
 use FacturaScripts\Dinamic\Model\TotalModel;
 use FacturaScripts\Dinamic\Model\User;
 use Symfony\Component\HttpFoundation\Request;
+use FacturaScripts\Core\Session;
 
 /**
  * View definition for its use in ListController
@@ -353,7 +354,18 @@ class ListView extends BaseView
         }
 
         // filtro guardado seleccionado?
-        $this->pageFilterKey = $request->request->get('loadfilter', 0);
+        $this->pageFilterKey = Cache::get(get_class($this->model) . '_' . Session::user()->nick . '_filter');
+
+        if($request->request->get('loadfilter', -1) != -1) {
+          if($request->request->get('loadfilter', 0) == Cache::get(get_class($this->model) . '_' . Session::user()->nick . '_filter')) {
+            $this->pageFilterKey = 0;
+          }
+          else {
+            $this->pageFilterKey = $request->request->get('loadfilter', 0);
+          }
+        }
+        Cache::set(get_class($this->model) . '_' . Session::user()->nick . '_filter', $this->pageFilterKey);
+
         if ($this->pageFilterKey) {
             $filterLoad = [];
             // cargamos los valores en la request

--- a/Core/View/Master/ListView.html.twig
+++ b/Core/View/Master/ListView.html.twig
@@ -255,9 +255,9 @@
         {% set viewName = currentView.getViewName() %}
         {% if currentView.pageFilterKey %}
             {# -- Disable user filters -- #}
-            <a href="{{ fsc.url() }}?activetab={{ viewName }}" class="btn btn-light" title="{{ trans('all') }}">
+            <button type="button" class="btn btn-light" onclick="listViewSetLoadFilter('{{ viewName }}', '0');">
                 <i class="fas fa-filter fa-fw"></i> {{ trans('all') }}
-            </a>
+            </button>
         {% else %}
             <button type="button" class="btn btn-light" onclick="listViewShowFilters('{{ viewName }}');">
                 <i class="fas fa-filter fa-fw"></i> {{ trans('filters') }}


### PR DESCRIPTION
# Descripción
Si en un ListView hay un filtro guardado y este se selecciona, se guarda en la caché para el usuario actual, el filtro que marcó para que cuando vuelva a ese ListView le vuelva a aparecer activo.
Para volver al listado completo, basta con seleccionar el filtro activo o seleccionar "Todos"

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [ X ] He revisado mi código antes de enviarlo.
- [ X ] He probado que funciona correctamente en mi PC.
