### PR TITLE
obtener la siguiente version a actualizar

### DIFF
--- a/Core/Controller/Updater.php
+++ b/Core/Controller/Updater.php
@@ -217,7 +217,11 @@ class Updater extends Controller
     private function getUpdateItemsCore(): array
     {
         $fileName = 'update-' . Forja::CORE_PROJECT_ID . '.zip';
-        foreach (Forja::getBuilds(Forja::CORE_PROJECT_ID) as $build) {
+
+        $builds = Forja::getBuilds(Forja::CORE_PROJECT_ID);
+        $builds = array_reverse($builds);
+
+        foreach ($builds as $build) {
             if ($build['version'] <= $this->getCoreVersion()) {
                 continue;
             }


### PR DESCRIPTION
# Descripción
- Antes se comprobaba si la versión es mayor a la versión instalada empezando por la última versión existente, lo que devolvía siempre la última versión del Kernel.
- Con esta modificación ordenamos inversamente el array de versiones para que empieza a comparar desde la versión mas antigua y por lo tanto devuelve la siguiente versión a la que ya hay instalada.
- De esta forma se evita actualizar con saltos grandes entre versiones y obliga a actualizar versión a versión. Si estas en un versión muy antigua se tendrá que actualizar muchas veces, pero se evitaran los fallos que ya han reportado algunos usuarios.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
