### PR TITLE
Tarea #2519 - evitar forma de pago de distinta empresa

### DIFF
--- a/Core/Model/Base/BusinessDocument.php
+++ b/Core/Model/Base/BusinessDocument.php
@@ -443,6 +443,14 @@ abstract class BusinessDocument extends ModelOnChangeClass
             return false;
         }
 
+        // check paymethod
+        $idCompanyPaymentMethod = $this->getPaymentMethod()->idempresa;
+        $idCompanyWhareHouse = (new Almacen())->get($this->codalmacen)->idempresa;
+        if($idCompanyPaymentMethod != $idCompanyWhareHouse){
+            Tools::log()->error('bad-paymentmethod-error');
+            return false;
+        }
+
         /**
          * We use the euro as a bridge currency when adding, compare
          * or convert amounts in several currencies. For this reason we need

--- a/Core/Model/Empresa.php
+++ b/Core/Model/Empresa.php
@@ -28,6 +28,7 @@ use FacturaScripts\Dinamic\Lib\RegimenIVA;
 use FacturaScripts\Dinamic\Model\Almacen as DinAlmacen;
 use FacturaScripts\Dinamic\Model\CuentaBanco as DinCuentaBanco;
 use FacturaScripts\Dinamic\Model\Ejercicio as DinEjercicio;
+use FacturaScripts\Dinamic\Model\FormaPago as DinFormaPago;
 
 /**
  * This class stores the main data of the company.
@@ -128,6 +129,18 @@ class Empresa extends Base\Contact
         $exercise = new DinEjercicio();
         $where = [new DataBaseWhere($this->primaryColumn(), $this->primaryColumnValue())];
         return $exercise->all($where, [], 0, 0);
+    }
+    
+    /**
+     * Devuelve los metodos de pago de la empresa.
+     *
+     * @return array
+     */
+    public function getPaymentMethods(): array
+    {
+        $payMethod = new DinFormaPago();
+        $where = [new DataBaseWhere($this->primaryColumn(), $this->primaryColumnValue())];
+        return $payMethod->all($where, [], 0, 0);
     }
 
     /**

--- a/Test/Core/Model/AlbaranClienteTest.php
+++ b/Test/Core/Model/AlbaranClienteTest.php
@@ -256,6 +256,7 @@ final class AlbaranClienteTest extends TestCase
 
         // creamos un albarán
         $doc = new AlbaranCliente();
+        $doc->codpago = $company2->getPaymentMethods()[0]->codpago;
         $doc->setSubject($subject);
         $doc->codalmacen = $warehouse->codalmacen;
         $this->assertTrue($doc->save(), 'albaran-cant-save');

--- a/Test/Core/Model/AlbaranProveedorTest.php
+++ b/Test/Core/Model/AlbaranProveedorTest.php
@@ -250,6 +250,7 @@ final class AlbaranProveedorTest extends TestCase
 
         // creamos un albarán y le asignamos el proveedor y el almacén
         $doc = new AlbaranProveedor();
+        $doc->codpago = $company2->getPaymentMethods()[0]->codpago;
         $doc->setSubject($subject);
         $doc->codalmacen = $warehouse->codalmacen;
         $this->assertTrue($doc->save(), 'albaran-cant-save');

--- a/Test/Core/Model/EjercicioCierreTest.php
+++ b/Test/Core/Model/EjercicioCierreTest.php
@@ -70,10 +70,14 @@ final class EjercicioCierreTest extends TestCase
 
         // creamos una factura de compra con fecha 04-01-2020
         $facturaCompra = $this->getRandomSupplierInvoice('2020-01-04', $almacen->codalmacen);
+        $facturaCompra->codpago = $empresa->getPaymentMethods()[0]->codpago;
+        $facturaCompra->save();
         $this->assertTrue($facturaCompra->exists());
 
         // creamos una factura de venta con fecha 05-01-2020
         $facturaVenta = $this->getRandomCustomerInvoice('2020-01-05', $almacen->codalmacen);
+        $facturaVenta->codpago = $empresa->getPaymentMethods()[0]->codpago;
+        $facturaVenta->save();
         $this->assertTrue($facturaVenta->exists());
 
         // cerramos el ejercicio

--- a/Test/Core/Model/FacturaClienteTest.php
+++ b/Test/Core/Model/FacturaClienteTest.php
@@ -448,6 +448,7 @@ final class FacturaClienteTest extends TestCase
 
         // creamos la factura
         $invoice = new FacturaCliente();
+        $invoice->codpago = $company->getPaymentMethods()[0]->codpago;
         foreach ($company->getWarehouses() as $warehouse) {
             $invoice->setWarehouse($warehouse->codalmacen);
             break;
@@ -805,6 +806,7 @@ final class FacturaClienteTest extends TestCase
 
         // creamos una factura
         $invoice = new FacturaCliente();
+        $invoice->codpago = $company->getPaymentMethods()[0]->codpago;
         foreach ($company->getWarehouses() as $warehouse) {
             $invoice->setWarehouse($warehouse->codalmacen);
             break;

--- a/Test/Core/Model/FacturaProveedorTest.php
+++ b/Test/Core/Model/FacturaProveedorTest.php
@@ -354,6 +354,7 @@ final class FacturaProveedorTest extends TestCase
 
         // creamos la factura
         $invoice = new FacturaProveedor();
+        $invoice->codpago = $company->getPaymentMethods()[0]->codpago;
         foreach ($company->getWarehouses() as $warehouse) {
             $invoice->setWarehouse($warehouse->codalmacen);
             break;
@@ -649,6 +650,7 @@ final class FacturaProveedorTest extends TestCase
 
         // creamos una factura
         $invoice = new FacturaProveedor();
+        $invoice->codpago = $company->getPaymentMethods()[0]->codpago;
         foreach ($company->getWarehouses() as $warehouse) {
             $invoice->setWarehouse($warehouse->codalmacen);
             break;

--- a/Test/Core/Model/PedidoClienteTest.php
+++ b/Test/Core/Model/PedidoClienteTest.php
@@ -247,6 +247,7 @@ final class PedidoClienteTest extends TestCase
 
         // creamos un pedido y le asignamos el cliente y el almacén
         $doc = new PedidoCliente();
+        $doc->codpago = $company2->getPaymentMethods()[0]->codpago;
         $doc->setSubject($subject);
         $doc->codalmacen = $warehouse->codalmacen;
         $this->assertTrue($doc->save(), 'pedido-cant-save');

--- a/Test/Core/Model/PedidoProveedorTest.php
+++ b/Test/Core/Model/PedidoProveedorTest.php
@@ -253,6 +253,7 @@ final class PedidoProveedorTest extends TestCase
 
         // creamos un pedido
         $doc = new PedidoProveedor();
+        $doc->codpago = $company2->getPaymentMethods()[0]->codpago;
         $doc->setSubject($subject);
         $doc->codalmacen = $warehouse->codalmacen;
         $this->assertTrue($doc->save(), 'pedido-cant-save');

--- a/Test/Core/Model/PresupuestoClienteTest.php
+++ b/Test/Core/Model/PresupuestoClienteTest.php
@@ -265,6 +265,7 @@ final class PresupuestoClienteTest extends TestCase
 
         // creamos un presupuesto y le asignamos el cliente y el almacén
         $doc = new PresupuestoCliente();
+        $doc->codpago = $company2->getPaymentMethods()[0]->codpago;
         $doc->setSubject($subject);
         $doc->codalmacen = $warehouse->codalmacen;
         $this->assertTrue($doc->save(), 'presupuesto-cant-save');

--- a/Test/Core/Model/PresupuestoProveedorTest.php
+++ b/Test/Core/Model/PresupuestoProveedorTest.php
@@ -269,6 +269,7 @@ final class PresupuestoProveedorTest extends TestCase
 
         // creamos un presupuesto en la empresa 2 y le asignamos el proveedor
         $doc = new PresupuestoProveedor();
+        $doc->codpago = $company2->getPaymentMethods()[0]->codpago;
         $doc->setSubject($subject);
         $doc->codalmacen = $warehouse->codalmacen;
         $this->assertTrue($doc->save(), 'presupuesto-cant-save');


### PR DESCRIPTION
# Descripción
- Al guardar un documento, ahora se comprueba de la forma de pago elegida pertenece a la empresa del documento.
- Se implementan tests que comprueban esta circunstancia.
- Se añade el metodo `getPaymentMethods()` a la clase Empresa para usarlo en los tests(y en futuras implementaciones) ya que con esta modificación muchos tests fallaban al obtener el método de pago del Subject que pertenecía a la empresa principal del test y no a una empresa diferente a la empresa por defecto de los tests.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
