### PR TITLE
Permite crear un widget file múltiple

### DIFF
--- a/Core/Lib/Widget/WidgetFile.php
+++ b/Core/Lib/Widget/WidgetFile.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2022 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -31,10 +31,11 @@ use Symfony\Component\HttpFoundation\Request;
 class WidgetFile extends BaseWidget
 {
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $accept;
+
+    /** @var bool */
+    public $multiple;
 
     /**
      * @param array $data
@@ -43,6 +44,7 @@ class WidgetFile extends BaseWidget
     {
         parent::__construct($data);
         $this->accept = $data['accept'] ?? '';
+        $this->multiple =  isset($data['multiple']) && $data['multiple'] == true;
     }
 
     /**
@@ -131,6 +133,12 @@ class WidgetFile extends BaseWidget
     protected function inputHtml($type = 'file', $extraClass = '')
     {
         $class = empty($extraClass) ? $this->css('form-control-file') : $this->css('form-control-file') . ' ' . $extraClass;
+
+        if ($this->multiple) {
+            return '<input type="' . $type . '" name="' . $this->fieldname . '[]" value="' . $this->value
+                . '" class="' . $class . '"' . $this->inputHtmlExtraParams() . ' multiple/>';
+        }
+
         return '<input type="' . $type . '" name="' . $this->fieldname . '" value="' . $this->value
             . '" class="' . $class . '"' . $this->inputHtmlExtraParams() . '/>';
     }


### PR DESCRIPTION
El widgetFile ya recoge todos los archivos cargados desde el html, pero no existía la posibilidad de decirle que es un html file múltiple, con este cambio añadimos la posibilidad, ya que el guardado de archivos múltiples ya está implementado pero no se podía usar.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.