### PR TITLE
Tarea #2262 - Añadida excepción de iva al cliente e impuesto 0 cuando es exento

### DIFF
--- a/Core/Base/Calculator.php
+++ b/Core/Base/Calculator.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Base;
 
 use FacturaScripts\Core\Base\Contract\CalculatorModInterface;
+use FacturaScripts\Core\DataSrc\Impuestos;
 use FacturaScripts\Core\Lib\InvoiceOperation;
 use FacturaScripts\Core\Lib\ProductType;
 use FacturaScripts\Core\Lib\RegimenIVA;
@@ -218,8 +219,10 @@ final class Calculator
      */
     private static function apply(BusinessDocument &$doc, array &$lines): void
     {
+        $subject = $doc->getSubject();
         $sinIva = $doc->getSerie()->siniva;
-        $regimen = $doc->getSubject()->regimeniva ?? RegimenIVA::TAX_SYSTEM_GENERAL;
+        $excepcionIva = $subject->excepcioniva;
+        $regimen = $subject->regimeniva ?? RegimenIVA::TAX_SYSTEM_GENERAL;
         $company = $doc->getCompany();
 
         // cargamos las zonas de impuestos
@@ -259,8 +262,9 @@ final class Calculator
 
             // ¿La serie es sin impuestos o el régimen exento?
             if ($sinIva || $regimen === RegimenIVA::TAX_SYSTEM_EXEMPT) {
-                $line->codimpuesto = null;
+                $line->codimpuesto = Impuestos::get('IVA0')->codimpuesto;
                 $line->iva = $line->recargo = 0.0;
+                $line->excepcioniva = $excepcionIva;
                 continue;
             }
 

--- a/Core/Controller/EditCliente.php
+++ b/Core/Controller/EditCliente.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -222,11 +222,20 @@ class EditCliente extends ComercialContactController
             case $mainViewName:
                 parent::loadData($viewName, $view);
                 $this->loadLanguageValues($viewName);
+                $this->loadExceptionVat($viewName);
                 break;
 
             default:
                 parent::loadData($viewName, $view);
                 break;
+        }
+    }
+
+    protected function loadExceptionVat(string $viewName): void
+    {
+        $column = $this->views[$viewName]->columnForName('vat-exception');
+        if ($column && $column->widget->getType() === 'select') {
+            $column->widget->setValuesFromArrayKeys(RegimenIVA::allExceptions(), true, true);
         }
     }
 

--- a/Core/Model/Cliente.php
+++ b/Core/Model/Cliente.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -51,6 +51,9 @@ class Cliente extends Base\ComercialContact
 
     /** @var string */
     public $diaspago;
+
+    /** @var string */
+    public $excepcioniva;
 
     /** @var integer */
     public $idcontactoenv;

--- a/Core/Table/clientes.xml
+++ b/Core/Table/clientes.xml
@@ -58,6 +58,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>excepcioniva</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
         <name>email</name>
         <type>character varying(100)</type>
     </column>

--- a/Core/XMLView/EditCliente.xml
+++ b/Core/XMLView/EditCliente.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -119,13 +119,18 @@
             <column name="vat-regime" numcolumns="2" order="180">
                 <widget type="select" fieldname="regimeniva" required="true"/>
             </column>
-            <column name="retention" titleurl="ListImpuesto?activetab=ListRetencion" numcolumns="2" order="190">
+            <column name="vat-exception" order="190">
+                <widget type="select" fieldname="excepcioniva">
+                    <values/>
+                </widget>
+            </column>
+            <column name="retention" titleurl="ListImpuesto?activetab=ListRetencion" numcolumns="2" order="200">
                 <widget type="select" fieldname="codretencion" onclick="EditRetencion">
                     <values source="retenciones" fieldcode="codretencion" fieldtitle="descripcion"/>
                 </widget>
             </column>
             <column name="subaccount" description="customer-subaccount-p" titleurl="ListCuenta" display="none"
-                    numcolumns="2" order="200">
+                    numcolumns="2" order="210">
                 <widget type="text" fieldname="codsubcuenta" maxlength="15" icon="fas fa-balance-scale"/>
             </column>
         </group>


### PR DESCRIPTION
[Tarea #2262](https://facturascripts.com/roadmap/EditTask?code=2262)

Cuando un cliente tiene un regimen exento el iva de las líneas en los documentos debe ser 0, no null. Además si el iva de la línea es 0, debería tener una excepción de iva, que se puede configurar en el producto, pero ahora también en el cliente.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.