### PR TITLE
Tarea #1368 crear nivel adicional settings

### DIFF
--- a/Core/Base/AjaxForms/SalesHeaderHTML.php
+++ b/Core/Base/AjaxForms/SalesHeaderHTML.php
@@ -67,6 +67,12 @@ class SalesHeaderHTML
             $model->setAuthor($user);
             if (isset($formData['codcliente']) && $formData['codcliente'] && $cliente->loadFromCode($formData['codcliente'])) {
                 $model->setSubject($cliente);
+
+                $model->codalmacen = $model->getSubject()->getSettings($model->idempresa)['codalmacen'] ?? $model->getCompany()->getSettings()['codalmacen'] ?? $model->codalmacen;
+                $model->codpago = $model->getSubject()->getSettings($model->idempresa)['codpago'] ?? $model->getCompany()->getSettings()['codpago'] ?? $model->codpago;
+                $model->codserie = $model->getSubject()->getSettings($model->idempresa)['codserie'] ?? $model->getCompany()->getSettings()['codserie'] ?? $model->codserie;
+                $model->coddivisa = $model->getSubject()->getSettings($model->idempresa)['$this->coddivisa'] ?? $model->getCompany()->getSettings()['$this->coddivisa'] ?? $model->coddivisa;
+
                 if (empty($formData['action']) || $formData['action'] === 'set-customer') {
                     return;
                 }
@@ -76,6 +82,12 @@ class SalesHeaderHTML
             $cliente->loadFromCode($formData['codcliente'])) {
             // existing record and change customer
             $model->setSubject($cliente);
+
+            $model->codalmacen = $model->getSubject()->getSettings($model->idempresa)['codalmacen'] ?? $model->getCompany()->getSettings()['codalmacen'] ?? $model->codalmacen;
+            $model->codpago = $model->getSubject()->getSettings($model->idempresa)['codpago'] ?? $model->getCompany()->getSettings()['codpago'] ?? $model->codpago;
+            $model->codserie = $model->getSubject()->getSettings($model->idempresa)['codserie'] ?? $model->getCompany()->getSettings()['codserie'] ?? $model->codserie;
+            $model->coddivisa = $model->getSubject()->getSettings($model->idempresa)['$this->coddivisa'] ?? $model->getCompany()->getSettings()['$this->coddivisa'] ?? $model->coddivisa;
+
             return;
         }
 

--- a/Core/Controller/EditCliente.php
+++ b/Core/Controller/EditCliente.php
@@ -191,9 +191,9 @@ class EditCliente extends ComercialContactController
             $settingsModel->idempresa = $this->request->request->get('idempresa');
             $settingsModel->settings = json_encode([
                 'codalmacen' => empty($this->request->request->get('codalmacen')) ? null : $this->request->request->get('codalmacen'),
-                'codserie' => empty($this->request->request->get('codserie')) ? null : $this->request->request->get('codalmacen'),
-                'coddivisa' => empty($this->request->request->get('coddivisa')) ? null : $this->request->request->get('codalmacen'),
-                'codpago' => empty($this->request->request->get('codpago')) ? null : $this->request->request->get('codalmacen'),
+                'codserie' => empty($this->request->request->get('codserie')) ? null : $this->request->request->get('codserie'),
+                'coddivisa' => empty($this->request->request->get('coddivisa')) ? null : $this->request->request->get('coddivisa'),
+                'codpago' => empty($this->request->request->get('codpago')) ? null : $this->request->request->get('codpago'),
             ]);
         }
 

--- a/Core/Controller/EditEmpresa.php
+++ b/Core/Controller/EditEmpresa.php
@@ -125,9 +125,9 @@ class EditEmpresa extends EditController
             $settingsModel->idempresa = $empresa->primaryColumnValue();
             $settingsModel->settings = json_encode([
                 'codalmacen' => empty($this->request->request->get('codalmacen')) ? null : $this->request->request->get('codalmacen'),
-                'codserie' => empty($this->request->request->get('codserie')) ? null : $this->request->request->get('codalmacen'),
-                'coddivisa' => empty($this->request->request->get('coddivisa')) ? null : $this->request->request->get('codalmacen'),
-                'codpago' => empty($this->request->request->get('codpago')) ? null : $this->request->request->get('codalmacen'),
+                'codserie' => empty($this->request->request->get('codserie')) ? null : $this->request->request->get('codserie'),
+                'coddivisa' => empty($this->request->request->get('coddivisa')) ? null : $this->request->request->get('coddivisa'),
+                'codpago' => empty($this->request->request->get('codpago')) ? null : $this->request->request->get('codpago'),
             ]);
         }
 

--- a/Core/Controller/EditEmpresa.php
+++ b/Core/Controller/EditEmpresa.php
@@ -24,6 +24,8 @@ use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\EditController;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Lib\RegimenIVA;
+use FacturaScripts\Dinamic\Model\Empresa;
+use FacturaScripts\Dinamic\Model\SettingsModel;
 
 /**
  * Controller to edit a single item from the  Empresa model
@@ -69,6 +71,7 @@ class EditEmpresa extends EditController
         $this->createViewBankAccounts();
         $this->createViewPaymentMethods();
         $this->createViewExercises();
+        $this->createViewSettings();
     }
 
     protected function createViewBankAccounts(string $viewName = 'ListCuentaBanco'): void
@@ -95,8 +98,39 @@ class EditEmpresa extends EditController
             ->disableColumn('company');
     }
 
+    protected function createViewSettings(string $viewName = 'EditSettingsModel'): void
+    {
+        $this->addEditView($viewName, 'SettingsModel', 'settings', 'fas fa-wrench');
+    }
+
     protected function execPreviousAction($action): bool
     {
+        if ($this->active === 'EditSettingsModel' && in_array($action, ['edit', 'insert'])){
+
+            /** @var Empresa $empresa */
+            $empresa = $this->getModel();
+            $empresa->loadFromCode($this->request->get('code'));
+            $this->request->request->set('idempresa', $empresa->primaryColumnValue());
+
+            /** @var SettingsModel $settingsModel */
+            $settingsModel = $this->views[$this->active]->model;
+            $settingsModel->loadFromCode('', [
+                new DataBaseWhere('classnamemodel', get_class($empresa)),
+                new DataBaseWhere('idmodel', $empresa->primaryColumnValue()),
+                new DataBaseWhere('idempresa', $empresa->primaryColumnValue()),
+            ]);
+
+            $settingsModel->classnamemodel = get_class($empresa);
+            $settingsModel->idmodel = $empresa->primaryColumnValue();
+            $settingsModel->idempresa = $empresa->primaryColumnValue();
+            $settingsModel->settings = json_encode([
+                'codalmacen' => empty($this->request->request->get('codalmacen')) ? null : $this->request->request->get('codalmacen'),
+                'codserie' => empty($this->request->request->get('codserie')) ? null : $this->request->request->get('codalmacen'),
+                'coddivisa' => empty($this->request->request->get('coddivisa')) ? null : $this->request->request->get('codalmacen'),
+                'codpago' => empty($this->request->request->get('codpago')) ? null : $this->request->request->get('codalmacen'),
+            ]);
+        }
+
         switch ($action) {
             case 'check-vies':
                 return $this->checkViesAction();
@@ -124,6 +158,28 @@ class EditEmpresa extends EditController
                 $id = $this->getViewModelValue($this->getMainViewName(), 'idempresa');
                 $where = [new DataBaseWhere('idempresa', $id)];
                 $view->loadData('', $where);
+                break;
+            case 'EditSettingsModel':
+                /** @var Empresa $empresa */
+                $empresa = $this->getModel();
+                $empresa->loadFromCode($this->request->get('code'));
+
+                /** @var SettingsModel $settingsModel */
+                $settingsModel = $this->views[$viewName]->model;
+                $where = [
+                    new DataBaseWhere('classnamemodel', get_class($empresa)),
+                    new DataBaseWhere('idempresa', $empresa->idempresa),
+                ];
+                $settingsModel->loadFromCode('', $where);
+
+                if($settingsModel->exists()){
+                    // agregamos al modelo las propiedades que hay dentro de settings
+                    // para conservar la clase con todas las propiedades y que detecte si el modelo existe o no.
+                    foreach ($this->views[$viewName]->model->settings as $key => $value) {
+                        $this->views[$viewName]->model->{$key} = $value;
+                    }
+                }
+
                 break;
 
             case $mvn:

--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -315,4 +315,22 @@ class Cliente extends Base\ComercialContact
 
         return $return;
     }
+
+    /**
+     * Devuelve las settings de la empresa
+     *
+     * @param string $idCompany
+     * @return array
+     */
+    public function getSettings(string $idCompany)
+    {
+        $settingsModel = new SettingsModel();
+        $settingsModel->loadFromCode('', [
+            new DataBaseWhere('classnamemodel', static::class),
+            new DataBaseWhere('idmodel', $this->primaryColumnValue()),
+            new DataBaseWhere('idempresa', $idCompany),
+        ]);
+
+        return $settingsModel->settings ?? [];
+    }
 }

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -239,4 +239,21 @@ class Empresa extends Base\Contact
 
         return parent::saveInsert($values) && $this->createPaymentMethods() && $this->createWarehouse();
     }
+
+    /**
+     * Devuelve las settings de la empresa
+     *
+     * @return array
+     */
+    public function getSettings()
+    {
+        $settingsModel = new SettingsModel();
+        $settingsModel->loadFromCode('', [
+            new DataBaseWhere('classnamemodel', static::class),
+            new DataBaseWhere('idmodel', $this->primaryColumnValue()),
+            new DataBaseWhere('idempresa', $this->primaryColumnValue()),
+        ]);
+
+        return $settingsModel->settings ?? [];
+    }
 }

--- a/Core/Model/SettingsModel.php
+++ b/Core/Model/SettingsModel.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace FacturaScripts\Core\Model;
+
+class SettingsModel extends Base\ModelClass
+{
+    use Base\ModelTrait;
+
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $classnamemodel;
+
+    /** @var string */
+    public $idmodel;
+
+    /** @var string */
+    public $idempresa;
+
+    /** @var array */
+    public $settings;
+
+    public static function primaryColumn(): string
+    {
+        return 'id';
+    }
+
+    public static function tableName(): string
+    {
+        return 'settings_model';
+    }
+
+    public function loadFromData(array $data = [], array $exclude = []): void
+    {
+        parent::loadFromData($data, ['settings', 'action']);
+        $this->settings = isset($data['settings']) ? json_decode($data['settings'], true) : [];
+    }
+
+    protected function saveUpdate(array $values = []): bool
+    {
+        // agregamos a la propiedad settings las propiedades que hay en el modelo
+        // y que nos vienen de la request/inputs
+        foreach ($this->settings as $key => $value) {
+            $this->settings[$key] = empty($this->{$key}) ? null : $this->{$key};
+        }
+
+        if (is_array($this->settings)) {
+            $this->settings = json_encode($this->settings);
+        }
+
+        return parent::saveUpdate($values);
+    }
+}

--- a/Core/Table/settings_model.xml
+++ b/Core/Table/settings_model.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+    <column>
+        <name>id</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>classnamemodel</name>
+        <type>text</type>
+    </column>
+    <column>
+        <name>idmodel</name>
+        <type>integer</type>
+    </column>
+    <column>
+        <name>idempresa</name>
+        <type>integer</type>
+    </column>
+    <column>
+        <name>settings</name>
+        <type>text</type>
+    </column>
+    <constraint>
+        <name>settings_model_pkey</name>
+        <type>PRIMARY KEY (id)</type>
+    </constraint>
+</table>

--- a/Core/XMLView/EditSettingsModel.xml
+++ b/Core/XMLView/EditSettingsModel.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<view>
+    <columns>
+        <group name="default" valign="bottom" numcolumns="12">
+            <column name="name" display="none" order="0">
+                <widget type="text" fieldname="name" readonly="true" required="true"/>
+            </column>
+            <column name="company" order="110">
+                <widget type="select" fieldname="idempresa" required="true">
+                    <values source="empresas" fieldcode="idempresa" fieldtitle="nombrecorto"></values>
+                </widget>
+            </column>
+            <column name="warehouse" order="120">
+                <widget type="select" fieldname="codalmacen" onclick="EditAlmacen" required="true">
+                    <values source="almacenes" fieldcode="codalmacen" fieldtitle="nombre"/>
+                </widget>
+            </column>
+            <column name="serie" numcolumns="3" order="130">
+                <widget type="select" fieldname="codserie" onclick="EditSerie">
+                    <values source="series" fieldcode="codserie" fieldtitle="descripcion"/>
+                </widget>
+            </column>
+            <column name="currency" numcolumns="3" order="140">
+                <widget type="select" fieldname="coddivisa" onclick="EditDivisa" icon="fas fa-money-bill-alt">
+                    <values source="divisas" fieldcode="coddivisa" fieldtitle="descripcion"/>
+                </widget>
+            </column>
+            <column name="payment-method" numcolumns="3" order="150">
+                <widget type="select" fieldname="codpago" onclick="EditFormaPago">
+                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
+                </widget>
+            </column>
+        </group>
+    </columns>
+</view>


### PR DESCRIPTION
# Descripción
- Se crea una clase/tabla SettingsModel que almacena los settings para cada modelo(cliente o empresa).
- Se crea en SalesHeaderHTML la logica que permite asignar a un nuevo documento la configuración predeterminado con el siguiente orden: 1. cliente según empresa, 2. empresa y por ultimo aplicación.
- De esta forma es posible asignar una configuración para multiples empresas de un cliente, para permitir que si la factura para un cliente es de una empresa se asigne una forma de pago y si para el mismo cliente la factura es para otra empresa que se asigne la forma de pago de esa otra empresa.
- De no tener asignado el cliente ninguna configuración por empresa, se asignara la configuración general de la empresa.
- Y de no tener asignada configuración ni de cliente ni de empresa se asignara la de la aplicación en Panel de control.
- Se crean las vistas tanto en EditEmpresa como en EditCliente para que se puedan asignar configuraciones.
- Se agregan los métodos getSettings tanto al modelo Empresa como al modelo Cliente, teniendo este ultimo un parámetro idEmpresa para devolver los settings del cliente para la empresa en cuestión.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [X] He probado que funciona correctamente con una base de datos vacía.
- [X] He ejecutado los tests unitarios.
