### PR TITLE
Tarea #3302 - agregar codpais, provincia y ciudad a clientes y provee…

### DIFF
--- a/Core/Model/Base/IntracomunitariaTrait.php
+++ b/Core/Model/Base/IntracomunitariaTrait.php
@@ -51,7 +51,7 @@ trait IntracomunitariaTrait
         $subject = $this->getSubject();
         $country = property_exists($this, 'codpais')
             ? Paises::get($this->codpais)
-            : Paises::get($subject->getDefaultAddress()->codpais);
+            : Paises::get($subject->codpais);
         if (false === Paises::miembroUE($country->codpais)) {
             Tools::log()->warning('subject-not-in-eu');
             return false;

--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -64,9 +64,18 @@ class Cliente extends Base\ComercialContact
     /** @var float */
     public $riesgomax;
 
+    /** @var string */
+    public $codpais;
+
+    /** @var string */
+    public $provincia;
+
+    /** @var string */
+    public $ciudad;
+
     public function checkVies(): bool
     {
-        $codiso = Paises::get($this->getDefaultAddress()->codpais)->codiso ?? '';
+        $codiso = Paises::get($this->codpais)->codiso ?? '';
         return Vies::check($this->cifnif ?? '', $codiso) === 1;
     }
 
@@ -309,6 +318,9 @@ class Cliente extends Base\ComercialContact
             $contact->tipoidfiscal = $this->tipoidfiscal;
             if ($contact->save()) {
                 $this->idcontactofact = $contact->idcontacto;
+                $this->codpais = $contact->codpais;
+                $this->provincia = $contact->provincia;
+                $this->ciudad = $contact->ciudad;
                 return $this->save();
             }
         }

--- a/Core/Model/Contacto.php
+++ b/Core/Model/Contacto.php
@@ -289,4 +289,31 @@ class Contacto extends Base\Contact
     {
         return parent::url($type, $list);
     }
+
+    protected function saveUpdate(array $values = []):bool
+    {
+        if(parent::saveUpdate($values)){
+            if (!empty($this->codcliente) && empty($this->codproveedor)){
+                $subject = new Cliente();
+                $subject->loadFromCode($this->codcliente);
+                $idContact = $subject->idcontactofact;
+            }else{
+                $subject = new Proveedor();
+                $subject->loadFromCode($this->codproveedor);
+                $idContact = $subject->idcontacto;
+            }
+
+            // solo actualizamos si el contacto a actualizar es el contacto por defecto.
+            if($idContact === $this->idcontacto){
+                $subject->codpais = $this->codpais;
+                $subject->provincia = $this->provincia;
+                $subject->ciudad = $this->ciudad;
+                $subject->save();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/Core/Model/Proveedor.php
+++ b/Core/Model/Proveedor.php
@@ -49,9 +49,18 @@ class Proveedor extends Base\ComercialContact
     /** @var int */
     public $idcontacto;
 
+    /** @var string */
+    public $codpais;
+
+    /** @var string */
+    public $provincia;
+
+    /** @var string */
+    public $ciudad;
+
     public function checkVies(): bool
     {
-        $codiso = Paises::get($this->getDefaultAddress()->codpais)->codiso ?? '';
+        $codiso = Paises::get($this->codpais)->codiso ?? '';
         return Vies::check($this->cifnif ?? '', $codiso) === 1;
     }
 
@@ -239,6 +248,9 @@ class Proveedor extends Base\ComercialContact
             $contact->tipoidfiscal = $this->tipoidfiscal;
             if ($contact->save()) {
                 $this->idcontacto = $contact->idcontacto;
+                $this->codpais = $contact->codpais;
+                $this->provincia = $contact->provincia;
+                $this->ciudad = $contact->ciudad;
                 return $this->save();
             }
         }

--- a/Core/Table/clientes.xml
+++ b/Core/Table/clientes.xml
@@ -131,6 +131,18 @@
         <name>web</name>
         <type>character varying(100)</type>
     </column>
+    <column>
+        <name>codpais</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>provincia</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>ciudad</name>
+        <type>character varying(100)</type>
+    </column>
     <constraint>
         <name>clientes_pkey</name>
         <type>PRIMARY KEY (codcliente)</type>

--- a/Core/Table/proveedores.xml
+++ b/Core/Table/proveedores.xml
@@ -112,6 +112,18 @@
         <name>web</name>
         <type>character varying(100)</type>
     </column>
+    <column>
+        <name>codpais</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>provincia</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
+        <name>ciudad</name>
+        <type>character varying(100)</type>
+    </column>
     <constraint>
         <name>proveedores_pkey</name>
         <type>PRIMARY KEY (codproveedor)</type>

--- a/Test/Core/Model/ClienteTest.php
+++ b/Test/Core/Model/ClienteTest.php
@@ -192,10 +192,8 @@ final class ClienteTest extends TestCase
         }
         $this->assertFalse($check1);
 
-        // asignamos dirección de Portugal
-        $address = $cliente->getDefaultAddress();
-        $address->codpais = 'PRT';
-        $this->assertTrue($address->save());
+        $cliente->codpais = 'PRT';
+        $this->assertTrue($cliente->save());
 
         // asignamos un cifnif incorrecto
         $cliente->cifnif = '12345678A';
@@ -206,8 +204,41 @@ final class ClienteTest extends TestCase
         $this->assertTrue($cliente->checkVies());
 
         // eliminamos
-        $this->assertTrue($address->delete());
         $this->assertTrue($cliente->delete());
+    }
+
+    public function testAddressDefaultContactInModel()
+    {
+        $cliente = new Cliente();
+        $cliente->nombre = 'Test';
+        $cliente->cifnif = '12345678A';
+        $this->assertTrue($cliente->save(), 'cliente-cant-save');
+
+        // comprobamos que el codpais, provincia y ciudad del contacto por defecto
+        // se encuentran replicados en el modelo
+        $defaultAddress = $cliente->getDefaultAddress();
+
+        $this->assertEquals($defaultAddress->codpais, $cliente->codpais);
+        $this->assertEquals($defaultAddress->provincia, $cliente->provincia);
+        $this->assertEquals($defaultAddress->ciudad, $cliente->ciudad);
+
+        // comprobamos que cuando se cambian los datos en el contacto
+        // se guardan en el modelo
+
+        $defaultAddress->codpais = 'COL';
+        $defaultAddress->provincia = 'Test-provincia';
+        $defaultAddress->ciudad = 'Test-ciudad';
+        $defaultAddress->save();
+
+        $cliente->loadFromCode($cliente->codcliente); // actualizamos desde la base de datos
+        $this->assertEquals($defaultAddress->codpais, $cliente->codpais);
+        $this->assertEquals($defaultAddress->provincia, $cliente->provincia);
+        $this->assertEquals($defaultAddress->ciudad, $cliente->ciudad);
+
+
+        // eliminamos
+        $this->assertTrue($cliente->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($cliente->delete(), 'cliente-cant-delete');
     }
 
     protected function tearDown(): void

--- a/Test/Core/Model/ProveedorTest.php
+++ b/Test/Core/Model/ProveedorTest.php
@@ -167,9 +167,8 @@ final class ProveedorTest extends TestCase
         $this->assertFalse($check1);
 
         // asignamos dirección de Italia
-        $address = $proveedor->getDefaultAddress();
-        $address->codpais = 'ITA';
-        $this->assertTrue($address->save());
+        $proveedor->codpais = 'ITA';
+        $this->assertTrue($proveedor->save());
 
         // asignamos un cif/nif incorrecto
         $proveedor->cifnif = '12345678A';
@@ -180,8 +179,41 @@ final class ProveedorTest extends TestCase
         $this->assertTrue($proveedor->checkVies());
 
         // eliminamos
-        $this->assertTrue($address->delete());
         $this->assertTrue($proveedor->delete());
+    }
+
+    public function testAddressDefaultContactInModel()
+    {
+        $supplier = new Proveedor();
+        $supplier->nombre = 'Test';
+        $supplier->cifnif = '12345678A';
+        $this->assertTrue($supplier->save(), 'cliente-cant-save');
+
+        // comprobamos que el codpais, provincia y ciudad del contacto por defecto
+        // se encuentran replicados en el modelo
+        $defaultAddress = $supplier->getDefaultAddress();
+
+        $this->assertEquals($defaultAddress->codpais, $supplier->codpais);
+        $this->assertEquals($defaultAddress->provincia, $supplier->provincia);
+        $this->assertEquals($defaultAddress->ciudad, $supplier->ciudad);
+
+        // comprobamos que cuando se cambian los datos en el contacto
+        // se guardan en el modelo
+
+        $defaultAddress->codpais = 'COL';
+        $defaultAddress->provincia = 'Test-provincia';
+        $defaultAddress->ciudad = 'Test-ciudad';
+        $defaultAddress->save();
+
+        $supplier->loadFromCode($supplier->codproveedor); // actualizamos desde la base de datos
+        $this->assertEquals($defaultAddress->codpais, $supplier->codpais);
+        $this->assertEquals($defaultAddress->provincia, $supplier->provincia);
+        $this->assertEquals($defaultAddress->ciudad, $supplier->ciudad);
+
+
+        // eliminamos
+        $this->assertTrue($supplier->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($supplier->delete(), 'cliente-cant-delete');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
# Descripción
- Tanto en clientes como en proveedores deberíamos tener los campos de codpais, provincia y ciudad replicados en el modelo, para simplificar las consultas. Si no lo tenemos, nos toca combinar con la tabla de contactos para sacar esa información.
- Se añaden a los modelos Cliente y Proveedor las nuevas propiedades.
- Se replican los datos del contacto al modelo cuando se crea alguno de estos dos modelos o se actualiza el Contacto por defecto.
- Se actualizan las tablas correspondientes.
- Se agregan tests para comprobar estas circunstancias y se modifican las llamadas innecesarias a getDefaultAddress() en los tests.
- Se cambia en el resto del codigo la llamda a getDefaultAddress() cuando no es necesaria.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
