### PR TITLE
fix getallheaders

### DIFF
--- a/Core/Request.php
+++ b/Core/Request.php
@@ -97,10 +97,26 @@ final class Request
 
     public static function createFromGlobals(): self
     {
+        $headers = [];
+
+        if(!function_exists('getallheaders')){
+            foreach($_SERVER as $name => $value){
+                if(substr($name, 0, 5) == 'HTTP_'){
+                    $headers[str_replace(
+                        ' ',
+                        '-',
+                        ucwords(strtolower(str_replace('_', ' ', substr($name, 5))))
+                    )] = $value;
+                }
+            }
+        }else{
+            $headers = getallheaders();
+        }
+
         return new self([
             'cookies' => $_COOKIE,
             'files' => $_FILES,
-            'headers' => getallheaders(),
+            'headers' => $headers,
             'query' => $_GET,
             'request' => $_POST,
         ]);

--- a/Test/Core/RequestTest.php
+++ b/Test/Core/RequestTest.php
@@ -78,7 +78,7 @@ final class RequestTest extends TestCase
         $emptyRequest = new Request();
         $this->assertNull($emptyRequest->file('test'));
 
-        $data = ['files' => ['test' => ['name' => 'test.txt']]];
+        $data = ['files' => ['test' => ['name' => 'test.txt', 'size' => 100]]];
         $request = new Request($data);
         $this->assertEquals('test.txt', $request->file('test')->name);
         $this->assertNull($request->file('test2'));


### PR DESCRIPTION
me he dado cuenta a pasar los tests.


la funcion getallheaders() solo se encuentra en algunos entornos(Works in the Apache, FastCGI, CLI, and FPM webservers)

he usado una solución que proponen en php.net pero creo que es muy básica:
https://www.php.net/manual/en/function.getallheaders.php#84262

Os pongo dos soluciones que creo que con mas completas:

Symfony:
https://github.com/symfony/http-foundation/blob/344a18f75343561ce58581b0735063350a506d01/ServerBag.php#L26

paquete de ralouphie:
https://github.com/ralouphie/getallheaders/blob/120b605dfeb996808c31b6477290a714d356e822/src/getallheaders.php#L10




