### PR TITLE
Evitar mostrar el mensaje de respuesta del vies

### DIFF
--- a/Core/Lib/Vies.php
+++ b/Core/Lib/Vies.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2023-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -39,17 +39,17 @@ class Vies
 
     private static $lastError = '';
 
-    public static function check(string $cifnif, string $codiso): int
+    public static function check(string $cifnif, string $codiso, bool $msg = true): int
     {
         // comprobamos si la extensión soap está instalada
-        if (!extension_loaded('soap')) {
-            Tools::log()->warning('soap-extension-not-installed');
+        if (false === extension_loaded('soap')) {
+            static::setMessage($msg, 'soap-extension-not-installed');
             return -1;
         }
 
         // si el país no es de la unión europea, devolvemos error
         if (!in_array($codiso, self::EU_COUNTRIES)) {
-            Tools::log()->warning('country-not-in-eu', ['%codiso%' => $codiso]);
+            static::setMessage($msg, 'country-not-in-eu', ['%codiso%' => $codiso]);
             return -1;
         }
 
@@ -58,13 +58,13 @@ class Vies
 
         // si el cifnif tiene menos de 5 caracteres, devolvemos error
         if (strlen($cifnif) < 5) {
-            Tools::log()->warning('vat-number-is-short', ['%vat-number%' => $cifnif]);
+            static::setMessage($msg, 'vat-number-is-short', ['%vat-number%' => $cifnif]);
             return -1;
         }
 
         // si codiso está vacío o es diferente de 2 caracteres, devolvemos error
         if (empty($codiso) || strlen($codiso) !== 2) {
-            Tools::log()->warning('invalid-iso-code', ['%iso-code%' => $codiso]);
+            static::setMessage($msg, 'invalid-iso-code', ['%iso-code%' => $codiso]);
             return -1;
         }
 
@@ -73,7 +73,7 @@ class Vies
             $cifnif = substr($cifnif, 2);
         }
 
-        return static::getViesInfo($cifnif, $codiso);
+        return static::getViesInfo($cifnif, $codiso, $msg);
     }
 
     public static function getLastError(): string
@@ -81,7 +81,7 @@ class Vies
         return self::$lastError;
     }
 
-    private static function getViesInfo(string $vatNumber, string $codiso): int
+    private static function getViesInfo(string $vatNumber, string $codiso, bool $msg): int
     {
         self::$lastError = '';
 
@@ -99,7 +99,7 @@ class Vies
                 return 1;
             }
 
-            Tools::log()->warning('vat-number-not-vies', ['%vat-number%' => $vatNumber]);
+            static::setMessage($msg, 'vat-number-not-valid', ['%vat-number%' => $vatNumber]);
             return 0;
         } catch (Exception $ex) {
             Tools::log('VatInfoFinder')->error($ex->getCode() . ' - ' . $ex->getMessage());
@@ -110,7 +110,14 @@ class Vies
         }
 
         // se ha producido error al comprobar el VAT number con VIES
-        Tools::log()->warning('error-checking-vat-number', ['%vat-number%' => $vatNumber]);
+        static::setMessage($msg, 'error-checking-vat-number', ['%vat-number%' => $vatNumber]);
         return -1;
+    }
+
+    private static function setMessage(bool $msg, string $txt, array $context = []): void
+    {
+        if ($msg) {
+            Tools::log()->warning($txt, $context);
+        }
     }
 }

--- a/Core/Model/Agente.php
+++ b/Core/Model/Agente.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -53,10 +53,10 @@ class Agente extends Base\Contact
     /** @var integer */
     public $idcontacto;
 
-    public function checkVies(): bool
+    public function checkVies(bool $msg = true): bool
     {
         $codiso = Paises::get($this->getContact()->codpais)->codiso ?? '';
-        return Vies::check($this->cifnif ?? '', $codiso) === 1;
+        return Vies::check($this->cifnif ?? '', $codiso, $msg) === 1;
     }
 
     public function getContact(): DinContacto

--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -64,10 +64,10 @@ class Cliente extends Base\ComercialContact
     /** @var float */
     public $riesgomax;
 
-    public function checkVies(): bool
+    public function checkVies(bool $msg = true): bool
     {
         $codiso = Paises::get($this->getDefaultAddress()->codpais)->codiso ?? '';
-        return Vies::check($this->cifnif ?? '', $codiso) === 1;
+        return Vies::check($this->cifnif ?? '', $codiso, $msg) === 1;
     }
 
     public function clear()

--- a/Core/Model/Contacto.php
+++ b/Core/Model/Contacto.php
@@ -110,10 +110,10 @@ class Contacto extends Base\Contact
         }
     }
 
-    public function checkVies(): bool
+    public function checkVies(bool $msg = true): bool
     {
         $codiso = Paises::get($this->codpais)->codiso ?? '';
-        return Vies::check($this->cifnif ?? '', $codiso) === 1;
+        return Vies::check($this->cifnif ?? '', $codiso, $msg) === 1;
     }
 
     public function clear()

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -77,10 +77,10 @@ class Empresa extends Base\Contact
     /** @var string */
     public $web;
 
-    public function checkVies(): bool
+    public function checkVies(bool $msg = true): bool
     {
         $codiso = Paises::get($this->codpais)->codiso ?? '';
-        return Vies::check($this->cifnif ?? '', $codiso) === 1;
+        return Vies::check($this->cifnif ?? '', $codiso, $msg) === 1;
     }
 
     public function clear()

--- a/Core/Model/Proveedor.php
+++ b/Core/Model/Proveedor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -49,10 +49,10 @@ class Proveedor extends Base\ComercialContact
     /** @var int */
     public $idcontacto;
 
-    public function checkVies(): bool
+    public function checkVies(bool $msg = true): bool
     {
         $codiso = Paises::get($this->getDefaultAddress()->codpais)->codiso ?? '';
-        return Vies::check($this->cifnif ?? '', $codiso) === 1;
+        return Vies::check($this->cifnif ?? '', $codiso, $msg) === 1;
     }
 
     public function clear()


### PR DESCRIPTION
En ocasiones necesitamos llamar al VIES y obtener solo el código de respuesta sin mostrar el mensaje, como el caso de Ticketbai.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.