### PR TITLE
Tarea #3301   agregar direccion a documentos compra

### DIFF
--- a/Core/Model/Base/PurchaseDocument.php
+++ b/Core/Model/Base/PurchaseDocument.php
@@ -23,6 +23,7 @@ use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Model\Proveedor as CoreProveedor;
 use FacturaScripts\Core\Model\User;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Dinamic\Model\Pais;
 use FacturaScripts\Dinamic\Model\ProductoProveedor;
 use FacturaScripts\Dinamic\Model\Proveedor;
 use FacturaScripts\Dinamic\Model\Variante;
@@ -35,6 +36,48 @@ use FacturaScripts\Dinamic\Model\Variante;
 abstract class PurchaseDocument extends TransformerDocument
 {
     /**
+     * Supplier's mailbox.
+     *
+     * @var string
+     */
+    public $apartado;
+
+    /**
+     * Supplier's city.
+     *
+     * @var string
+     */
+    public $ciudad;
+
+    /**
+     * Supplier's country.
+     *
+     * @var string
+     */
+    public $codpais;
+
+    /**
+     * Supplier's postal code.
+     *
+     * @var string
+     */
+    public $codpostal;
+
+    /**
+     * Supplier's address
+     *
+     * @var string
+     */
+    public $direccion;
+
+    /**
+     * Supplier's province.
+     *
+     * @var string
+     */
+    public $provincia;
+
+    /**
      * Supplier code for this document.
      *
      * @var string
@@ -42,7 +85,7 @@ abstract class PurchaseDocument extends TransformerDocument
     public $codproveedor;
 
     /**
-     * Provider's name.
+     * Supplier's name.
      *
      * @var string
      */
@@ -59,10 +102,21 @@ abstract class PurchaseDocument extends TransformerDocument
     public function clear()
     {
         parent::clear();
+        $this->direccion = '';
 
         // select default currency
         $coddivisa = Tools::settings('default', 'coddivisa');
         $this->setCurrency($coddivisa, true);
+    }
+
+    public function country(): string
+    {
+        $country = new Pais();
+        if ($country->loadFromCode($this->codpais)) {
+            return Tools::fixHtml($country->nombre) ?? '';
+        }
+
+        return $this->codpais ?? '';
     }
 
     /**
@@ -164,6 +218,12 @@ abstract class PurchaseDocument extends TransformerDocument
         $this->codproveedor = $subject->codproveedor;
         $this->nombre = $subject->razonsocial;
         $this->cifnif = $subject->cifnif ?? '';
+        $this->apartado = $subject->getDefaultAddress()->apartado;
+        $this->ciudad = $subject->getDefaultAddress()->ciudad;
+        $this->codpostal = $subject->getDefaultAddress()->codpostal;
+        $this->direccion = $subject->getDefaultAddress()->direccion;
+        $this->provincia = $subject->getDefaultAddress()->provincia;
+        $this->codpais = $subject->getDefaultAddress()->codpais;
 
         // commercial data
         if (empty($this->primaryColumnValue())) {
@@ -191,6 +251,12 @@ abstract class PurchaseDocument extends TransformerDocument
     {
         $this->nombre = Tools::noHtml($this->nombre);
         $this->numproveedor = Tools::noHtml($this->numproveedor);
+
+        $this->apartado = Tools::noHtml($this->apartado);
+        $this->ciudad = Tools::noHtml($this->ciudad);
+        $this->codpostal = Tools::noHtml($this->codpostal);
+        $this->direccion = Tools::noHtml($this->direccion);
+        $this->provincia = Tools::noHtml($this->provincia);
 
         return parent::test();
     }
@@ -232,7 +298,7 @@ abstract class PurchaseDocument extends TransformerDocument
 
     protected function setPreviousData(array $fields = [])
     {
-        $more = ['codproveedor'];
+        $more = ['codproveedor', 'direccion'];
         parent::setPreviousData(array_merge($more, $fields));
     }
 }

--- a/Core/Table/albaranesprov.xml
+++ b/Core/Table/albaranesprov.xml
@@ -155,6 +155,30 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>apartado</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>ciudad</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>codpais</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>codpostal</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>direccion</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>provincia</name>
+        <type>character varying(100)</type>
+    </column>
     <constraint>
         <name>albaranesprov_pkey</name>
         <type>PRIMARY KEY (idalbaran)</type>

--- a/Core/Table/facturasprov.xml
+++ b/Core/Table/facturasprov.xml
@@ -181,6 +181,30 @@
         <type>boolean</type>
         <default>false</default>
     </column>
+    <column>
+        <name>apartado</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>ciudad</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>codpais</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>codpostal</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>direccion</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>provincia</name>
+        <type>character varying(100)</type>
+    </column>
     <constraint>
         <name>facturasprov_pkey</name>
         <type>PRIMARY KEY (idfactura)</type>

--- a/Core/Table/pedidosprov.xml
+++ b/Core/Table/pedidosprov.xml
@@ -154,6 +154,30 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>apartado</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>ciudad</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>codpais</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>codpostal</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>direccion</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>provincia</name>
+        <type>character varying(100)</type>
+    </column>
     <constraint>
         <name>pedidosprov_pkey</name>
         <type>PRIMARY KEY (idpedido)</type>

--- a/Core/Table/presupuestosprov.xml
+++ b/Core/Table/presupuestosprov.xml
@@ -154,6 +154,30 @@
         <type>double precision</type>
         <default>0</default>
     </column>
+    <column>
+        <name>apartado</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>ciudad</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>codpais</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>codpostal</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
+        <name>direccion</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>provincia</name>
+        <type>character varying(100)</type>
+    </column>
     <constraint>
         <name>presupuestosprov_pkey</name>
         <type>PRIMARY KEY (idpresupuesto)</type>

--- a/Test/Core/Model/AlbaranClienteTest.php
+++ b/Test/Core/Model/AlbaranClienteTest.php
@@ -298,6 +298,47 @@ final class AlbaranClienteTest extends TestCase
         $this->assertTrue($company2->delete(), 'empresa-cant-delete');
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un cliente
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save());
+
+        // completamos los datos del contacto
+        $contact = $customer->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new AlbaranCliente();
+        $doc->setSubject($customer);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new AlbaranCliente();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($customer->getDefaultAddress()->delete());
+        $this->assertTrue($customer->delete());
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/AlbaranProveedorTest.php
+++ b/Test/Core/Model/AlbaranProveedorTest.php
@@ -292,6 +292,47 @@ final class AlbaranProveedorTest extends TestCase
         $this->assertTrue($company2->delete(), 'empresa-cant-delete');
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un proveedor
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save());
+
+        // completamos los datos del contacto
+        $contact = $supplier->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new AlbaranProveedor();
+        $doc->setSubject($supplier);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new AlbaranProveedor();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($supplier->getDefaultAddress()->delete());
+        $this->assertTrue($supplier->delete());
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/FacturaClienteTest.php
+++ b/Test/Core/Model/FacturaClienteTest.php
@@ -835,6 +835,47 @@ final class FacturaClienteTest extends TestCase
         $this->assertTrue($company->delete());
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un cliente
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save());
+
+        // completamos los datos del contacto
+        $contact = $customer->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new FacturaCliente();
+        $doc->setSubject($customer);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new FacturaCliente();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($customer->getDefaultAddress()->delete());
+        $this->assertTrue($customer->delete());
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/FacturaProveedorTest.php
+++ b/Test/Core/Model/FacturaProveedorTest.php
@@ -680,6 +680,47 @@ final class FacturaProveedorTest extends TestCase
         $this->assertTrue($company->delete());
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un proveedor
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save());
+
+        // completamos los datos del contacto
+        $contact = $supplier->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new FacturaProveedor();
+        $doc->setSubject($supplier);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new FacturaProveedor();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($supplier->getDefaultAddress()->delete());
+        $this->assertTrue($supplier->delete());
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/PedidoClienteTest.php
+++ b/Test/Core/Model/PedidoClienteTest.php
@@ -289,6 +289,47 @@ final class PedidoClienteTest extends TestCase
         $this->assertTrue($company2->delete(), 'empresa-cant-delete');
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un cliente
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save());
+
+        // completamos los datos del contacto
+        $contact = $customer->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new PedidoCliente();
+        $doc->setSubject($customer);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new PedidoCliente();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($customer->getDefaultAddress()->delete());
+        $this->assertTrue($customer->delete());
+    }
+
     protected function setUp(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/PedidoProveedorTest.php
+++ b/Test/Core/Model/PedidoProveedorTest.php
@@ -295,6 +295,47 @@ final class PedidoProveedorTest extends TestCase
         $this->assertTrue($company2->delete(), 'empresa-cant-delete');
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un proveedor
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save());
+
+        // completamos los datos del contacto
+        $contact = $supplier->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new PedidoProveedor();
+        $doc->setSubject($supplier);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new PedidoProveedor();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($supplier->getDefaultAddress()->delete());
+        $this->assertTrue($supplier->delete());
+    }
+
     protected function setUp(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/PresupuestoClienteTest.php
+++ b/Test/Core/Model/PresupuestoClienteTest.php
@@ -355,6 +355,47 @@ final class PresupuestoClienteTest extends TestCase
         $this->assertTrue($subject->delete(), 'cliente-cant-delete');
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un cliente
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save());
+
+        // completamos los datos del contacto
+        $contact = $customer->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new PresupuestoCliente();
+        $doc->setSubject($customer);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new PresupuestoCliente();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($customer->getDefaultAddress()->delete());
+        $this->assertTrue($customer->delete());
+    }
+
     protected function setUp(): void
     {
         $this->logErrors();

--- a/Test/Core/Model/PresupuestoProveedorTest.php
+++ b/Test/Core/Model/PresupuestoProveedorTest.php
@@ -311,6 +311,47 @@ final class PresupuestoProveedorTest extends TestCase
         $this->assertTrue($company2->delete(), 'empresa-cant-delete');
     }
 
+    public function testInvoiceAddress()
+    {
+        // creamos un proveedor
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save());
+
+        // completamos los datos del contacto
+        $contact = $supplier->getDefaultAddress();
+        $contact->apartado = '12345';
+        $contact->ciudad = 'Test-ciudad';
+        $contact->codpais = 'Test-codpais';
+        $contact->codpostal = '12345';
+        $contact->direccion = 'Test-direccion';
+        $contact->provincia = 'Test-provincia';
+        $this->assertTrue($contact->save());
+
+        // creamos un documento
+        $doc = new PresupuestoProveedor();
+        $doc->setSubject($supplier);
+        $this->assertTrue($doc->save());
+
+        // obtenemos el documento de la base de datos
+        // para así comprobar que se estan guardando bien
+        // en la base de datos
+        $savedDoc = new PresupuestoProveedor();
+        $savedDoc->loadFromCode($doc->primaryColumnValue());
+
+        // comparamos que los datos del contacto/cliente se guardan en el documento
+        $this->assertEquals($contact->apartado, $savedDoc->apartado);
+        $this->assertEquals($contact->ciudad, $savedDoc->ciudad);
+        $this->assertEquals($contact->codpais, $savedDoc->codpais);
+        $this->assertEquals($contact->codpostal, $savedDoc->codpostal);
+        $this->assertEquals($contact->direccion, $savedDoc->direccion);
+        $this->assertEquals($contact->provincia, $savedDoc->provincia);
+
+        // eliminamos
+        $this->assertTrue($doc->delete());
+        $this->assertTrue($supplier->getDefaultAddress()->delete());
+        $this->assertTrue($supplier->delete());
+    }
+
     protected function setUp(): void
     {
         $this->logErrors();


### PR DESCRIPTION
# Descripción

- Al añadir documentos de compra también deberíamos guardar la dirección en el documento, como hacemos con las ventas.

![image](https://github.com/NeoRazorX/facturascripts/assets/2836337/c72365ea-baa9-4fbf-879d-4f41a0d88fc7)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
