### PR TITLE
Mejora para devolver los archivos guardados en openAI

### DIFF
--- a/Core/Lib/OpenAi.php
+++ b/Core/Lib/OpenAi.php
@@ -169,7 +169,12 @@ class OpenAi
             return [];
         }
 
-        return $response->json();
+        $json = $response->json();
+        if (empty($json) || empty($json['data'])) {
+            return [];
+        }
+
+        return $json['data'];
     }
 
     public function fileRead(string $id_file): array


### PR DESCRIPTION
Pequeña mejora para obtener los archivos guardado en openAI sin tener que estar comprobando en cada uso el parámetro data, la función ya devuelve el array de archivos preparado.