### PR TITLE
Tarea #2972 - agregar modal fecha y forma de pago

### DIFF
--- a/Core/Base/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Base/AjaxForms/CommonSalesPurchases.php
@@ -162,7 +162,7 @@ trait CommonSalesPurchases
 
         $attributes = $model->editable ? 'name="codpago" required' : 'disabled';
         return empty($model->subjectColumnValue()) ? '' : '<div class="col-sm-3 col-md-2 col-lg">'
-            . '<div class="form-group">'
+            . '<div id="payment-methods" class="form-group">'
             . '<a href="' . FormasPago::get($model->codpago)->url() . '">' . $i18n->trans('payment-method') . '</a>'
             . '<select ' . $attributes . ' class="form-control">' . implode('', $options) . '</select>'
             . '</div>'
@@ -303,7 +303,7 @@ trait CommonSalesPurchases
     {
         $attributes = $model->editable && $enabled ? 'name="fecha" required' : 'disabled';
         return empty($model->subjectColumnValue()) ? '' : '<div class="col-sm">'
-            . '<div class="form-group">' . $i18n->trans('date')
+            . '<div id="document-date" class="form-group">' . $i18n->trans('date')
             . '<input type="date" ' . $attributes . ' value="' . date('Y-m-d', strtotime($model->fecha)) . '" class="form-control"/>'
             . '</div>'
             . '</div>';
@@ -539,7 +539,7 @@ trait CommonSalesPurchases
             . '<div class="form-group">'
             . '<button class="btn btn-spin-action btn-outline-danger dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">'
             . '<i class="fas fa-times fa-fw"></i> ' . $i18n->trans('unpaid') . '</button>'
-            . '<div class="dropdown-menu"><a class="dropdown-item text-success" href="#" onclick="return ' . $jsName . '(\'save-paid\', \'1\');">'
+            . '<div class="dropdown-menu"><a class="dropdown-item text-success" href="#" onclick="showModalPaymentConditions(' . $jsName . ')">'
             . '<i class="fas fa-check-square fa-fw"></i> ' . $i18n->trans('paid') . '</a></div>'
             . '</div>'
             . '</div>';

--- a/Core/Base/AjaxForms/PurchasesController.php
+++ b/Core/Base/AjaxForms/PurchasesController.php
@@ -436,8 +436,14 @@ abstract class PurchasesController extends PanelController
         }
 
         // marcamos los recibos como pagados, eso marcará la factura como pagada
+        $formData = json_decode($this->request->request->get('data'), true);
         foreach ($receipts as $receipt) {
             $receipt->nick = $this->user->nick;
+            // si no está pagado, actualizamos fechapago y codpago
+            if (false == $receipt->pagado){
+                $receipt->fechapago = $formData['fechapagorecibo'] ?? Tools::date();
+                $receipt->codpago = $model->codpago;
+            }
             $receipt->pagado = (bool)$this->request->request->get('selectedLine');
             if (false === $receipt->save()) {
                 $this->sendJsonWithLogs(['ok' => false]);

--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -451,8 +451,14 @@ abstract class SalesController extends PanelController
         }
 
         // marcamos los recibos como pagados, eso marca la factura como pagada
+        $formData = json_decode($this->request->request->get('data'), true);
         foreach ($receipts as $receipt) {
             $receipt->nick = $this->user->nick;
+            // si no está pagado, actualizamos fechapago y codpago
+            if (false == $receipt->pagado){
+                $receipt->fechapago = $formData['fechapagorecibo'] ?? Tools::date();
+                $receipt->codpago = $model->codpago;
+            }
             $receipt->pagado = (bool)$this->request->request->get('selectedLine');
             if (false === $receipt->save()) {
                 $this->sendJsonWithLogs(['ok' => false]);

--- a/Core/View/Tab/PurchasesDocument.html.twig
+++ b/Core/View/Tab/PurchasesDocument.html.twig
@@ -295,6 +295,61 @@
         $("#purchasesFormLines").sortable("disable");
     }
 
+    // Muestra el modal para elegir la forma de pago y fecha de los recibos
+    // al presionar el boton para pagar la factura.
+    function showModalPaymentConditions(callback) {
+        const textClose = "{{ trans('close') }}";
+        const textPaid = "{{ trans('paid') }}";
+        // reutilizamos los inputs del formulario del header
+        // para mantener formatos y valores dinamicos
+        const paymentMethodsHTML = $('#payment-methods').html();
+        const documentDateHTML = $('#document-date').html();
+
+        const html = `
+            <div class="modal fade" id="modalPaymentConditions" tabindex="-1" aria-hidden="true">
+              <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                  <div class="modal-body">
+                    <div class="mb-3" id="payment-methods-modal">
+                        ${paymentMethodsHTML}
+                    </div>
+                    <div class="mb-3" id="document-date-modal">
+                        ${documentDateHTML}
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">${textClose}</button>
+                    <button type="button" class="btn btn-primary" onclick="prepareForm(${callback})">${textPaid}</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+        `;
+        document.body.insertAdjacentHTML('beforeend', html);
+
+        // cambiamos la fecha del input para que por defecto sea la de hoy
+        $('#document-date-modal').children('input').val('{{ "now"|date("Y-m-d") }}');
+
+        $('#modalPaymentConditions').modal('show');
+    }
+
+    // creamos los inputs para que se envien por post
+    // con el resto de campos del formulario
+    function prepareForm(callback){
+
+        // creamos un input para enviar la fecha de pago para los recibos
+        const inputFechaPagoRecibo = document.createElement('input');
+        inputFechaPagoRecibo.type = 'hidden';
+        inputFechaPagoRecibo.name = 'fechapagorecibo';
+        inputFechaPagoRecibo.value = $('#document-date-modal').children('input').val();
+        document.forms['purchasesForm'].appendChild(inputFechaPagoRecibo);
+
+        // cambiamos la forma de pago para que coincida con la de los recibos y se envie por el formulario
+        $('#payment-methods').children('select').val($('#payment-methods-modal').children('select').val());
+
+        callback('save-paid', 1);
+    }
+
     $(document).on('keyup', '.doc-line-desc', function (e) {
         while ($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))) {
             $(this).height($(this).height() + 1);

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -295,6 +295,61 @@
         $("#salesFormLines").sortable("disable");
     }
 
+    // Muestra el modal para elegir la forma de pago y fecha de los recibos
+    // al presionar el boton para pagar la factura.
+    function showModalPaymentConditions(callback) {
+        const textClose = "{{ trans('close') }}";
+        const textPaid = "{{ trans('paid') }}";
+        // reutilizamos los inputs del formulario del header
+        // para mantener formatos y valores dinamicos
+        const paymentMethodsHTML = $('#payment-methods').html();
+        const documentDateHTML = $('#document-date').html();
+
+        const html = `
+            <div class="modal fade" id="modalPaymentConditions" tabindex="-1" aria-hidden="true">
+              <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                  <div class="modal-body">
+                    <div class="mb-3" id="payment-methods-modal">
+                        ${paymentMethodsHTML}
+                    </div>
+                    <div class="mb-3" id="document-date-modal">
+                        ${documentDateHTML}
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">${textClose}</button>
+                    <button type="button" class="btn btn-primary" onclick="prepareForm(${callback})">${textPaid}</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+        `;
+        document.body.insertAdjacentHTML('beforeend', html);
+
+        // cambiamos la fecha del input para que por defecto sea la de hoy
+        $('#document-date-modal').children('input').val('{{ "now"|date("Y-m-d") }}');
+
+        $('#modalPaymentConditions').modal('show');
+    }
+
+    // creamos los inputs para que se envien por post
+    // con el resto de campos del formulario
+    function prepareForm(callback){
+
+        // creamos un input para enviar la fecha de pago para los recibos
+        const inputFechaPagoRecibo = document.createElement('input');
+        inputFechaPagoRecibo.type = 'hidden';
+        inputFechaPagoRecibo.name = 'fechapagorecibo';
+        inputFechaPagoRecibo.value = $('#document-date-modal').children('input').val();
+        document.forms['salesForm'].appendChild(inputFechaPagoRecibo);
+
+        // cambiamos la forma de pago para que coincida con la de los recibos y se envie por el formulario
+        $('#payment-methods').children('select').val($('#payment-methods-modal').children('select').val());
+
+        callback('save-paid', 1);
+    }
+
     $(document).on('keyup', '.doc-line-desc', function (e) {
         while ($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))) {
             $(this).height($(this).height() + 1);


### PR DESCRIPTION
# Descripción
- En el formulario de edición de facturas, en el botón impagado, cuando marcamos pagado, debería mostrar un modal donde podamos seleccionar la forma de pago y la fecha de pago (por defecto hoy). De esta forma podemos pagar con una forma de pago y fecha distinta a la actual, en un solo paso.

![Animation](https://github.com/NeoRazorX/facturascripts/assets/2836337/399f25f2-6e84-4436-bb8e-b0df323f8fb8)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
