### PR TITLE
Bug comparacion con ceros a la izquierda

### DIFF
--- a/Core/Model/Producto.php
+++ b/Core/Model/Producto.php
@@ -386,7 +386,7 @@ class Producto extends ModelClass
         }
 
         // si hay cambios, actualizamos el producto
-        if ($newPrecio != $this->precio || $newReferencia != $this->referencia) {
+        if ($newPrecio != $this->precio || strcmp($newReferencia, $this->referencia) !== 0) {
             $this->precio = $newPrecio;
             $this->referencia = $newReferencia;
             $this->save();

--- a/Test/Core/Model/ProductoTest.php
+++ b/Test/Core/Model/ProductoTest.php
@@ -666,6 +666,9 @@ final class ProductoTest extends TestCase
 
         // comprobamos que se haya actualizado la referencia en el producto
         $this->assertEquals('01', $product->referencia);
+
+        // eliminamos
+        $this->assertTrue($product->delete(), 'product-cant-delete');
     }
 
     private function getTestProduct(): Producto

--- a/Test/Core/Model/ProductoTest.php
+++ b/Test/Core/Model/ProductoTest.php
@@ -649,6 +649,25 @@ final class ProductoTest extends TestCase
         $this->assertTrue($model->delete(), 'can-not-delete-file');
     }
 
+    public function testDetectChangesWithLeadingZeroes(): void
+    {
+        // creamos un producto
+        $product = $this->getTestProduct();
+        $product->referencia = "0001";
+        $this->assertTrue($product->save(), 'product-cant-save');
+
+        // eliminamos dos ceros a la referencia de la variante
+        $variante = $product->getVariants()[0];
+        $variante->referencia = '01';
+        $variante->save();
+
+        // refrescamos los datos desde la base de datos
+        $product->loadFromCode($product->idproducto);
+
+        // comprobamos que se haya actualizado la referencia en el producto
+        $this->assertEquals('01', $product->referencia);
+    }
+
     private function getTestProduct(): Producto
     {
         $product = new Producto();


### PR DESCRIPTION
# Descripción
- Actualmente no se detectaba que existían cambios en una referencia de una variante cuando se comparaba por ejemplo `01 != 001`, y por lo tanto no se actualizaba la referencia en el producto.

- Usando la función `strcmp()` se comparan los dos string incluyendo los ceros a la izquierda.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
