### PR TITLE
Las funciones para obtener la fecha y hora ahora permiten pasarle el formato

### DIFF
--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -80,14 +80,14 @@ class Tools
         return $default;
     }
 
-    public static function date(?string $date = null): string
+    public static function date(?string $date = null, string $format = self::DATE_STYLE): string
     {
-        return empty($date) ? date(self::DATE_STYLE) : date(self::DATE_STYLE, strtotime($date));
+        return empty($date) ? date($format) : date($format, strtotime($date));
     }
 
-    public static function dateTime(?string $date = null): string
+    public static function dateTime(?string $date = null, string $format = self::DATETIME_STYLE): string
     {
-        return empty($date) ? date(self::DATETIME_STYLE) : date(self::DATETIME_STYLE, strtotime($date));
+        return empty($date) ? date($format) : date($format, strtotime($date));
     }
 
     public static function fixHtml(?string $text = null): ?string
@@ -196,9 +196,9 @@ class Tools
         return $result;
     }
 
-    public static function hour(?string $date = null): string
+    public static function hour(?string $date = null, string $format = self::HOUR_STYLE): string
     {
-        return empty($date) ? date(self::HOUR_STYLE) : date(self::HOUR_STYLE, strtotime($date));
+        return empty($date) ? date($format) : date($format, strtotime($date));
     }
 
     public static function lang(?string $lang = ''): Translator
@@ -351,14 +351,14 @@ class Tools
         return $result;
     }
 
-    public static function timeToDate(int $time): string
+    public static function timeToDate(int $time, string $format = self::DATE_STYLE): string
     {
-        return date(self::DATE_STYLE, $time);
+        return date($format, $time);
     }
 
-    public static function timeToDateTime(int $time): string
+    public static function timeToDateTime(int $time, string $format = self::DATETIME_STYLE): string
     {
-        return date(self::DATETIME_STYLE, $time);
+        return date($format, $time);
     }
 
     private static function settingsLoad(): void


### PR DESCRIPTION
En todo el core usamos el mismo formato para pintar las fechas y horas, pero por ejemplo cuando queremos rellenar un input date o time, pide el formato inglés, por lo que obliga a usar date('Y-m-d', fecha), de este modo podemos usar Tools::date('01-04-2024', 'Y-m-d')

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.