### PR TITLE
Tarea #862 - agregar columnas desde plugins

### DIFF
--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Lib\PDF;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Base\ExtensionsTrait;
 use FacturaScripts\Core\Base\Utils;
 use FacturaScripts\Core\Model\Base\BusinessDocument;
 use FacturaScripts\Core\Tools;
@@ -47,6 +48,8 @@ use FacturaScripts\Dinamic\Model\ReciboCliente;
  */
 abstract class PDFDocument extends PDFCore
 {
+    use ExtensionsTrait;
+
     const INVOICE_TOTALS_Y = 200;
 
     /** @var FormatoDocumento */
@@ -161,7 +164,7 @@ abstract class PDFDocument extends PDFCore
 
     protected function getLineHeaders(): array
     {
-        return [
+        $lineHeaders = [
             'referencia' => ['type' => 'text', 'title' => $this->i18n->trans('reference') . ' - ' . $this->i18n->trans('description')],
             'cantidad' => ['type' => 'number', 'title' => $this->i18n->trans('quantity')],
             'pvpunitario' => ['type' => 'number', 'title' => $this->i18n->trans('price')],
@@ -172,6 +175,10 @@ abstract class PDFDocument extends PDFCore
             'recargo' => ['type' => 'percentage', 'title' => $this->i18n->trans('re')],
             'irpf' => ['type' => 'percentage', 'title' => $this->i18n->trans('irpf')]
         ];
+
+        $lineHeaders = $this->pipe('getLineHeaders', $lineHeaders) ?? $lineHeaders;
+
+        return $lineHeaders;
     }
 
     /**


### PR DESCRIPTION
# Descripción
- mostrar columnas agregadas desde plugins en el pdf al imprimir. Dichas columnas ahora mismo solo se podrían añadir con herencia sobre PDFDocument, por lo que otro plugin al realizar herencia sobre el mismo archivo estaría ocultando las otras columnas del otro plugin.

se debe implementar de la siguiente forma:

en el Init.php
```php
public function init(): void
{
    $this->loadExtension(new Extension\Lib\PDF\PDFDocument());
}
```
y en la extension seria así:
```php
class PDFDocument
{
    public function getLineHeaders(): Closure
    {
        return function ($lineHeaders) {

            $newHeader = ['coste' => ['type' => 'number', 'title' => Tools::lang()->trans('cost')]];

            // Definimos la posición de la columna
            $position = 3;
            // Dividimos el array original en dos partes según la posicion donde queremos incluirlo
            $lineHeadersBefore = array_slice($lineHeaders, 0, $position, true);
            $lineHeadersAfter = array_slice($lineHeaders, $position, null, true);
            // Insertar el nuevo header entre los dos arrays divididos
            $lineHeaders = $lineHeadersBefore + $newHeader + $lineHeadersAfter;

            return $lineHeaders;
        };
    }
}
```
## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [] He ejecutado los tests unitarios.
