### PR TITLE
Tarea #1835 - agregar valores por defecto en instalador

### DIFF
--- a/Core/Controller/Installer.php
+++ b/Core/Controller/Installer.php
@@ -225,9 +225,13 @@ class Installer implements ControllerInterface
         fwrite($file, "define('FS_DB_USER', '" . $this->db_user . "');\n");
         fwrite($file, "define('FS_DB_PASS', '" . $this->request->request->get('fs_db_pass') . "');\n");
 
-        $fields = ['lang', 'timezone', 'hidden_plugins'];
-        foreach ($fields as $field) {
-            fwrite($file, "define('FS_" . strtoupper($field) . "', '" . $this->request->request->get('fs_' . $field, '') . "');\n");
+        $fields = [
+            'lang' => 'es_ES',
+            'timezone' => 'Europe/Madrid',
+            'hidden_plugins' => ''
+        ];
+        foreach ($fields as $field => $default) {
+            fwrite($file, "define('FS_" . strtoupper($field) . "', '" . $this->request->request->get('fs_' . $field, $default) . "');\n");
         }
 
         $booleanFields = ['debug', 'disable_add_plugins', 'disable_rm_plugins'];


### PR DESCRIPTION
# Descripción
- El instalador puede que no detecte la zona horaria y se quede en blanco, por lo que fallará después.
- Hemos incluido valores por defecto, para que en el caso que lleguen los valores del formulario en blanco, tome los valores por defecto y no genere errores en un futuro.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
