### PR TITLE
evitar llamadas a endpoints durante los tests

### DIFF
--- a/Core/Lib/Vies.php
+++ b/Core/Lib/Vies.php
@@ -39,6 +39,9 @@ class Vies
 
     private static $lastError = '';
 
+    /** @var SoapClient */
+    private static $client;
+
     public static function check(string $cifnif, string $codiso): int
     {
         // comprobamos si la extensión soap está instalada
@@ -86,7 +89,11 @@ class Vies
         self::$lastError = '';
 
         try {
-            $client = new SoapClient(self::VIES_URL, ['exceptions' => true]);
+            if (!self::$client instanceof SoapClient){
+                self::$client = new SoapClient(self::VIES_URL, ['exceptions' => true]);
+            }
+            $client = self::$client;
+
             $json = json_encode(
                 $client->checkVat([
                     'countryCode' => $codiso,
@@ -112,5 +119,17 @@ class Vies
         // se ha producido error al comprobar el VAT number con VIES
         Tools::log()->warning('error-checking-vat-number', ['%vat-number%' => $vatNumber]);
         return -1;
+    }
+
+    /**
+     * Permite asignar la clase del cliente Soap
+     * Esto lo usamos para realizar los tests
+     * usando una clase Mock
+     *
+     * @param SoapClient $soapClient
+     */
+    public static function setClient(SoapClient $soapClient)
+    {
+        self::$client = $soapClient;
     }
 }

--- a/Test/Core/Lib/SoapClientMock.php
+++ b/Test/Core/Lib/SoapClientMock.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace FacturaScripts\Test\Core\Lib;
+
+use SoapClient;
+
+/**
+ * Esta clase la usamos para no tener que realizar
+ * peticiones a un endpoint durante los tests
+ *
+ * Simulamos que el servicio devuelve 'valid' true o false
+ */
+class SoapClientMock extends SoapClient
+{
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * @param array $requestData
+     * @return array
+     */
+    public function checkVat(array $requestData)
+    {
+        $responseData = [
+            ['results' => -1, 'number' => '', 'iso' => ''],
+            ['results' => -1, 'number' => '123', 'iso' => ''],
+            ['results' => 0, 'number' => '123456789', 'iso' => 'ES'],
+            ['results' => 0, 'number' => 'ES74003828J', 'iso' => 'ES'],
+            ['results' => 1, 'number' => 'ES74003828V', 'iso' => 'ES'],
+            ['results' => 1, 'number' => '74003828V', 'iso' => 'ES'],
+            ['results' => 1, 'number' => '43834596223', 'iso' => 'FR'],
+            ['results' => 0, 'number' => '81328757100011', 'iso' => 'FR'],
+            ['results' => 1, 'number' => '514356480', 'iso' => 'PT'],
+            ['results' => 1, 'number' => '513969144', 'iso' => 'PT'],
+            ['results' => 0, 'number' => '513967144', 'iso' => 'PT'],
+            ['results' => 0, 'number' => '12345678A', 'iso' => 'IT'],
+            ['results' => 1, 'number' => '02839750995', 'iso' => 'IT'],
+            ['results' => 0, 'number' => '12345678A', 'iso' => 'PT'],
+            ['results' => 1, 'number' => '503297887', 'iso' => 'PT'],
+            ['results' => 1, 'number' => 'B13658620', 'iso' => 'ES'],
+            ['results' => 0, 'number' => '12345678A', 'iso' => 'ES'],
+            ['results' => 1, 'number' => 'B87533303', 'iso' => 'ES'],
+            ['results' => 1, 'number' => 'B01563311', 'iso' => 'ES'],
+        ];
+
+        foreach ($responseData as $data) {
+            if ($requestData['vatNumber'] == $data['number'] && $requestData['countryCode'] == $data['iso']){
+                return [
+                    'valid' => $data['results'] === 1,
+                ];
+            }
+        }
+
+        return [
+            'valid' => false,
+        ];
+    }
+}

--- a/Test/Core/Lib/ViesTest.php
+++ b/Test/Core/Lib/ViesTest.php
@@ -24,6 +24,11 @@ use PHPUnit\Framework\TestCase;
 
 final class ViesTest extends TestCase
 {
+    protected function setUp(): void
+    {
+         Vies::setClient(new SoapClientMock());
+    }
+
     public function testCheck(): void
     {
         $data = [
@@ -48,9 +53,6 @@ final class ViesTest extends TestCase
             }
 
             $this->assertEquals($item['results'], $check);
-
-            // esperamos medio segundo para no saturar el servicio
-            usleep(500000);
         }
     }
 }

--- a/Test/Core/Model/AgenteTest.php
+++ b/Test/Core/Model/AgenteTest.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Agente;
+use FacturaScripts\Test\Core\Lib\SoapClientMock;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -88,6 +89,8 @@ final class AgenteTest extends TestCase
 
     public function testVies(): void
     {
+         Vies::setClient(new SoapClientMock());
+
         // creamos un agente sin cifnif
         $agent = new Agente();
         $agent->codagente = 'Test';

--- a/Test/Core/Model/ClienteTest.php
+++ b/Test/Core/Model/ClienteTest.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Cliente;
+use FacturaScripts\Test\Core\Lib\SoapClientMock;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -180,6 +181,8 @@ final class ClienteTest extends TestCase
 
     public function testVies(): void
     {
+         Vies::setClient(new SoapClientMock());
+
         // creamos un cliente sin cifnif
         $cliente = new Cliente();
         $cliente->nombre = 'Test';

--- a/Test/Core/Model/ContactoTest.php
+++ b/Test/Core/Model/ContactoTest.php
@@ -23,6 +23,7 @@ use FacturaScripts\Core\Base\DataBase;
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Contacto;
+use FacturaScripts\Test\Core\Lib\SoapClientMock;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
 use PHPUnit\Framework\TestCase;
@@ -197,6 +198,8 @@ final class ContactoTest extends TestCase
 
     public function testVies(): void
     {
+         Vies::setClient(new SoapClientMock());
+
         // creamos un contacto sin cif/nif
         $contact = new Contacto();
         $contact->nombre = 'Test';

--- a/Test/Core/Model/FacturaClienteTest.php
+++ b/Test/Core/Model/FacturaClienteTest.php
@@ -29,6 +29,7 @@ use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Ejercicio;
 use FacturaScripts\Core\Model\FacturaCliente;
 use FacturaScripts\Core\Model\Stock;
+use FacturaScripts\Test\Core\Lib\SoapClientMock;
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -719,10 +720,7 @@ final class FacturaClienteTest extends TestCase
 
     public function testSetIntraCommunity(): void
     {
-        // comprobamos primero si el VIES funciona
-        if (Vies::getLastError() != '') {
-            $this->markTestSkipped('Vies service is not available');
-        }
+         Vies::setClient(new SoapClientMock());
 
         // establecemos la empresa en España con un cif español
         $company = Empresas::default();

--- a/Test/Core/Model/FacturaProveedorTest.php
+++ b/Test/Core/Model/FacturaProveedorTest.php
@@ -29,6 +29,7 @@ use FacturaScripts\Core\Lib\ProductType;
 use FacturaScripts\Core\Lib\RegimenIVA;
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\FacturaProveedor;
+use FacturaScripts\Test\Core\Lib\SoapClientMock;
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -576,10 +577,7 @@ final class FacturaProveedorTest extends TestCase
 
     public function testSetIntraCommunity(): void
     {
-        // comprobamos si el VIES funciona
-        if (Vies::getLastError() != '') {
-            $this->markTestSkipped('Vies service is not available');
-        }
+         Vies::setClient(new SoapClientMock());
 
         // establecemos la empresa en España con un cif español
         $company = Empresas::default();

--- a/Test/Core/Model/ProveedorTest.php
+++ b/Test/Core/Model/ProveedorTest.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Proveedor;
+use FacturaScripts\Test\Core\Lib\SoapClientMock;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -154,6 +155,8 @@ final class ProveedorTest extends TestCase
 
     public function testVies(): void
     {
+         Vies::setClient(new SoapClientMock());
+
         // creamos un proveedor sin cif/nif
         $proveedor = new Proveedor();
         $proveedor->nombre = 'Test';


### PR DESCRIPTION
# Descripción
- Se crea una clase Mock que simula la respuesta del servicio VIES devolviendo 'valid' true o false, según corresponda.
- Con esta clase evitamos tener que consultar al servicio VIES durante los tests.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
