### PR TITLE
Tarea #2970 - agregar worker actualizar numero productos en familias

### DIFF
--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -116,6 +116,9 @@ final class Kernel
         WorkQueue::addWorker('CuentaWorker', 'Model.Subcuenta.Update');
         WorkQueue::addWorker('PartidaWorker', 'Model.Partida.Delete');
         WorkQueue::addWorker('PartidaWorker', 'Model.Partida.Save');
+        WorkQueue::addWorker('UpdateFamilyNumProductsWorker', 'Model.Producto.Insert');
+        WorkQueue::addWorker('UpdateFamilyNumProductsWorker', 'Model.Producto.Update');
+        WorkQueue::addWorker('UpdateFamilyNumProductsWorker', 'Model.Producto.Delete');
 
         self::stopTimer('kernel::init');
     }

--- a/Core/Worker/UpdateFamilyNumProductsWorker.php
+++ b/Core/Worker/UpdateFamilyNumProductsWorker.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace FacturaScripts\Core\Worker;
+
+use FacturaScripts\Core\DbQuery;
+use FacturaScripts\Core\Model\Familia;
+use FacturaScripts\Core\Model\Producto;
+use FacturaScripts\Core\Model\WorkEvent;
+use FacturaScripts\Core\Template\WorkerClass;
+
+class UpdateFamilyNumProductsWorker extends WorkerClass
+{
+    public function run(WorkEvent $event): bool
+    {
+        $currentCodFamilia = $event->param(Familia::primaryColumn());
+        $previousCodFamilia = is_array($event->param('previous')) ? $event->param('previous')[Familia::primaryColumn()] : null;
+
+        $idFamilia = $currentCodFamilia ?? $previousCodFamilia;
+
+        if (empty($idFamilia) || $currentCodFamilia === $previousCodFamilia) {
+            return $this->done();
+        }
+
+        $family = new Familia();
+        if (false === $family->loadFromCode($idFamilia)) {
+            return $this->done();
+        }
+
+        $totalProductsFamily = DbQuery::table(Producto::tableName())
+            ->whereEq(Familia::primaryColumn(), $family->primaryColumnValue())
+            ->count();
+
+        $family->numproductos = $totalProductsFamily;
+        $family->save();
+
+        return $this->done();
+    }
+}


### PR DESCRIPTION
# Descripción
- Añadir un worker para actualizar el número de productos de las familias, cuando se crea, modifica o elimina un producto.
- He usado 'Model.Producto.Insert', 'Model.Producto.Update' y 'Model.Producto.Delete' porque usando 'Model.Producto.*' duplica las llamadas, ya que, por ejemplo, al actualizar un producto llama dos veces al worker: 'Model.Producto.Update' y tambien a 'Model.Producto.Save'
- He añadido al metodo saveUpdate() de la clase Core/Model/Base/ModelClass.php que se envia al Worker los datos antes de actualizar, ya que si no es así cuando se desvincula un producto de una familia llega el codfamilia a null y no hay forma de saber a que familia pertenecía antes. Lo he puesto en esta clase porque creo que es útil y se podrá usar en muchas ocasiones y para los Plugins también creo que puede venir muy bien disponer de estos datos en el worker.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
