### PR TITLE
Tarea #3396 - agrupar paginas con el mismo submenu

### DIFF
--- a/Core/Controller/EditRole.php
+++ b/Core/Controller/EditRole.php
@@ -44,6 +44,7 @@ class EditRole extends EditController
         foreach ($this->getAllPages() as $page) {
             $rules[$page->name] = [
                 'menu' => $i18n->trans($page->menu),
+                'submenu' => $i18n->trans($page->submenu),
                 'page' => $i18n->trans($page->title),
                 'show' => false,
                 'onlyOwner' => false,
@@ -62,6 +63,14 @@ class EditRole extends EditController
             $rules[$roleAccess->pagename]['export'] = $roleAccess->allowexport;
             $rules[$roleAccess->pagename]['import'] = $roleAccess->allowimport;
         }
+
+        // ordenamos el array primero por nombre del menu,
+        // segundo por nombre del submenu
+        // y tercero por nombre de la pagina
+        $menuColumn = array_column($rules, 'menu');
+        $pageColumn = array_column($rules, 'page');
+        $submenuColumn = array_column($rules, 'submenu');
+        array_multisort($menuColumn, SORT_ASC, $submenuColumn, SORT_ASC, $pageColumn, SORT_ASC, $rules);
 
         return $rules;
     }

--- a/Core/View/Tab/RoleAccess.html.twig
+++ b/Core/View/Tab/RoleAccess.html.twig
@@ -117,7 +117,7 @@
                     {% endif %}
                     <tr class="d-none tr{{menu}}" >
                         <td>
-                            {{ ' » ' ~ rule.page }}
+                            {{ ((rule.submenu is not empty) ? ' » ' ~ rule.submenu : '') ~ ' » ' ~ rule.page }}
                             {% if 'List' in pageName %}
                                 <span class="badge badge-info ml-1">{{ trans('list') }}</span>
                             {% endif %}


### PR DESCRIPTION
# Descripción
- Actualmente en la pagina de asignar los roles, aparecen las paginas desordenadas y las que tienen submenu no aparecen agrupadas.

- Hemos ordenado el array $rules para que se ordene primero por nombre del menú, segundo por el nombre del submenu y por ultimo por el nombre de la página. De esta forma aparecen agrupadas las paginas que tiene el mismo submenu.

![imagen](https://github.com/NeoRazorX/facturascripts/assets/2836337/8e3ca2e7-cd52-452d-98e2-4fb02335eabe)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
