### PR TITLE
WidgetDatalist no sensible a acentos

### DIFF
--- a/Core/Lib/Widget/WidgetDatalist.php
+++ b/Core/Lib/Widget/WidgetDatalist.php
@@ -49,8 +49,8 @@ class WidgetDatalist extends WidgetSelect
 
         $list = $this->fieldname . '-list-' . $this->getUniqueId();
         $html = '<input type="text" name="' . $this->fieldname . '" value="' . $this->value . '"'
+            . ' id="input-' . $list . '"'
             . ' class="' . $class . '"'
-            . ' list="' . $list . '"'
             . $this->inputHtmlExtraParams()
             . ' parent="' . $this->parent . '"'
             . ' data-field="' . $this->fieldname . '"'
@@ -61,12 +61,8 @@ class WidgetDatalist extends WidgetSelect
             . ' data-limit="' . $this->limit . '"'
             . '/>';
 
-        $html .= '<datalist id="' . $list . '">';
-        foreach ($this->values as $option) {
-            $title = empty($option['title']) ? $option['value'] : $option['title'];
-            $html .= '<option value="' . $title . '" />';
-        }
-        $html .= '</datalist>';
+        $html .= $this->generateAutocompleteScript($list);
+
         return $html;
     }
 
@@ -88,5 +84,38 @@ class WidgetDatalist extends WidgetSelect
             $values = static::$codeModel->all($this->source, $this->fieldcode, $this->fieldtitle, false);
             $this->setValuesFromCodeModel($values, $this->translate);
         }
+    }
+
+    /**
+     * Genera el script de autocomplete para el campo input.
+     *
+     * @param $list
+     * @return string
+     */
+    protected function generateAutocompleteScript($list)
+    {
+        $options = array_map(function ($option) {
+            return empty($option['title']) ? $option['value'] : $option['title'];
+        }, $this->values);
+
+        $optionsJson = json_encode($options, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+
+        return '<script>
+            $(document).ready(function() {
+                const options = ' . $optionsJson . ';
+    
+                $("#input-' . htmlspecialchars($list, ENT_QUOTES, 'UTF-8') . '").autocomplete({
+                    minLength: 3,               
+                    source: function(request, response) {
+                        const term = request.term.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+                        const matches = options.filter(option => {
+                            const normalizedOption = option.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+                            return normalizedOption.includes(term);
+                        });
+                        response(matches);
+                    }
+                });
+            });
+        </script>';
     }
 }


### PR DESCRIPTION
# Descripción
- Se cambia el datalist por el Jquery Autocomplete.
- Se normalizan los valores del input para mostrar las coincidencias sin que sea sensible a los acentos.

![Animation](https://github.com/NeoRazorX/facturascripts/assets/2836337/63957c5e-398a-47fe-bfd6-c7ea69465654)

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
