### PR TITLE
Separar listado plugins activos y no activos

### DIFF
--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -1146,6 +1146,8 @@
     "plugin-unsupported-version": "El plugin %pluginName% es para FacturaScripts 2017 o anteriores, pero estás usando FacturaScripts %version%",
     "plugin-update": "Actualización del plugin %pluginName% a la versión %version%",
     "plugins": "Plugins",
+    "plugins-disabled": "Plugins Desactivados",
+    "plugins-enabled": "Plugins Activos",
     "plugins-p": "Los plugins permiten añadir nuevas funciones. Activa los que necesites ahora, o bien hazlo cuando quieras desde el menú administrador.",
     "points": "Puntos",
     "port": "Puerto",

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -261,110 +261,136 @@
 
 {% macro showInstalledPlugins(fsc) %}
     <div class="p-2">
-        <input type="text" class="form-control" id="querySearchInstalledPlugins" placeholder="{{ trans('search') }}"/>
+        <input type="text" class="form-control border-dark" id="querySearchInstalledPlugins" placeholder="{{ trans('search') }}"/>
     </div>
+
+    <div class="p-2">
+        <div class="card border-success">
+            <div class="card-header border-success">
+                {{ trans('plugins-enabled') }}
+            </div>
+            <div class="card-body">
+                {{ _self.tablePlugins(fsc.pluginList|filter(plugin => plugin.enabled)|sort((a, b) => a.order <=> b.order), fsc.url()) }}
+            </div>
+        </div>
+    </div>
+
+    <div class="p-2">
+        <div class="card border-dark">
+            <div class="card-header border-dark">
+                {{ trans('plugins-disabled') }}
+            </div>
+            <div class="card-body">
+                {{ _self.tablePlugins(fsc.pluginList|filter(plugin => plugin.enabled == false), fsc.url()) }}
+            </div>
+        </div>
+    </div>
+
+{% endmacro %}
+
+{% macro tablePlugins(pluginList, url) %}
     <div class="table-responsive" id="installed-plugins">
         <table class="table table-striped table-hover">
-            <thead>
-            <tr>
-                <th>{{ trans('name') }}</th>
-                <th class="text-right">{{ trans('version') }}</th>
-                <th>{{ trans('description') }}</th>
-                <th class="text-right pr-3">{{ trans('actions') }}</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for plugin in fsc.pluginList %}
-                {% set trClass = 'table-danger' %}
-                {% if plugin.enabled %}
-                    {% set trClass = 'table-success' %}
-                {% elseif plugin.compatible %}
-                    {% set trClass = '' %}
-                {% endif %}
-                <tr class="{{ trClass }} item-plugin">
-                    <td class="plugin-name">{{ plugin.name }}</td>
-                    <td class="text-right">
-                        {% if plugin.version == 0 %}
-                            <span class="text-danger">v{{ plugin.version }}</span>
-                        {% elseif plugin.version < 1 %}
-                            <span class="text-warning">v{{ plugin.version }}</span>
-                        {% else %}
-                            v{{ plugin.version }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        {{ plugin.description | nl2br }}
-                        {% if plugin.forja('url', '') %}
-                            <a href="{{ plugin.forja('url', '') }}" target="_blank" class="ml-2">
-                                {{ trans('more') }} <i class="fas fa-external-link-alt"></i>
-                            </a>
-                        {% endif %}
+        <thead>
+        <tr>
+            <th>{{ trans('name') }}</th>
+            <th class="text-right">{{ trans('version') }}</th>
+            <th>{{ trans('description') }}</th>
+            <th class="text-right pr-3">{{ trans('actions') }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for plugin in pluginList %}
+            {% set trClass = 'table-danger' %}
+            {% if plugin.enabled %}
+                {% set trClass = 'table-success' %}
+            {% elseif plugin.compatible %}
+                {% set trClass = '' %}
+            {% endif %}
+            <tr class="{{ trClass }} item-plugin">
+                <td class="plugin-name">{{ plugin.name }}</td>
+                <td class="text-right">
+                    {% if plugin.version == 0 %}
+                        <span class="text-danger">v{{ plugin.version }}</span>
+                    {% elseif plugin.version < 1 %}
+                        <span class="text-warning">v{{ plugin.version }}</span>
+                    {% else %}
+                        v{{ plugin.version }}
+                    {% endif %}
+                </td>
+                <td>
+                    {{ plugin.description | nl2br }}
+                    {% if plugin.forja('url', '') %}
+                        <a href="{{ plugin.forja('url', '') }}" target="_blank" class="ml-2">
+                            {{ trans('more') }} <i class="fas fa-external-link-alt"></i>
+                        </a>
+                    {% endif %}
+                    <br/>
+                    {% for requiredPluginName in plugin.require %}
+                        <div class="badge badge-secondary">
+                            {{ trans('plugin-needed', {'%pluginName%': requiredPluginName}) }}
+                        </div>
+                    {% endfor %}
+                </td>
+                <td class="text-right text-nowrap">
+                    {% if plugin.hasUpdate() %}
+                        <a href="Updater" class="btn btn-spin-action btn-sm btn-info mr-1"
+                           title="{{ trans('updater') }}">
+                            <i class="fas fa-cloud-download-alt" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
+                    {% if plugin.enabled %}
+                        <a class="btn btn-sm btn-secondary btn-spin-action" onclick="animateSpinner('add');"
+                           href="{{ url }}?action=disable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                            <i class="fas fa-times" aria-hidden="true"></i>
+                            <span class="d-none d-sm-inline-block">{{ trans('disable') }}</span>
+                        </a>
                         <br/>
-                        {% for requiredPluginName in plugin.require %}
-                            <div class="badge badge-secondary">
-                                {{ trans('plugin-needed', {'%pluginName%': requiredPluginName}) }}
-                            </div>
-                        {% endfor %}
-                    </td>
-                    <td class="text-right text-nowrap">
+                        <small>{{ trans('plugin-order', {'%num%': plugin.order}) }}</small>
+                    {% elseif plugin.compatible %}
+                        {% if not constant('FS_DISABLE_RM_PLUGINS') %}
+                            <a class="btn btn-sm btn-danger mr-1 btn-spin-action" href="#"
+                               title="{{ trans('delete') }}" onclick="deletePlugin('{{ plugin.name }}');">
+                                <i class="fas fa-trash-alt" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
                         {% if plugin.hasUpdate() %}
-                            <a href="Updater" class="btn btn-spin-action btn-sm btn-info mr-1"
-                               title="{{ trans('updater') }}">
-                                <i class="fas fa-cloud-download-alt" aria-hidden="true"></i>
-                            </a>
-                        {% endif %}
-                        {% if plugin.enabled %}
-                            <a class="btn btn-sm btn-secondary btn-spin-action" onclick="animateSpinner('add');"
-                               href="{{ fsc.url() }}?action=disable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                <i class="fas fa-times" aria-hidden="true"></i>
-                                <span class="d-none d-sm-inline-block">{{ trans('disable') }}</span>
-                            </a>
-                            <br/>
-                            <small>{{ trans('plugin-order', {'%num%': plugin.order}) }}</small>
-                        {% elseif plugin.compatible %}
-                            {% if not constant('FS_DISABLE_RM_PLUGINS') %}
-                                <a class="btn btn-sm btn-danger mr-1 btn-spin-action" href="#"
-                                   title="{{ trans('delete') }}" onclick="deletePlugin('{{ plugin.name }}');">
-                                    <i class="fas fa-trash-alt" aria-hidden="true"></i>
-                                </a>
-                            {% endif %}
-                            {% if plugin.hasUpdate() %}
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm btn-warning dropdown-toggle"
-                                            data-toggle="dropdown" aria-expanded="false">
-                                        {{ trans('enable') }}
-                                    </button>
-                                    <div class="dropdown-menu">
-                                        <a class="dropdown-item" href="Updater">
-                                            <i class="fas fa-cloud-download-alt fa-fw mr-1"
-                                               aria-hidden="true"></i> {{ trans('update') }}
-                                        </a>
-                                        <div class="dropdown-divider"></div>
-                                        <a class="dropdown-item"
-                                           href="{{ fsc.url() }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                            <i class="fas fa-check fa-fw mr-1"
-                                               aria-hidden="true"></i> {{ trans('enable') }}
-                                        </a>
-                                    </div>
+                            <div class="btn-group">
+                                <button type="button" class="btn btn-sm btn-warning dropdown-toggle"
+                                        data-toggle="dropdown" aria-expanded="false">
+                                    {{ trans('enable') }}
+                                </button>
+                                <div class="dropdown-menu">
+                                    <a class="dropdown-item" href="Updater">
+                                        <i class="fas fa-cloud-download-alt fa-fw mr-1"
+                                           aria-hidden="true"></i> {{ trans('update') }}
+                                    </a>
+                                    <div class="dropdown-divider"></div>
+                                    <a class="dropdown-item"
+                                       href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                        <i class="fas fa-check fa-fw mr-1"
+                                           aria-hidden="true"></i> {{ trans('enable') }}
+                                    </a>
                                 </div>
-                            {% else %}
-                                <a class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');"
-                                   href="{{ fsc.url() }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                    <i class="fas fa-check" aria-hidden="true"></i>
-                                    <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
-                                </a>
-                            {% endif %}
+                            </div>
                         {% else %}
-                            {{ plugin.compatibilityDescription() }}
+                            <a class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');"
+                               href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                <i class="fas fa-check" aria-hidden="true"></i>
+                                <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
+                            </a>
                         {% endif %}
-                    </td>
-                </tr>
-            {% else %}
-                <tr class="table-warning">
-                    <td colspan="4"><b>{{ trans('no-data') }}</b></td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+                    {% else %}
+                        {{ plugin.compatibilityDescription() }}
+                    {% endif %}
+                </td>
+            </tr>
+        {% else %}
+            <tr class="table-warning">
+                <td colspan="4"><b>{{ trans('no-data') }}</b></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
     </div>
 {% endmacro %}

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -291,106 +291,106 @@
 {% macro tablePlugins(pluginList, url) %}
     <div class="table-responsive" id="installed-plugins">
         <table class="table table-striped table-hover">
-        <thead>
-        <tr>
-            <th>{{ trans('name') }}</th>
-            <th class="text-right">{{ trans('version') }}</th>
-            <th>{{ trans('description') }}</th>
-            <th class="text-right pr-3">{{ trans('actions') }}</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for plugin in pluginList %}
-            {% set trClass = 'table-danger' %}
-            {% if plugin.enabled %}
-                {% set trClass = 'table-success' %}
-            {% elseif plugin.compatible %}
-                {% set trClass = '' %}
-            {% endif %}
-            <tr class="{{ trClass }} item-plugin">
-                <td class="plugin-name">{{ plugin.name }}</td>
-                <td class="text-right">
-                    {% if plugin.version == 0 %}
-                        <span class="text-danger">v{{ plugin.version }}</span>
-                    {% elseif plugin.version < 1 %}
-                        <span class="text-warning">v{{ plugin.version }}</span>
-                    {% else %}
-                        v{{ plugin.version }}
-                    {% endif %}
-                </td>
-                <td>
-                    {{ plugin.description | nl2br }}
-                    {% if plugin.forja('url', '') %}
-                        <a href="{{ plugin.forja('url', '') }}" target="_blank" class="ml-2">
-                            {{ trans('more') }} <i class="fas fa-external-link-alt"></i>
-                        </a>
-                    {% endif %}
-                    <br/>
-                    {% for requiredPluginName in plugin.require %}
-                        <div class="badge badge-secondary">
-                            {{ trans('plugin-needed', {'%pluginName%': requiredPluginName}) }}
-                        </div>
-                    {% endfor %}
-                </td>
-                <td class="text-right text-nowrap">
-                    {% if plugin.hasUpdate() %}
-                        <a href="Updater" class="btn btn-spin-action btn-sm btn-info mr-1"
-                           title="{{ trans('updater') }}">
-                            <i class="fas fa-cloud-download-alt" aria-hidden="true"></i>
-                        </a>
-                    {% endif %}
-                    {% if plugin.enabled %}
-                        <a class="btn btn-sm btn-secondary btn-spin-action" onclick="animateSpinner('add');"
-                           href="{{ url }}?action=disable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                            <i class="fas fa-times" aria-hidden="true"></i>
-                            <span class="d-none d-sm-inline-block">{{ trans('disable') }}</span>
-                        </a>
-                        <br/>
-                        <small>{{ trans('plugin-order', {'%num%': plugin.order}) }}</small>
-                    {% elseif plugin.compatible %}
-                        {% if not constant('FS_DISABLE_RM_PLUGINS') %}
-                            <a class="btn btn-sm btn-danger mr-1 btn-spin-action" href="#"
-                               title="{{ trans('delete') }}" onclick="deletePlugin('{{ plugin.name }}');">
-                                <i class="fas fa-trash-alt" aria-hidden="true"></i>
-                            </a>
-                        {% endif %}
-                        {% if plugin.hasUpdate() %}
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm btn-warning dropdown-toggle"
-                                        data-toggle="dropdown" aria-expanded="false">
-                                    {{ trans('enable') }}
-                                </button>
-                                <div class="dropdown-menu">
-                                    <a class="dropdown-item" href="Updater">
-                                        <i class="fas fa-cloud-download-alt fa-fw mr-1"
-                                           aria-hidden="true"></i> {{ trans('update') }}
-                                    </a>
-                                    <div class="dropdown-divider"></div>
-                                    <a class="dropdown-item"
-                                       href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                        <i class="fas fa-check fa-fw mr-1"
-                                           aria-hidden="true"></i> {{ trans('enable') }}
-                                    </a>
-                                </div>
-                            </div>
+            <thead>
+            <tr>
+                <th>{{ trans('name') }}</th>
+                <th class="text-right">{{ trans('version') }}</th>
+                <th>{{ trans('description') }}</th>
+                <th class="text-right pr-3">{{ trans('actions') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for plugin in pluginList %}
+                {% set trClass = 'table-danger' %}
+                {% if plugin.enabled %}
+                    {% set trClass = 'table-success' %}
+                {% elseif plugin.compatible %}
+                    {% set trClass = '' %}
+                {% endif %}
+                <tr class="{{ trClass }} item-plugin">
+                    <td class="plugin-name">{{ plugin.name }}</td>
+                    <td class="text-right">
+                        {% if plugin.version == 0 %}
+                            <span class="text-danger">v{{ plugin.version }}</span>
+                        {% elseif plugin.version < 1 %}
+                            <span class="text-warning">v{{ plugin.version }}</span>
                         {% else %}
-                            <a class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');"
-                               href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                <i class="fas fa-check" aria-hidden="true"></i>
-                                <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
+                            v{{ plugin.version }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {{ plugin.description | nl2br }}
+                        {% if plugin.forja('url', '') %}
+                            <a href="{{ plugin.forja('url', '') }}" target="_blank" class="ml-2">
+                                {{ trans('more') }} <i class="fas fa-external-link-alt"></i>
                             </a>
                         {% endif %}
-                    {% else %}
-                        {{ plugin.compatibilityDescription() }}
-                    {% endif %}
-                </td>
-            </tr>
-        {% else %}
-            <tr class="table-warning">
-                <td colspan="4"><b>{{ trans('no-data') }}</b></td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+                        <br/>
+                        {% for requiredPluginName in plugin.require %}
+                            <div class="badge badge-secondary">
+                                {{ trans('plugin-needed', {'%pluginName%': requiredPluginName}) }}
+                            </div>
+                        {% endfor %}
+                    </td>
+                    <td class="text-right text-nowrap">
+                        {% if plugin.hasUpdate() %}
+                            <a href="Updater" class="btn btn-spin-action btn-sm btn-info mr-1"
+                               title="{{ trans('updater') }}">
+                                <i class="fas fa-cloud-download-alt" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
+                        {% if plugin.enabled %}
+                            <a class="btn btn-sm btn-secondary btn-spin-action" onclick="animateSpinner('add');"
+                               href="{{ url }}?action=disable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                <i class="fas fa-times" aria-hidden="true"></i>
+                                <span class="d-none d-sm-inline-block">{{ trans('disable') }}</span>
+                            </a>
+                            <br/>
+                            <small>{{ trans('plugin-order', {'%num%': plugin.order}) }}</small>
+                        {% elseif plugin.compatible %}
+                            {% if not constant('FS_DISABLE_RM_PLUGINS') %}
+                                <a class="btn btn-sm btn-danger mr-1 btn-spin-action" href="#"
+                                   title="{{ trans('delete') }}" onclick="deletePlugin('{{ plugin.name }}');">
+                                    <i class="fas fa-trash-alt" aria-hidden="true"></i>
+                                </a>
+                            {% endif %}
+                            {% if plugin.hasUpdate() %}
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm btn-warning dropdown-toggle"
+                                            data-toggle="dropdown" aria-expanded="false">
+                                        {{ trans('enable') }}
+                                    </button>
+                                    <div class="dropdown-menu">
+                                        <a class="dropdown-item" href="Updater">
+                                            <i class="fas fa-cloud-download-alt fa-fw mr-1"
+                                               aria-hidden="true"></i> {{ trans('update') }}
+                                        </a>
+                                        <div class="dropdown-divider"></div>
+                                        <a class="dropdown-item"
+                                           href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                            <i class="fas fa-check fa-fw mr-1"
+                                               aria-hidden="true"></i> {{ trans('enable') }}
+                                        </a>
+                                    </div>
+                                </div>
+                            {% else %}
+                                <a class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');"
+                                   href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                    <i class="fas fa-check" aria-hidden="true"></i>
+                                    <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
+                                </a>
+                            {% endif %}
+                        {% else %}
+                            {{ plugin.compatibilityDescription() }}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% else %}
+                <tr class="table-warning">
+                    <td colspan="4"><b>{{ trans('no-data') }}</b></td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
     </div>
 {% endmacro %}


### PR DESCRIPTION
# Descripción
- Se crean dos listados en la vista de Plugins Instalados, un listado para Plugins Activados y otro para Plugins Desactivados.
- En el listado de Plugins Activados se ordena por el campo "orden" ascendentemente.

![Animation](https://github.com/NeoRazorX/facturascripts/assets/2836337/0159dc76-6287-4c1b-b7d0-abc7a0210b69)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
