### PR TITLE
Tarea #3337   asignar orden en get line

### DIFF
--- a/Core/Model/AlbaranCliente.php
+++ b/Core/Model/AlbaranCliente.php
@@ -69,7 +69,6 @@ class AlbaranCliente extends Base\SalesDocument
         $newLine->idalbaran = $this->idalbaran;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/AlbaranCliente.php
+++ b/Core/Model/AlbaranCliente.php
@@ -69,6 +69,7 @@ class AlbaranCliente extends Base\SalesDocument
         $newLine->idalbaran = $this->idalbaran;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/AlbaranProveedor.php
+++ b/Core/Model/AlbaranProveedor.php
@@ -69,7 +69,6 @@ class AlbaranProveedor extends Base\PurchaseDocument
         $newLine->idalbaran = $this->idalbaran;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/AlbaranProveedor.php
+++ b/Core/Model/AlbaranProveedor.php
@@ -69,6 +69,7 @@ class AlbaranProveedor extends Base\PurchaseDocument
         $newLine->idalbaran = $this->idalbaran;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -155,6 +155,9 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
     /** @var bool */
     public $suplido;
 
+    /** @var int|null */
+    private static $ultimo = null;
+
     /**
      * Returns the parent document of this line.
      */
@@ -409,7 +412,7 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
 
     protected function saveInsert(array $values = []): bool
     {
-        $this->orden = $this->getOrder();
+//        $this->orden = $this->getOrder();
         return $this->updateStock() && parent::saveInsert($values);
     }
 
@@ -497,12 +500,15 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
      */
     public function getOrder(): int
     {
-        $doc = $this->getDocument();
+        if (is_null(self::$ultimo)){
+            $doc = $this->getDocument();
+            $ultimo = (int)$this::table()
+                ->whereEq($doc->primaryColumn(), $doc->primaryColumnValue())
+                ->min('orden');
+        }else{
+            $ultimo = self::$ultimo;
+        }
 
-        $ultimo = (int)$this::table()
-            ->whereEq($doc->primaryColumn(), $doc->primaryColumnValue())
-            ->min('orden');
-
-        return $ultimo - 10;
+        return self::$ultimo = $ultimo - 10;
     }
 }

--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -409,6 +409,7 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
 
     protected function saveInsert(array $values = []): bool
     {
+        $this->orden = $this->getOrder();
         return $this->updateStock() && parent::saveInsert($values);
     }
 
@@ -482,5 +483,26 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
         }
 
         return false;
+    }
+
+    /**
+     * Devuelve el siguiente número de orden para una línea.
+     *
+     * Se hace en negativo porque desde siempre se ha estado
+     * asignando el orden descendentemente.
+     *
+     * Es decir el la primera línea tiene el orden 20 y la segunda el orden 10.
+     *
+     * @return int
+     */
+    public function getOrder(): int
+    {
+        $doc = $this->getDocument();
+
+        $ultimo = (int)$this::table()
+            ->whereEq($doc->primaryColumn(), $doc->primaryColumnValue())
+            ->min('orden');
+
+        return $ultimo - 10;
     }
 }

--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -412,7 +412,6 @@ abstract class BusinessDocumentLine extends ModelOnChangeClass
 
     protected function saveInsert(array $values = []): bool
     {
-//        $this->orden = $this->getOrder();
         return $this->updateStock() && parent::saveInsert($values);
     }
 

--- a/Core/Model/FacturaCliente.php
+++ b/Core/Model/FacturaCliente.php
@@ -74,7 +74,6 @@ class FacturaCliente extends Base\SalesDocument
         $newLine->idfactura = $this->idfactura;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/FacturaCliente.php
+++ b/Core/Model/FacturaCliente.php
@@ -74,6 +74,7 @@ class FacturaCliente extends Base\SalesDocument
         $newLine->idfactura = $this->idfactura;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/FacturaProveedor.php
+++ b/Core/Model/FacturaProveedor.php
@@ -73,6 +73,7 @@ class FacturaProveedor extends Base\PurchaseDocument
         $newLine->idfactura = $this->idfactura;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/FacturaProveedor.php
+++ b/Core/Model/FacturaProveedor.php
@@ -73,7 +73,6 @@ class FacturaProveedor extends Base\PurchaseDocument
         $newLine->idfactura = $this->idfactura;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PedidoCliente.php
+++ b/Core/Model/PedidoCliente.php
@@ -88,6 +88,7 @@ class PedidoCliente extends SalesDocument
         $newLine->idpedido = $this->idpedido;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PedidoCliente.php
+++ b/Core/Model/PedidoCliente.php
@@ -88,7 +88,6 @@ class PedidoCliente extends SalesDocument
         $newLine->idpedido = $this->idpedido;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PedidoProveedor.php
+++ b/Core/Model/PedidoProveedor.php
@@ -68,7 +68,6 @@ class PedidoProveedor extends Base\PurchaseDocument
         $newLine->idpedido = $this->idpedido;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PedidoProveedor.php
+++ b/Core/Model/PedidoProveedor.php
@@ -68,6 +68,7 @@ class PedidoProveedor extends Base\PurchaseDocument
         $newLine->idpedido = $this->idpedido;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PresupuestoCliente.php
+++ b/Core/Model/PresupuestoCliente.php
@@ -87,6 +87,7 @@ class PresupuestoCliente extends SalesDocument
         $newLine->idpresupuesto = $this->idpresupuesto;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PresupuestoCliente.php
+++ b/Core/Model/PresupuestoCliente.php
@@ -87,7 +87,6 @@ class PresupuestoCliente extends SalesDocument
         $newLine->idpresupuesto = $this->idpresupuesto;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PresupuestoProveedor.php
+++ b/Core/Model/PresupuestoProveedor.php
@@ -68,6 +68,7 @@ class PresupuestoProveedor extends Base\PurchaseDocument
         $newLine->idpresupuesto = $this->idpresupuesto;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
+        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/Model/PresupuestoProveedor.php
+++ b/Core/Model/PresupuestoProveedor.php
@@ -68,7 +68,6 @@ class PresupuestoProveedor extends Base\PurchaseDocument
         $newLine->idpresupuesto = $this->idpresupuesto;
         $newLine->irpf = $this->irpf;
         $newLine->actualizastock = $this->getStatus()->actualizastock;
-        $newLine->orden = $newLine->getOrder();
         $newLine->loadFromData($data, $exclude);
 
         // allow extensions

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -191,7 +191,6 @@
 
     function salesFormSave(action, selectedLine) {
         animateSpinner('add');
-        setOrdenLines();
 
         document.forms['salesForm']['action'].value = action;
         document.forms['salesForm']['selectedLine'].value = selectedLine;


### PR DESCRIPTION
# Descripción

- Las líneas de documentos de compra y venta tienen un campo orden, que usamos para ordenar las líneas. Este campo lo inicializamos a cero y luego en javascript lo rellenamos. Pero si en la función getNewLine() implementamos un contador de líneas y rellenamos el campo orden, nos ahorramos tener que usar el javascript.

- Eliminamos el javascript que asigna el orden al guardar. Se mantienen las llamadas a la funcion ordenar en javascript cuando se ordena con el jquery-ui sortable.

- Se crea un método que devuelve el ultimo orden para una nueva línea. En este caso se obtiene el valor mínimo y se resta 10 para mantener la retrocompatibilidad, ya que desde siempre se a asignado el orden de las líneas decrecientemente.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
