### PR TITLE
agregar-custom_resources-a-EditApiKey

### DIFF
--- a/Core/Controller/ApiRoot.php
+++ b/Core/Controller/ApiRoot.php
@@ -26,7 +26,7 @@ use FacturaScripts\Core\Tools;
 class ApiRoot extends ApiController
 {
     /** @var array */
-    private static $custom_resources = ['crearFacturaCliente'];
+    public static $custom_resources = ['crearFacturaCliente'];
 
     public static function addCustomResource(string $name): void
     {

--- a/Core/Controller/ApiRoot.php
+++ b/Core/Controller/ApiRoot.php
@@ -26,7 +26,7 @@ use FacturaScripts\Core\Tools;
 class ApiRoot extends ApiController
 {
     /** @var array */
-    public static $custom_resources = ['crearFacturaCliente'];
+    private static $custom_resources = ['crearFacturaCliente'];
 
     public static function addCustomResource(string $name): void
     {
@@ -44,6 +44,11 @@ class ApiRoot extends ApiController
         sort($json['resources']);
 
         $this->response->setContent(json_encode($json));
+    }
+
+    public static function getCustomResources(): array
+    {
+        return self::$custom_resources;
     }
 
     protected function getResourcesMap(): array

--- a/Core/Controller/EditApiKey.php
+++ b/Core/Controller/EditApiKey.php
@@ -185,7 +185,7 @@ class EditApiKey extends EditController
         }
 
         // agregamos los recursos custom y de los plugins
-        $resources = array_merge($resources, ApiRoot::$custom_resources);
+        $resources = array_merge($resources, ApiRoot::getCustomResources());
 
         sort($resources);
         return $resources;

--- a/Core/Controller/EditApiKey.php
+++ b/Core/Controller/EditApiKey.php
@@ -184,6 +184,9 @@ class EditApiKey extends EditController
             }
         }
 
+        // agregamos los recursos custom y de los plugins
+        $resources = array_merge($resources, ApiRoot::$custom_resources);
+
         sort($resources);
         return $resources;
     }


### PR DESCRIPTION
# Descripción
- Estoy desarrollando un plugin donde estoy añadiendo un endpoint a la api, pero la api key para usar este plugin quiero que solo tenga acceso de lectura al controlador expuesto. Actualmente tienes que poner "acceso completo" para que se pueda acceder al recurso de un plugin.
- Actualmente no aparece el recurso "custom" del plugin en el controlador EditApiKey ya que solo recupera los recursos del directorio Lib/API y de los modelos por el metodo getResourcesFromFolder de la clase APIModel. y por tanto no agrega los recursos añadidos por los plugins con el metodo ApiRoot::addCustomResource('xxxx');
- Por lo que hemos cambiado la propiedad $custom_resources a publica para poder acceder desde el EditApiKey y que aparezcan en el listado de permisos de recursos.
- De esta forma para una apikey doy permiso SOLO al recurso de mi plugin

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
