### PR TITLE
Corregido bug al comprobar las tablas en los JoinModel

### DIFF
--- a/Core/Model/Base/JoinModel.php
+++ b/Core/Model/Base/JoinModel.php
@@ -252,6 +252,11 @@ abstract class JoinModel
                 continue;
             }
 
+            // comprobamos si existe la tabla
+            if (false === in_array($arrayField[0], $this->getTables())) {
+                continue;
+            }
+
             // consultamos la información de la tabla para obtener el tipo
             $columns = self::$dataBase->getColumns($arrayField[0]);
             if (isset($columns[$arrayField[1]])) {


### PR DESCRIPTION
En la última del core los JoinModel están fallando porque no se comprueba si existe la tabla en el JoinModel.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.