### PR TITLE
evitar pasa null parametros stripos

### DIFF
--- a/Core/Base/DataBase/PostgresqlEngine.php
+++ b/Core/Base/DataBase/PostgresqlEngine.php
@@ -289,7 +289,7 @@ class PostgresqlEngine extends DataBaseEngine
     {
         foreach ($fields as $colName => $field) {
             /// serial type
-            if (stripos($field['default'], 'nextval(') !== false) {
+            if (!empty($field['default']) && stripos($field['default'], 'nextval(') !== false) {
                 $sql = "SELECT setval('" . $tableName . "_" . $colName . "_seq', (SELECT MAX(" . $colName . ") from " . $tableName . "));";
                 $this->exec($link, $sql);
             }


### PR DESCRIPTION
# Descripción
- Desde la versión 8.1 de PHP no se le puede pasar null al primer parametros de la función stripos.
- Ahora comprobamos si es null antes de invocar esta función.
- OJO que esto afecta solo cuando se usa Postgresql.

![Animation1](https://github.com/NeoRazorX/facturascripts/assets/2836337/686a811d-444d-4f2b-8186-77759674b018)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [X] He revisado mi código antes de enviarlo.
- [X] He probado que funciona correctamente en mi PC.
- [X] He probado que funciona correctamente con una base de datos vacía.
- [X] He ejecutado los tests unitarios.
