### PR TITLE
Tarea #324 - agregar end point API ExportFacturaCliente

### DIFF
--- a/Core/Controller/ApiExportFacturaCliente.php
+++ b/Core/Controller/ApiExportFacturaCliente.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Template\ApiController;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Dinamic\Lib\ExportManager;
+use FacturaScripts\Dinamic\Model\FacturaCliente;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiExportFacturaCliente extends ApiController
+{
+    protected function runResource(): void
+    {
+        // si el método no es GET, devolvemos un error
+        if (false === $this->request->isMethod(Request::METHOD_GET)) {
+            $this->response->setStatusCode(Response::HTTP_METHOD_NOT_ALLOWED);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Method not allowed',
+            ]));
+            return;
+        }
+
+        $code = $this->request->query->get('idfactura');
+        $requestLang = $this->request->query->get('langcode');
+
+        if (empty($code)) {
+            $this->response->setStatusCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'idfactura field is required',
+            ]));
+            return;
+        }
+
+        $facturaCliente = new FacturaCliente();
+        $facturaCliente->loadFromCode($code);
+
+        $title = Tools::lang()->trans('invoice') . ' ' . $facturaCliente->primaryDescription();
+        $format = 0; // TODO COMENTAR CON CARLOS
+
+        $subjectLang = $facturaCliente->getSubject()->langcode;
+        $lang = $requestLang ?? $subjectLang ?? '';
+
+        $exportManager = new ExportManager();
+        $exportManager->newDoc('PDF', $title, $format, $lang);
+        $exportManager->addBusinessDocPage($facturaCliente);
+
+        $facturaClientePdfFile = $exportManager->getDoc();
+
+        // devolvemos la respuesta
+        $this->response->headers->set('Content-Type', 'application/pdf');
+        $this->response->setStatusCode(Response::HTTP_OK);
+        $this->response->setContent($facturaClientePdfFile);
+    }
+}

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -263,6 +263,7 @@ final class Kernel
             '/AdminPlugins' => 'AdminPlugins',
             '/api' => 'ApiRoot',
             '/api/3/crearFacturaCliente' => 'ApiCreateFacturaCliente',
+            '/api/3/ExportFacturaCliente' => 'ApiExportFacturaCliente',
             '/api/*' => 'ApiRoot',
             '/Core/Assets/*' => 'Files',
             '/cron' => 'Cron',


### PR DESCRIPTION
# Descripción
- Necesitamos poder generar el PDF de una factura desde la API. Para ello hay que añadir el endpoint ExportFacturaCliente a la API. Este endpoint debe cargar la factura indicada, generar el PDF y devolverlo.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [X] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
