### PR TITLE
Tarea #2313 - redireccionar al documento previo al crear nuevo cliente

### DIFF
--- a/Core/Base/AjaxForms/SalesController.php
+++ b/Core/Base/AjaxForms/SalesController.php
@@ -85,10 +85,16 @@ abstract class SalesController extends PanelController
      */
     public function renderSalesForm(SalesDocument $model, array $lines): string
     {
+        $url = $this->url();
+
+        if($model->primaryColumnValue()){
+            $url = Tools::urlAddParams($url, ['code' => $model->primaryColumnValue()]);
+        }
+
         return '<div id="salesFormHeader">' . SalesHeaderHTML::render($model) . '</div>'
             . '<div id="salesFormLines">' . SalesLineHTML::render($lines, $model) . '</div>'
             . '<div id="salesFormFooter">' . SalesFooterHTML::render($model) . '</div>'
-            . SalesModalHTML::render($model, $this->url(), $this->user, $this->permissions);
+            . SalesModalHTML::render($model, $url, $this->user, $this->permissions);
     }
 
     public function series(string $type = ''): array
@@ -320,6 +326,12 @@ abstract class SalesController extends PanelController
 
                 // data not found?
                 $view->loadData($code);
+                if($this->request->query->has(Cliente::primaryColumn())){
+                    $cliente = new Cliente();
+                    $cliente->loadFromCode($this->request->query->get(Cliente::primaryColumn()));
+                    $view->model->setSubject($cliente);
+                    $view->model->save();
+                }
                 $action = $this->request->request->get('action', '');
                 if ('' === $action && empty($view->model->primaryColumnValue())) {
                     Tools::log()->warning('record-not-found');

--- a/Core/Base/AjaxForms/SalesModalHTML.php
+++ b/Core/Base/AjaxForms/SalesModalHTML.php
@@ -297,9 +297,8 @@ class SalesModalHTML
                 . '</tr>';
         }
 
-        $linkAgent = '';
-        if ($user->codagente) {
-            $linkAgent = '&codagente=' . $user->codagente;
+        if($user->codagente){
+            $url = Tools::urlAddParams($url, ['codagente' => $user->codagente]);
         }
 
         return '<div class="modal" id="findCustomerModal" tabindex="-1" aria-hidden="true">'
@@ -322,7 +321,7 @@ class SalesModalHTML
             . '</div>'
             . '<table class="table table-hover mb-0">' . $trs . '</table></div>'
             . '<div class="modal-footer bg-light">'
-            . '<a href="EditCliente?return=' . urlencode($url) . $linkAgent . '" class="btn btn-block btn-success">'
+            . '<a href="EditCliente?return=' . urlencode($url) . '" class="btn btn-block btn-success">'
             . '<i class="fas fa-plus fa-fw"></i> ' . $i18n->trans('new')
             . '</a>'
             . '</div>'

--- a/Core/Controller/EditCliente.php
+++ b/Core/Controller/EditCliente.php
@@ -174,7 +174,7 @@ class EditCliente extends ComercialContactController
         $returnUrl = $this->request->query->get('return');
         if (!empty($returnUrl)) {
             $model = $this->views[$this->active]->model;
-            $this->redirect($returnUrl . '?' . $model->primaryColumn() . '=' . $model->primaryColumnValue());
+            $this->redirect(Tools::urlAddParams($returnUrl, [$model::primaryColumn() => $model->primaryColumnValue()]));
         }
 
         return true;

--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -361,6 +361,22 @@ class Tools
         return date(self::DATETIME_STYLE, $time);
     }
 
+    public static function urlAddParams(string $url, array $params = []): string
+    {
+        $urlQuery = parse_url($url, PHP_URL_QUERY);
+        $urlPath = parse_url($url, PHP_URL_PATH);
+        $urlParams = [];
+
+        if ($urlQuery){
+            parse_str($urlQuery, $urlParams);
+        }
+
+        $urlParams = array_merge($urlParams, $params);
+        $paramsQuery = '?' . http_build_query($urlParams);
+
+        return $urlPath . $paramsQuery;
+    }
+
     private static function settingsLoad(): void
     {
         if ('' === Tools::config('db_name', '')) {


### PR DESCRIPTION
# Descripción

- cuando abrimos un presupuesto, pedido, albarán o factura, pulsamos cambiar el cliente y pulsamos en el botón nuevo, al guardar el cliente realmente nos ha creado un presupuesto nuevo (o lo que sea), en lugar de asignar ese nuevo cliente al documento original.

- Si existe el modelo(no es un formulario de creación) incluimos el code en la url del modal cliente para que redireccione al documento guardado del que proviene.

- Cuando volvemos al documento, asignamos(setSubject()) el cliente al documento que nos llega en los parametros de la url.

- He implementado una función para la clase Tools que añade parámetros a una url. es muy útil porque si la url ya tiene parámetros pues no nos liamos con los ? y los &.. Le pasamos una url incluso con parámetros anteriores y añade correctamente los demás parámetros pasados por array y devuelve la url formateada correctamente.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
