### PR TITLE
descargar e instalar plugin automaticamente

### DIFF
--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -246,8 +246,8 @@
                 </div>
                 <div class="card-footer p-2">
                     {% set extraBtnClass = plugin.health > 2 ? 'btn-outline-success' : plugin.health == 0 ? 'btn-outline-danger' : 'btn-outline-warning' %}
-                    <a href="{{ plugin.url }}" class="btn {{ extraBtnClass }}"
-                       target="_blank">{{ trans('add') }}</a>
+                    <a href="{{ plugin.url ~ ((plugin.price > 0) ? '' : '&multireqtoken=' ~ formToken(false)) }}" class="btn {{ extraBtnClass }}"
+                       target="{{ plugin.price > 0 ? '_blank' : '' }}">{{ trans('add') }}</a>
                     <span class="ml-2 text-danger" title="{{ trans('health') }}">
                         {{ _self.healthStatus(plugin.health) }}
                     </span>


### PR DESCRIPTION
# Descripción
- se implementa el metodo/accion installPluginAction() para reducir los pasos para instalar los plugins gratuitos.
- ahora cuando se pulsa en el boton Añadir de un plugin gratuito, el sistema descarga la ultima versión estable del plugin, descomprime el zip e instala el plugin, dejándolo listo para su activación.

![Animation](https://github.com/NeoRazorX/facturascripts/assets/2836337/c9be201d-5978-4997-93bc-63ce9952513f)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
