### PR TITLE
Tarea #2938 - agregar indices a tablas y renombrar columnas

### DIFF
--- a/Core/Base/DataBase.php
+++ b/Core/Base/DataBase.php
@@ -296,13 +296,34 @@ final class DataBase
      *
      * @return array
      */
-    public function getIndexes(string $tableName): array
+    public function getAllIndexes(string $tableName): array
     {
         $result = [];
         $data = $this->select(self::$engine->getSQL()->sqlIndexes($tableName));
         foreach ($data as $row) {
-            $result[] = ['name' => $row['Key_name'] ?? $row['key_name'] ?? ''];
+            $result[] = [
+                'name' => $row['Key_name'] ?? $row['key_name'] ?? '',
+                'column' => $row['Column_name'] ?? $row['column_name'] ?? '',
+            ];
         }
+
+        return $result;
+    }
+
+    /**
+     * Returns an array with the FacturaScripts indexes of a given table.
+     *
+     * @param string $tableName
+     *
+     * @return array
+     */
+    public function getIndexes(string $tableName): array
+    {
+        $result =  array_filter($this->getAllIndexes($tableName), function ($dbIdx) {
+            return false !== strpos($dbIdx['name'], 'fs_');
+        });
+
+        $result = array_values($result);
 
         return $result;
     }

--- a/Core/Base/DataBase/DataBaseQueries.php
+++ b/Core/Base/DataBase/DataBaseQueries.php
@@ -121,10 +121,11 @@ interface DataBaseQueries
      * @param string $tableName
      * @param array $columns
      * @param array $constraints
+     * @param array $indexes
      *
      * @return string
      */
-    public function sqlCreateTable(string $tableName, array $columns, array $constraints): string;
+    public function sqlCreateTable(string $tableName, array $columns, array $constraints, array $indexes): string;
 
     /**
      * SQL statement to delete a given table column's constraint

--- a/Core/Base/DataBase/MysqlQueries.php
+++ b/Core/Base/DataBase/MysqlQueries.php
@@ -82,6 +82,11 @@ class MysqlQueries implements DataBaseQueries
         return $colData['type'] === 'serial' ? '' : $this->sqlAlterModifyColumn($tableName, $colData);
     }
 
+    public function sqlAddIndex(string $tableName, string $indexName, string $columns): string
+    {
+        return 'CREATE INDEX ' . $indexName . ' ON ' . $tableName . ' (' . $columns . ');';
+    }
+
     /**
      * SQL statement to alter a null constraint in a table column
      *
@@ -173,10 +178,11 @@ class MysqlQueries implements DataBaseQueries
      * @param string $tableName
      * @param array $columns
      * @param array $constraints
+     * @param array $indexes
      *
      * @return string
      */
-    public function sqlCreateTable(string $tableName, array $columns, array $constraints): string
+    public function sqlCreateTable(string $tableName, array $columns, array $constraints, array $indexes): string
     {
         $fields = '';
         foreach ($columns as $col) {
@@ -189,7 +195,8 @@ class MysqlQueries implements DataBaseQueries
         $collate = defined('FS_MYSQL_COLLATE') ? FS_MYSQL_COLLATE : 'utf8_bin';
         return 'CREATE TABLE ' . $tableName . ' (' . $sql
             . $this->sqlTableConstraints($constraints) . ') '
-            . 'ENGINE=InnoDB DEFAULT CHARSET=' . $charset . ' COLLATE=' . $collate . ';';
+            . 'ENGINE=InnoDB DEFAULT CHARSET=' . $charset . ' COLLATE=' . $collate . ';'
+            . $this->sqlTableIndexes($tableName, $indexes);
     }
 
     /**
@@ -213,6 +220,11 @@ class MysqlQueries implements DataBaseQueries
             default:
                 return '';
         }
+    }
+
+    public function sqlDropIndex(string $tableName, array $colData): string
+    {
+        return 'DROP INDEX IF EXISTS ' . $colData['name'] . ' ON ' . $tableName . ';';
     }
 
     /**
@@ -267,6 +279,16 @@ class MysqlQueries implements DataBaseQueries
         }
 
         return $this->fixPostgresql($sql);
+    }
+
+    private function sqlTableIndexes(string $tableName, array $xmlIndexes)
+    {
+        $sql = '';
+        foreach ($xmlIndexes as $idx) {
+            $sql .= ' CREATE INDEX fs_' . $idx['name'] . ' ON ' . $tableName . ' (' . $idx['columns'] . ');';
+        }
+
+        return $sql;
     }
 
     /**

--- a/Core/Base/DataBase/PostgresqlQueries.php
+++ b/Core/Base/DataBase/PostgresqlQueries.php
@@ -97,6 +97,11 @@ class PostgresqlQueries implements DataBaseQueries
         return 'ALTER TABLE ' . $tableName . ' ALTER COLUMN ' . $colData['name'] . $action . ';';
     }
 
+    public function sqlAddIndex(string $tableName, string $indexName, string $columns): string
+    {
+        return 'CREATE INDEX ' . $indexName . ' ON ' . $tableName . ' (' . $columns . ');';
+    }
+
     /**
      * SQL statement to alter a null constraint in a table column
      *
@@ -199,10 +204,11 @@ class PostgresqlQueries implements DataBaseQueries
      * @param string $tableName
      * @param array $columns
      * @param array $constraints
+     * @param array $indexes
      *
      * @return string
      */
-    public function sqlCreateTable(string $tableName, array $columns, array $constraints): string
+    public function sqlCreateTable(string $tableName, array $columns, array $constraints, array $indexes): string
     {
         $serials = ['serial', 'bigserial'];
         $fields = '';
@@ -223,7 +229,8 @@ class PostgresqlQueries implements DataBaseQueries
         }
 
         return 'CREATE TABLE ' . $tableName . ' (' . substr($fields, 2)
-            . $this->sqlTableConstraints($constraints) . ');';
+            . $this->sqlTableConstraints($constraints) . ');'
+            . $this->sqlTableIndexes($tableName, $indexes);
     }
 
     /**
@@ -237,6 +244,11 @@ class PostgresqlQueries implements DataBaseQueries
     public function sqlDropConstraint(string $tableName, array $colData): string
     {
         return 'ALTER TABLE ' . $tableName . ' DROP CONSTRAINT ' . $colData['name'] . ';';
+    }
+
+    public function sqlDropIndex(string $tableName, array $colData): string
+    {
+        return 'DROP INDEX IF EXISTS ' . $colData['name'] . ';';
     }
 
     /**
@@ -260,7 +272,23 @@ class PostgresqlQueries implements DataBaseQueries
      */
     public function sqlIndexes(string $tableName): string
     {
-        return "SELECT indexname as Key_name FROM pg_indexes WHERE tablename = '" . $tableName . "';";
+        return "SELECT
+                  i.relname AS key_name,
+                  a.attname AS column_name
+                FROM
+                  pg_class t
+                JOIN
+                  pg_index ix ON t.oid = ix.indrelid
+                JOIN
+                  pg_class i ON i.oid = ix.indexrelid
+                JOIN
+                  pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+                WHERE
+                  t.relkind = 'r'
+                  AND t.relname = '" . $tableName . "'
+                ORDER BY
+                  i.relname,
+                  a.attname;";
     }
 
     /**
@@ -294,6 +322,16 @@ class PostgresqlQueries implements DataBaseQueries
             if (FS_DB_FOREIGN_KEYS || 0 !== strpos($res['constraint'], 'FOREIGN KEY')) {
                 $sql .= ', CONSTRAINT ' . $res['name'] . ' ' . $res['constraint'];
             }
+        }
+
+        return $sql;
+    }
+
+    private function sqlTableIndexes(string $tableName, array $xmlIndexes)
+    {
+        $sql = '';
+        foreach ($xmlIndexes as $idx) {
+            $sql .= ' CREATE INDEX fs_' . $idx['name'] . ' ON ' . $tableName . ' (' . $idx['columns'] . ');';
         }
 
         return $sql;

--- a/Test/__files/test_table.xml
+++ b/Test/__files/test_table.xml
@@ -10,6 +10,10 @@
         <type>character varying(100)</type>
     </column>
     <column>
+        <name>email2</name>
+        <type>character varying(100)</type>
+    </column>
+    <column>
         <name>fechaalta</name>
         <type>date</type>
     </column>
@@ -48,4 +52,12 @@
         <name>test_table_pkey</name>
         <type>PRIMARY KEY (id)</type>
     </constraint>
+    <index>
+        <name>idx_email</name>
+        <columns>email</columns>
+    </index>
+    <index>
+        <name>idx_email_email2</name>
+        <columns>email, email2</columns>
+    </index>
 </table>

--- a/Test/__files/test_table_update_3.xml
+++ b/Test/__files/test_table_update_3.xml
@@ -65,8 +65,4 @@
         <name>idx_email_email2</name>
         <columns>email, email2</columns>
     </index>
-    <index>
-        <name>idx_observaciones</name>
-        <columns>observaciones</columns>
-    </index>
 </table>


### PR DESCRIPTION
# Descripción
- Debemos poder indicar el nombre del índice, así como la columna o columna involucrada. Al comprobarse la estructura de la tabla se debe comprobar si existe el índice o crearlo si no existe.
- En ocasiones tenemos columnas como lastipcontacto que serían más legibles si se llamasen last_ip_contacto. Para estos casos, cuando queremos renombrar una columna que ya existe, podemos dar de alta estas instrucciones de renombrado. Para decirle a FacturaScripts que si existe esa columna, la debe renombrar.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
