### PR TITLE
Tarea #1439 - crear clase para encriptar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ generateDoc.sh
 package-lock.json
 *.cache
 *.lock
+.env
 
 # Eclipse
 .buildpath

--- a/Core/Lib/Encrypter.php
+++ b/Core/Lib/Encrypter.php
@@ -1,0 +1,368 @@
+<?php declare(strict_types=1);
+
+namespace FacturaScripts\Core\Lib;
+
+use Exception;
+use FacturaScripts\Core\KernelException;
+use function openssl_decrypt;
+use function openssl_encrypt;
+
+class Encrypter
+{
+    public const DEFAULT_CIPHER = 'aes-128-cbc';
+
+    /**
+     * The supported cipher algorithms and their properties.
+     *
+     * @var array
+     */
+    private static $supportedCiphers = [
+        'aes-128-cbc' => ['size' => 16, 'aead' => false],
+        'aes-256-cbc' => ['size' => 32, 'aead' => false],
+        'aes-128-gcm' => ['size' => 16, 'aead' => true],
+        'aes-256-gcm' => ['size' => 32, 'aead' => true],
+    ];
+    /**
+     * The encryption key.
+     *
+     * @var string
+     */
+    protected $key;
+    /**
+     * The previous / legacy encryption keys.
+     *
+     * @var array
+     */
+    protected $previousKeys = [];
+    /**
+     * The algorithm used for encryption.
+     *
+     * @var string
+     */
+    protected $cipher;
+
+    /**
+     * Create a new encrypter instance.
+     *
+     * @param string $key
+     * @param string $cipher
+     * @return void
+     *
+     * @throws KernelException
+     */
+    public function __construct($key, $cipher = self::DEFAULT_CIPHER)
+    {
+        $key = (string)$key;
+
+        if (!static::supported($key, $cipher)) {
+            $ciphers = implode(', ', array_keys(self::$supportedCiphers));
+
+            throw new KernelException("DefaultError", "Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
+        }
+
+        $this->key = $key;
+        $this->cipher = $cipher;
+    }
+
+    /**
+     * Determine if the given key and cipher combination is valid.
+     *
+     * @param string $key
+     * @param string $cipher
+     * @return bool
+     */
+    public static function supported($key, $cipher)
+    {
+        if (!isset(self::$supportedCiphers[strtolower($cipher)])) {
+            return false;
+        }
+
+        return mb_strlen($key, '8bit') === self::$supportedCiphers[strtolower($cipher)]['size'];
+    }
+
+    /**
+     * Create a new encryption key for the given cipher.
+     *
+     * @param string $cipher
+     * @return string
+     *
+     * @throws Exception
+     */
+    public static function generateKey($cipher = self::DEFAULT_CIPHER)
+    {
+        return random_bytes(self::$supportedCiphers[strtolower($cipher)]['size'] ?? 32);
+    }
+
+    /**
+     * Encrypt a string without serialization.
+     *
+     * @param string $value
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function encryptString($value)
+    {
+        return $this->encrypt($value, false);
+    }
+
+    /**
+     * Encrypt the given value.
+     *
+     * @param mixed $value
+     * @param bool $serialize
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function encrypt($value, $serialize = true)
+    {
+        $iv = random_bytes(openssl_cipher_iv_length(strtolower($this->cipher)));
+
+        $value = openssl_encrypt(
+            $serialize ? serialize($value) : $value,
+            strtolower($this->cipher),
+            $this->key,
+            0,
+            $iv,
+            $tag
+        );
+
+        if ($value === false) {
+            throw new KernelException('DefaultError', 'Could not encrypt the data.');
+        }
+
+        $iv = base64_encode($iv);
+        $tag = base64_encode($tag ?? '');
+
+        $mac = self::$supportedCiphers[strtolower($this->cipher)]['aead']
+            ? '' // For AEAD-algorithms, the tag / MAC is returned by openssl_encrypt...
+            : $this->hash($iv, $value, $this->key);
+
+        $json = json_encode(compact('iv', 'value', 'mac', 'tag'), JSON_UNESCAPED_SLASHES);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new KernelException('DefaultError', 'Could not encrypt the data.');
+        }
+
+        return base64_encode($json);
+    }
+
+    /**
+     * Create a MAC for the given value.
+     *
+     * @param string $iv
+     * @param mixed $value
+     * @param string $key
+     * @return string
+     */
+    protected function hash($iv, $value, $key)
+    {
+        return hash_hmac('sha256', $iv . $value, $key);
+    }
+
+    /**
+     * Decrypt the given string without unserialization.
+     *
+     * @param string $payload
+     * @return string
+     *
+     * @throws KernelException
+     */
+    public function decryptString($payload)
+    {
+        return $this->decrypt($payload, false);
+    }
+
+    /**
+     * Decrypt the given value.
+     *
+     * @param string $payload
+     * @param bool $unserialize
+     * @return mixed
+     *
+     * @throws KernelException
+     */
+    public function decrypt($payload, $unserialize = true)
+    {
+        $payload = $this->getJsonPayload($payload);
+
+        $iv = base64_decode($payload['iv']);
+
+        $this->ensureTagIsValid(
+            $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
+        );
+
+        // Here we will decrypt the value. If we are able to successfully decrypt it
+        // we will then unserialize it and return it out to the caller. If we are
+        // unable to decrypt this value we will throw out an exception message.
+        foreach ($this->getAllKeys() as $key) {
+            $decrypted = openssl_decrypt(
+                $payload['value'],
+                strtolower($this->cipher),
+                $key,
+                0,
+                $iv,
+                $tag ?? ''
+            );
+
+            if ($decrypted !== false) {
+                break;
+            }
+        }
+
+        if ($decrypted === false) {
+            throw new KernelException('DefaultError', 'Could not decrypt the data.');
+        }
+
+        return $unserialize ? unserialize($decrypted) : $decrypted;
+    }
+
+    /**
+     * Get the JSON array from the given payload.
+     *
+     * @param string $payload
+     * @return array
+     *
+     * @throws KernelException
+     */
+    protected function getJsonPayload($payload)
+    {
+        if (!is_string($payload)) {
+            throw new KernelException('DefaultError', 'The payload is invalid.');
+        }
+
+        $payload = json_decode(base64_decode($payload), true);
+
+        // If the payload is not valid JSON or does not have the proper keys set we will
+        // assume it is invalid and bail out of the routine since we will not be able
+        // to decrypt the given value. We'll also check the MAC for this encryption.
+        if (!$this->validPayload($payload)) {
+            throw new KernelException('DefaultError', 'The payload is invalid.');
+        }
+
+        if (!self::$supportedCiphers[strtolower($this->cipher)]['aead'] && !$this->validMac($payload)) {
+            throw new KernelException('DefaultError', 'The MAC is invalid.');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Verify that the encryption payload is valid.
+     *
+     * @param mixed $payload
+     * @return bool
+     */
+    protected function validPayload($payload)
+    {
+        if (!is_array($payload)) {
+            return false;
+        }
+
+        foreach (['iv', 'value', 'mac'] as $item) {
+            if (!isset($payload[$item]) || !is_string($payload[$item])) {
+                return false;
+            }
+        }
+
+        if (isset($payload['tag']) && !is_string($payload['tag'])) {
+            return false;
+        }
+
+        return strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
+    }
+
+    /**
+     * Determine if the MAC for the given payload is valid.
+     *
+     * @param array $payload
+     * @return bool
+     */
+    protected function validMac(array $payload)
+    {
+        foreach ($this->getAllKeys() as $key) {
+            $valid = hash_equals(
+                $this->hash($payload['iv'], $payload['value'], $key),
+                $payload['mac']
+            );
+
+            if ($valid === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the current encryption key and all previous encryption keys.
+     *
+     * @return array
+     */
+    public function getAllKeys()
+    {
+        return array_merge([$this->key], $this->previousKeys);
+    }
+
+    /**
+     * Ensure the given tag is a valid tag given the selected cipher.
+     *
+     * @param string $tag
+     * @return void
+     *
+     * @throws KernelException
+     */
+    protected function ensureTagIsValid($tag):void
+    {
+        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
+            throw new KernelException('DefaultError', 'Could not decrypt the data.');
+        }
+
+        if (!self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
+            throw new KernelException('DefaultError', 'Unable to use tag because the cipher algorithm does not support AEAD.');
+        }
+    }
+
+    /**
+     * Get the encryption key that the encrypter is currently using.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Get the previous encryption keys.
+     *
+     * @return array
+     */
+    public function getPreviousKeys()
+    {
+        return $this->previousKeys;
+    }
+
+    /**
+     * Set the previous / legacy encryption keys that should be utilized if decryption fails.
+     *
+     * @param array $keys
+     * @return $this
+     * @throws KernelException
+     */
+    public function previousKeys(array $keys)
+    {
+        foreach ($keys as $key) {
+            if (!static::supported($key, $this->cipher)) {
+                $ciphers = implode(', ', array_keys(self::$supportedCiphers));
+
+                throw new KernelException("DefaultError", "Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
+            }
+        }
+
+        $this->previousKeys = $keys;
+
+        return $this;
+    }
+}

--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Core;
 
 use FacturaScripts\Core\Base\MiniLog;
 use FacturaScripts\Core\DataSrc\Divisas;
+use FacturaScripts\Core\Lib\Encrypter;
 use FacturaScripts\Core\Model\Settings;
 
 class Tools
@@ -378,5 +379,29 @@ class Tools
 
             return $settings;
         });
+    }
+
+    /**
+     * @param $value
+     * @return string
+     *
+     * @throws KernelException
+     */
+    public static function encriptar($value): string
+    {
+        $key = base64_decode($_ENV['APP_KEY']);
+        return (new Encrypter($key))->encryptString($value);
+    }
+
+    /**
+     * @param $value
+     * @return string
+     *
+     * @throws KernelException
+     */
+    public static function desencriptar($value): string
+    {
+        $key = base64_decode($_ENV['APP_KEY']);
+        return (new Encrypter($key))->decryptString($value);
     }
 }

--- a/Test/Core/ToolsTest.php
+++ b/Test/Core/ToolsTest.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Test\Core;
 
 use FacturaScripts\Core\App\AppSettings;
+use FacturaScripts\Core\Lib\Encrypter;
 use FacturaScripts\Core\Model\Settings;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Model\Divisa;
@@ -283,5 +284,13 @@ final class ToolsTest extends TestCase
         $this->assertEquals('1.23', Tools::number(1.234, 2));
         $this->assertEquals('1.234', Tools::number(1.234, 3));
         $this->assertEquals('1.23', Tools::number(1.234, 2));
+    }
+
+    public function testEncrypter(): void
+    {
+        $_ENV['APP_KEY'] = base64_encode(Encrypter::generateKey());
+        $texto = 'test';
+        $textoEncriptado = Tools::encriptar($texto);
+        $this->assertEquals($texto, Tools::desencriptar($textoEncriptado));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
     "ext-mysqli": "*",
     "ext-bcmath": "*",
     "ext-gd": "*",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "ext-openssl": "*",
+    "vlucas/phpdotenv": "^5.6"
   },
   "require-dev": {
     "phpunit/phpunit": "8.*",

--- a/index.php
+++ b/index.php
@@ -45,6 +45,22 @@ date_default_timezone_set($timeZone);
 // cargamos el gestor de errores
 CrashReport::init();
 
+// cargamos la variable APP_KEY para poder encriptar
+// en entornos de desarrollo usamos el archivo .env para poner la APP_KEY en variable de entorno
+// en entornos de producción se debe configurar la variable de entorno APP_KEY en el hosting
+if(FS_DEBUG){
+    $envFilePath = Tools::folder('.env');
+    if (false === is_file($envFilePath)){
+        $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
+        file_put_contents($envFilePath, 'APP_KEY=' . $key, FILE_APPEND);
+    }
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+    $dotenv->safeLoad();
+}else{
+    $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
+    throw new \FacturaScripts\Core\KernelException('DefaultError', 'Debe configurar esta variable de entorno en el hosting: APP_KEY="' . $key . '"');
+}
+
 // iniciamos el kernel
 Kernel::init();
 

--- a/index.php
+++ b/index.php
@@ -48,17 +48,17 @@ CrashReport::init();
 // cargamos la variable APP_KEY para poder encriptar
 // en entornos de desarrollo usamos el archivo .env para poner la APP_KEY en variable de entorno
 // en entornos de producción se debe configurar la variable de entorno APP_KEY en el hosting
-if(FS_DEBUG){
+if (FS_DEBUG) {
     $envFilePath = Tools::folder('.env');
-    if (false === is_file($envFilePath)){
+    if (false === is_file($envFilePath) || !isset($_ENV['APP_KEY']) || is_null($_ENV['APP_KEY']) || empty($_ENV['APP_KEY'])) {
         $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
         file_put_contents($envFilePath, 'APP_KEY=' . $key, FILE_APPEND);
     }
     $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
     $dotenv->safeLoad();
-}else{
-    $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
-    throw new \FacturaScripts\Core\KernelException('DefaultError', 'Debe configurar esta variable de entorno en el hosting: APP_KEY="' . $key . '"');
+} elseif (!isset($_ENV['APP_KEY']) || is_null($_ENV['APP_KEY']) || empty($_ENV['APP_KEY'])) {
+        $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
+        throw new \FacturaScripts\Core\KernelException('DefaultError', 'Debe configurar esta variable de entorno en el hosting: APP_KEY="' . $key . '"');
 }
 
 // iniciamos el kernel

--- a/index.php
+++ b/index.php
@@ -50,12 +50,23 @@ CrashReport::init();
 // en entornos de producción se debe configurar la variable de entorno APP_KEY en el hosting
 if (FS_DEBUG) {
     $envFilePath = Tools::folder('.env');
-    if (false === is_file($envFilePath) || !isset($_ENV['APP_KEY']) || is_null($_ENV['APP_KEY']) || empty($_ENV['APP_KEY'])) {
+
+    // si no existe el archivo, lo creamos y agregamos la variable de entorno
+    if (false === is_file($envFilePath)) {
         $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
         file_put_contents($envFilePath, 'APP_KEY=' . $key, FILE_APPEND);
     }
+
     $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
     $dotenv->safeLoad();
+
+    // si aún existiendo el archivo, no existe la variable en el archivo la agregamos y volvemos a leer
+    if (!isset($_ENV['APP_KEY']) || is_null($_ENV['APP_KEY']) || empty($_ENV['APP_KEY'])){
+        $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
+        file_put_contents($envFilePath, 'APP_KEY=' . $key, FILE_APPEND);
+        $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+        $dotenv->safeLoad();
+    }
 } elseif (!isset($_ENV['APP_KEY']) || is_null($_ENV['APP_KEY']) || empty($_ENV['APP_KEY'])) {
         $key = base64_encode(\FacturaScripts\Core\Lib\Encrypter::generateKey());
         throw new \FacturaScripts\Core\KernelException('DefaultError', 'Debe configurar esta variable de entorno en el hosting: APP_KEY="' . $key . '"');


### PR DESCRIPTION
# Descripción
- He usado una clase de laravel que funciona correctamente y la he adaptado a FacturaScripts.
- He modificado la clase Tools para añadir los metodos encriptar y desencriptar
- He añadido logica en el index para que se use la variable de entorno desde el archivo .env cuando estamos en desarrollo(FS_DEBUG=true) o para que se use la variable de entorno del hosting cuando estamos en producción(FS_DEBUG=false).
- No lo he implementado en el config.php porque carecería de seguridad en el caso que se vulnere el servidor y se tenga acceso a este archivo. Forzando a configurar la variable de entorno en el hosting no hay forma de que los atacantes sepan la variable APP_KEY y no podrán desencriptar nada.
- Ahora es necesaria la extensión "openssl" que se encarga de encriptar y desencriptar.
- Ahora es necesario el paquete "vlucas/phpdotenv" que se encarga de añadir las variables de entorno desde el archivo .env

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
