### PR TITLE
add Tests ApiCreateFacturaClienteTest.php

### DIFF
--- a/Core/Template/ApiController.php
+++ b/Core/Template/ApiController.php
@@ -41,13 +41,13 @@ abstract class ApiController implements ControllerInterface
     protected $apiKey;
 
     /** @var Request */
-    protected $request;
+    public $request;
 
     /** @var Response */
-    protected $response;
+    public $response;
 
     /** @var string */
-    protected $url;
+    public $url;
 
     abstract protected function runResource(): void;
 

--- a/Test/Core/Controller/ApiCreateFacturaClienteTest.php
+++ b/Test/Core/Controller/ApiCreateFacturaClienteTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace FacturaScripts\Test\Core\Controller;
+
+use FacturaScripts\Core\Controller\ApiCreateFacturaCliente;
+use FacturaScripts\Core\KernelException;
+use FacturaScripts\Core\Model\ApiKey;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+
+class ApiCreateFacturaClienteTest extends TestCase
+{
+    use LogErrorsTrait;
+    use RandomDataTrait;
+    use DefaultSettingsTrait;
+
+    /** @var ApiKey */
+    private $apiKey;
+
+    public function testMetodoNoPermitido(): void
+    {
+        $apiCreateFacturaCliente = new ApiCreateFacturaCliente('');
+
+        $apiCreateFacturaCliente->request->headers->set('Token', $this->apiKey->apikey);
+        $apiCreateFacturaCliente->url = '/api/3/crearFacturaCliente';
+
+        try {
+            $apiCreateFacturaCliente->run();
+        } catch (KernelException $e) {
+            //
+        }
+
+        static::assertEquals('error', json_decode($apiCreateFacturaCliente->response->getContent())->status);
+        static::assertEquals('Method not allowed', json_decode($apiCreateFacturaCliente->response->getContent())->message);
+        static::assertEquals(200, $apiCreateFacturaCliente->response->getStatusCode());
+    }
+
+    public function testCodclienteRequerido(): void
+    {
+        $apiCreateFacturaCliente = new ApiCreateFacturaCliente('');
+
+        $apiCreateFacturaCliente->request->headers->set('Token', $this->apiKey->apikey);
+        $apiCreateFacturaCliente->url = '/api/3/crearFacturaCliente';
+        $apiCreateFacturaCliente->request->setMethod('POST');
+
+        try {
+            $apiCreateFacturaCliente->run();
+        } catch (KernelException $e) {
+            //
+        }
+
+        static::assertEquals('error', json_decode($apiCreateFacturaCliente->response->getContent())->status);
+        static::assertEquals('codcliente is required', json_decode($apiCreateFacturaCliente->response->getContent())->message);
+        static::assertEquals(200, $apiCreateFacturaCliente->response->getStatusCode());
+    }
+
+    public function testClienteNoEncontrado(): void
+    {
+        $apiCreateFacturaCliente = new ApiCreateFacturaCliente('');
+
+        $apiCreateFacturaCliente->request->headers->set('Token', $this->apiKey->apikey);
+        $apiCreateFacturaCliente->url = '/api/3/crearFacturaCliente';
+        $apiCreateFacturaCliente->request->setMethod('POST');
+        $apiCreateFacturaCliente->request->request->set('codcliente', 1);
+
+        try {
+            $apiCreateFacturaCliente->run();
+        } catch (KernelException $e) {
+            //
+        }
+
+        static::assertEquals('error', json_decode($apiCreateFacturaCliente->response->getContent())->status);
+        static::assertEquals('Customer not found', json_decode($apiCreateFacturaCliente->response->getContent())->message);
+        static::assertEquals(200, $apiCreateFacturaCliente->response->getStatusCode());
+    }
+
+    public function testLineasRequeridas(): void
+    {
+        $apiCreateFacturaCliente = new ApiCreateFacturaCliente('');
+
+        $apiCreateFacturaCliente->request->headers->set('Token', $this->apiKey->apikey);
+        $apiCreateFacturaCliente->url = '/api/3/crearFacturaCliente';
+        $apiCreateFacturaCliente->request->setMethod('POST');
+
+        $cliente = $this->getRandomCustomer();
+        $this->assertTrue($cliente->save());
+        $apiCreateFacturaCliente->request->request->set('codcliente', $cliente->primaryColumnValue());
+
+        try {
+            $apiCreateFacturaCliente->run();
+        } catch (KernelException $e) {
+            //
+        }
+
+        static::assertEquals('error', json_decode($apiCreateFacturaCliente->response->getContent())->status);
+        static::assertEquals('Lines are required', json_decode($apiCreateFacturaCliente->response->getContent())->message);
+        static::assertEquals(200, $apiCreateFacturaCliente->response->getStatusCode());
+
+        static::assertTrue($cliente->delete());
+    }
+
+    protected function setUp(): void
+    {
+        static::setDefaultSettings();
+
+        Tools::settingsSet('default', 'enable_api', true);
+
+        $this->apiKey = new ApiKey();
+        $this->apiKey->nick = 'admin';
+        $this->apiKey->description = 'tests';
+        $this->apiKey->enabled = true;
+        $this->apiKey->fullaccess = true;
+        static::assertTrue($this->apiKey->save());
+    }
+
+    protected function tearDown(): void
+    {
+        static::assertTrue($this->apiKey->delete());
+        $this->logErrors();
+    }
+}


### PR DESCRIPTION
# Descripción
- Si haces publicas algunas propiedades, podemos testear los controladores.
- En este caso, se realizan los tests para los errores que puedan darse en la request.
- Faltaría comprobar que la factura se guarda correctamente en la base de datos cuando ya no existe ningún error.
- Para probar los controladores correctamente, creo que lo mejor seria poner el metodo runResource como público.
- Otra forma de poder hacer los tests sin modificar las propiedades a publicas es crear clases Mock y entonces ahí se hacen métodos publicos que devuelvan esas propiedades o metodos protected.

creo que esto sale en los test porque se termina llamando al response->send(). por eso la importancia de poder llamar al metodo runResource(). para no tener que ejecutar toda la logica de la respuesta. 
![image](https://github.com/NeoRazorX/facturascripts/assets/2836337/02cf8ed0-0d78-4f01-bfc6-7bbb6c2bdaf7)



## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
