### PR TITLE
Permitir enviar archivos desde la clase Http

### DIFF
--- a/Core/Http.php
+++ b/Core/Http.php
@@ -247,14 +247,14 @@ class Http
             case 'POST':
                 curl_setopt($ch, CURLOPT_POST, 1);
                 curl_setopt($ch, CURLOPT_URL, $this->url);
-                $postFields = is_array($this->data) ? http_build_query($this->data) : $this->data;
+                $postFields = $this->getPostFields();
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
                 break;
 
             case 'PUT':
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 curl_setopt($ch, CURLOPT_URL, $this->url);
-                $postFields = is_array($this->data) ? http_build_query($this->data) : $this->data;
+                $postFields = $this->getPostFields();
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
                 break;
 
@@ -285,5 +285,24 @@ class Http
         curl_close($ch);
 
         $this->executed = true;
+    }
+
+    protected function getPostFields()
+    {
+        // si en el header existe "multipart/form-data"
+        // entonces no se codifica en json
+        if (array_key_exists('Content-Type', $this->headers)) {
+            $contentType = $this->headers['Content-Type'];
+            if (false !== strpos($contentType, 'multipart/form-data')) {
+                return $this->data;
+            }
+        }
+
+        // si data es un array, lo codificamos en json
+        if (is_array($this->data)) {
+            return http_build_query($this->data);
+        }
+
+        return $this->data;
     }
 }


### PR DESCRIPTION
En ocasiones necesitamos poder enviar archivos en nuestras llamadas post, para eso necesitamos adjuntar el array con los datos, pero no debemos convertirlo. Con este cambio solucionamos el problema y damos la posibilidad de enviar CURLfile()

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.