### PR TITLE
corregir ordenar lineas documentos

### DIFF
--- a/Core/Base/AjaxForms/SalesLineHTML.php
+++ b/Core/Base/AjaxForms/SalesLineHTML.php
@@ -178,7 +178,7 @@ class SalesLineHTML
     {
         self::$num++;
         $idlinea = $line->idlinea ?? 'n' . self::$num;
-        return '<div class="container-fluid"><div class="form-row align-items-center border-bottom pb-3 pb-lg-0">'
+        return '<div class="container-fluid fs-line"><div class="form-row align-items-center border-bottom pb-3 pb-lg-0">'
             . self::renderField($i18n, $idlinea, $line, $model, 'referencia')
             . self::renderField($i18n, $idlinea, $line, $model, 'descripcion')
             . self::renderField($i18n, $idlinea, $line, $model, 'cantidad')
@@ -555,7 +555,7 @@ class SalesLineHTML
 
     private static function renderTitles(Translator $i18n, SalesDocument $model): string
     {
-        return '<div class="container-fluid d-none d-lg-block"><div class="form-row border-bottom">'
+        return '<div class="container-fluid d-none d-lg-block titles"><div class="form-row border-bottom">'
             . self::renderTitle($i18n, $model, 'referencia')
             . self::renderTitle($i18n, $model, 'descripcion')
             . self::renderTitle($i18n, $model, 'cantidad')

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -287,12 +287,24 @@
                 setOrdenLines();
             }
         });
+        $("#salesFormLines").sortable("option", "items", "> .fs-line");
         $("#salesFormLines").sortable("option", "disabled", false);
+        $("#salesFormLines").sortable("option", "cursor", "move");
+        $("#salesFormLines").sortable("option", "cancel", "null");
+        $("#salesFormLines").sortable("option", "cancel", ".titles");
+        $("#salesFormLines").sortable("option", "axis", "y");
+
+        $("#salesFormLines .fs-line").css('cursor', 'grab');
+        $("#salesFormLines .fs-line :input").css('cursor', 'grab');
+
         $("#salesFormLines").disableSelection();
     }
 
     function sortableDisable() {
         $("#salesFormLines").sortable("disable");
+
+        $("#salesFormLines .fs-line").css('cursor', 'default');
+        $("#salesFormLines .fs-line :input").css('cursor', 'default');
     }
 
     $(document).on('keyup', '.doc-line-desc', function (e) {


### PR DESCRIPTION
# Descripción

- $("#salesFormLines").sortable("option", "items", "> .fs-line");
con esto limitamos que los elementos ordenables dentro de #salesFormLines sean las líneas.

- $("#salesFormLines").sortable("option", "cursor", "move");
con esto mostramos el cursor del ratón con una cruz de movimiento cuando se están ordenando las líneas

- $("#salesFormLines").sortable("option", "cancel", "null");
- $("#salesFormLines").sortable("option", "cancel", ".titles");
con estas dos líneas evitamos que al pulsar sobre un input se habilite para poder escribir sin dejarnos ordenar. también evitamos que se pueda seleccionar la linea de titulos.

- $("#salesFormLines").sortable("option", "axis", "y");
con esto permitimos que se muevan las líneas solo en el eje y

- $("#salesFormLines .fs-line").css('cursor', 'grab');
- $("#salesFormLines .fs-line :input").css('cursor', 'grab');
con estas dos líneas cuando habilitamos el sortable, mostramos el cursor del ratón con una manita que invita a coger las líneas y moverlas.

## ANTES

![captura_pantalla_antes](https://github.com/NeoRazorX/facturascripts/assets/2836337/07b960cf-89c1-42f5-ac06-be6b53a405e1)


## DESPUES

![captura_pantalla_despues](https://github.com/NeoRazorX/facturascripts/assets/2836337/399f546b-9234-405d-8687-99f448d1859e)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.

