### PR TITLE
Tarea #3064 - checkbox servir todo o nada por linea

### DIFF
--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -219,6 +219,17 @@
             document.formDocStitcher.status.value = status;
             document.formDocStitcher.submit();
         }
+
+        function toggleServe(input) {
+            const celda = input.closest('td.table-success');
+            if(input.checked){
+                const toServe = celda.querySelector('input.to_serve').value;
+                celda.querySelector('input.to_be_served').value = toServe;
+            }else{
+                celda.querySelector('input.to_be_served').value = 0;
+            }
+        };
+
     </script>
 {% endblock %}
 
@@ -277,9 +288,16 @@
                         {% set newQuantity = line.cantidad - line.servido %}
                         <td class="{{ newQuantity == 0 ? 'table-warning' : 'table-success' }}">
                             <input type="hidden" class="to_serve" value="{{ newQuantity }}"/>
-                            <input type="number" name="approve_quant_{{ line.primaryColumnValue() }}"
-                                   value="{{ newQuantity }}" step="any" min="0" max="{{ line.cantidad }}"
-                                   class="form-control text-right to_be_served" autocomplete="off"/>
+                            <div class="input-group">
+                                <input type="number" name="approve_quant_{{ line.primaryColumnValue() }}"
+                                       value="{{ newQuantity }}" step="any" min="0" max="{{ line.cantidad }}"
+                                       class="form-control text-right to_be_served" autocomplete="off"/>
+                                <div class="input-group-append">
+                                    <div class="input-group-text">
+                                        <input type="checkbox" onclick="toggleServe(this)">
+                                    </div>
+                                </div>
+                            </div>
                         </td>
                     </tr>
                 {% else %}


### PR DESCRIPTION
# Descripción
- Al agrupar documentos, en las líneas tenemos que poner las cantidades. Sería muy cómodo tener un botón todo para poner automáticamente el máximo de la línea.

También sería interesante añadir un checkbox para indicar si incluir la línea o no. De esta forma podemos solucionar el problema de "a veces quiero copiar líneas a 0, a veces no".
Implementación

Se puede combinar el checkbox con el funcionamiento del botón: al marcar el checkbox, se puede poner la cantidad máxima, y al desmarcar, se pone cantidad 0.

![Animation](https://github.com/NeoRazorX/facturascripts/assets/2836337/84fb6023-6d0f-4ae7-8427-92ea6d2bac68)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
