### PR TITLE
Tarea #3007 - evitar bucle infinito al guardar logs database

### DIFF
--- a/Core/Base/MiniLogStorage.php
+++ b/Core/Base/MiniLogStorage.php
@@ -40,6 +40,7 @@ final class MiniLogStorage implements MiniLogStorageInterface
             }
 
             // guardamos el resto
+            MiniLog::$saving = true;
             $logItem = new LogMessage();
             $logItem->channel = $item['channel'];
             $logItem->context = json_encode($item['context']);
@@ -55,6 +56,7 @@ final class MiniLogStorage implements MiniLogStorageInterface
             if (false === $logItem->save()) {
                 $done = false;
             }
+            MiniLog::$saving = false;
         }
 
         return $done;


### PR DESCRIPTION
# Descripción
- Se puede producir un bucle al ejecutar más de 5000 consultas SQL, ya que estas se añaden como debug al canal database y cada 5000 entradas se guarda en la base de datos, lo que hace que se vuelvan a añadir consultas SQL.

- Con la flag MiniLog::$saving evitamos que se incluyan logs de debug nuevos que hacen el bucle infinito.
- Mientras MiniLog::$saving esta a true se guardan los logs en una variable temporal MiniLog::$tempData
- Cuando se termina de guardar el log principal, entonces se guardan los logs de debug database que se han ido generando mientras(begin transaction, insert, commit, etc)(que realmente no se llegan a guardar en la base de datos porque se excluyen)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
