### PR TITLE
Tarea #1275 - agregar modelo LogAudit

### DIFF
--- a/Core/Lib/ExtendedController/LogAuditTrait.php
+++ b/Core/Lib/ExtendedController/LogAuditTrait.php
@@ -25,7 +25,7 @@ trait LogAuditTrait
 {
     public function createViewLogAudit(string $viewName = 'ListLogMessage')
     {
-        $this->addListView($viewName, 'LogMessage', 'history', 'fas fa-history');
+        $this->addListView($viewName, 'LogAudit', 'history', 'fas fa-history');
         $this->views[$viewName]->addOrderBy(['time'], 'date', 2);
         $this->views[$viewName]->addSearchFields(['context', 'message']);
 

--- a/Core/Model/Asiento.php
+++ b/Core/Model/Asiento.php
@@ -169,7 +169,8 @@ class Asiento extends Base\ModelOnChangeClass
         }
 
         // add audit log
-        Tools::log(self::AUDIT_CHANNEL)->warning('deleted-model', [
+        $logAudit = new LogAudit();
+        $logAudit->warning('deleted-model', [
             '%model%' => $this->modelClassName(),
             '%key%' => $this->primaryColumnValue(),
             '%desc%' => $this->primaryDescription(),
@@ -337,7 +338,8 @@ class Asiento extends Base\ModelOnChangeClass
         }
 
         // add audit log
-        Tools::log(self::AUDIT_CHANNEL)->info('updated-model', [
+        $logAudit = new LogAudit();
+        $logAudit->info('updated-model', [
             '%model%' => $this->modelClassName(),
             '%key%' => $this->primaryColumnValue(),
             '%desc%' => $this->primaryDescription(),

--- a/Core/Model/Base/BusinessDocument.php
+++ b/Core/Model/Base/BusinessDocument.php
@@ -22,6 +22,7 @@ namespace FacturaScripts\Core\Model\Base;
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Base\Utils;
 use FacturaScripts\Core\DataSrc\Almacenes;
+use FacturaScripts\Core\Model\LogAudit;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Lib\BusinessDocumentCode;
 use FacturaScripts\Dinamic\Model\Almacen;
@@ -506,7 +507,8 @@ abstract class BusinessDocument extends ModelOnChangeClass
         }
 
         // add audit log
-        Tools::log(self::AUDIT_CHANNEL)->info('updated-model', [
+        $logAudit = new LogAudit();
+        $logAudit->info('updated-model', [
             '%model%' => $this->modelClassName(),
             '%key%' => $this->primaryColumnValue(),
             '%desc%' => $this->primaryDescription(),

--- a/Core/Model/Base/TransformerDocument.php
+++ b/Core/Model/Base/TransformerDocument.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model\Base;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Model\LogAudit;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Lib\BusinessDocumentGenerator;
 use FacturaScripts\Dinamic\Model\DocTransformation;
@@ -167,7 +168,8 @@ abstract class TransformerDocument extends BusinessDocument
         }
 
         // add audit log
-        Tools::log(self::AUDIT_CHANNEL)->warning('deleted-model', [
+        $logAudit = new LogAudit();
+        $logAudit->warning('deleted-model', [
             '%model%' => $this->modelClassName(),
             '%key%' => $this->primaryColumnValue(),
             '%desc%' => $this->primaryDescription(),

--- a/Core/Model/LogAudit.php
+++ b/Core/Model/LogAudit.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+namespace FacturaScripts\Core\Model;
+
+use FacturaScripts\Core\Session;
+use FacturaScripts\Core\Tools;
+
+class LogAudit extends Base\ModelClass
+{
+    use Base\ModelTrait;
+
+    public const MAX_MESSAGE_LEN = 3000;
+
+    /** @var string */
+    public $channel;
+
+    /** @var string */
+    public $context;
+
+    /** @var int */
+    public $id;
+
+    /** @var int */
+    public $idcontacto;
+
+    /** @var string */
+    public $ip;
+
+    /** @var string */
+    public $level;
+
+    /** @var string */
+    public $message;
+
+    /** @var string */
+    public $model;
+
+    /** @var string */
+    public $modelcode;
+
+    /** @var string */
+    public $nick;
+
+    /** @var string */
+    public $time;
+
+    /** @var string */
+    public $uri;
+
+    public function clear(): void
+    {
+        parent::clear();
+        $this->time = Tools::dateTime();
+    }
+
+    /**
+     * Returns the saved context as array.
+     *
+     * @return array
+     */
+    public function context(): array
+    {
+        return json_decode(Tools::fixHtml($this->context), true);
+    }
+
+    public function delete(): bool
+    {
+        Tools::log()->warning('cant-delete-audit-log');
+        return false;
+    }
+
+    public static function primaryColumn(): string
+    {
+        return 'id';
+    }
+
+    public static function tableName(): string
+    {
+        return 'logs_audit';
+    }
+
+    public function test(): bool
+    {
+        $this->channel = Tools::noHtml($this->channel);
+        $this->context = Tools::noHtml($this->context);
+        $this->message = Tools::noHtml($this->message);
+        if (strlen($this->message) > static::MAX_MESSAGE_LEN) {
+            $this->message = substr($this->message, 0, static::MAX_MESSAGE_LEN);
+        }
+
+        $this->model = Tools::noHtml($this->model);
+        $this->modelcode = Tools::noHtml((string)$this->modelcode);
+        $this->uri = Tools::noHtml($this->uri);
+
+        return parent::test();
+    }
+
+    /**
+     * @param string $message
+     * @param array $context
+     */
+    public function warning(string $message, array $context = []): void
+    {
+        $this->level = 'warning';
+        $this->log($message, $context);
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+        $this->level = 'info';
+        $this->log($message, $context);
+    }
+
+    private function log(string $message, array $context = []): void
+    {
+        $this->channel = self::AUDIT_CHANNEL;
+        $this->context = $this->getContext($context);
+        $this->idcontacto = $context['idcontacto'] ?? null;
+        $this->ip = Session::getClientIp();
+        $this->message = Tools::lang()->trans($message, $context);
+        $this->model = $context['model-class'] ?? null;
+        $this->modelcode = $context['model-code'] ?? null;
+        $this->nick = $context['nick'] ?? Session::user()->nick;
+        $this->time = isset($context['time']) ? date('d-m-Y H:i:s', (int)$context['time']) : date('d-m-Y H:i:s');
+        $this->uri = $context['uri'] ?? Session::get('uri');
+        $this->save();
+    }
+
+    protected function saveUpdate(array $values = []): bool
+    {
+        Tools::log()->warning('cant-update-audit-log');
+        return false;
+    }
+
+    private function getContext(array $context)
+    {
+        return json_encode($context);
+    }
+}

--- a/Core/Table/logs_audit.xml
+++ b/Core/Table/logs_audit.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+    <column>
+        <name>channel</name>
+        <type>character varying(40)</type>
+    </column>
+    <column>
+        <name>context</name>
+        <type>text</type>
+    </column>
+    <column>
+        <name>id</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>idcontacto</name>
+        <type>integer</type>
+    </column>
+    <column>
+        <name>ip</name>
+        <type>character varying(40)</type>
+    </column>
+    <column>
+        <name>level</name>
+        <type>character varying(15)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>message</name>
+        <type>text</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>model</name>
+        <type>character varying(30)</type>
+    </column>
+    <column>
+        <name>modelcode</name>
+        <type>character varying(40)</type>
+    </column>
+    <column>
+        <name>nick</name>
+        <type>character varying(50)</type>
+    </column>
+    <column>
+        <name>time</name>
+        <type>timestamp</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>uri</name>
+        <type>character varying(200)</type>
+    </column>
+    <constraint>
+        <name>logs_pkey</name>
+        <type>PRIMARY KEY (id)</type>
+    </constraint>
+</table>

--- a/Test/Core/Model/LogAuditTest.php
+++ b/Test/Core/Model/LogAuditTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Model;
+
+use FacturaScripts\Core\Model\Base\ModelCore;
+use FacturaScripts\Core\Model\LogAudit;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use PHPUnit\Framework\TestCase;
+
+class LogAuditTest extends TestCase
+{
+    use LogErrorsTrait;
+
+    public function testCanNotDeleteAuditLogs()
+    {
+        $item = new LogAudit();
+        $item->channel = ModelCore::AUDIT_CHANNEL;
+        $item->level = 'info';
+        $item->message = 'test-audit-to-delete';
+        $this->assertTrue($item->save(), 'cant-save-model');
+        $this->assertTrue($item->exists(), 'item-not-found-in-db');
+        $this->assertFalse($item->delete(), 'can-delete-audit-log');
+    }
+
+    public function testCanNotUpdateAuditLogs()
+    {
+        $item = new LogAudit();
+        $item->channel = ModelCore::AUDIT_CHANNEL;
+        $item->level = 'info';
+        $item->message = 'test-audit-to-update';
+        $this->assertTrue($item->save(), 'cant-save-model');
+
+        $item->message = 'test-audit-to-update-2';
+        $this->assertFalse($item->save(), 'can-update-audit-log');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}

--- a/Test/Traits/LogErrorsTrait.php
+++ b/Test/Traits/LogErrorsTrait.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Test\Traits;
 
 use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Model\LogAudit;
 
 trait LogErrorsTrait
 {
@@ -36,12 +37,9 @@ trait LogErrorsTrait
 
     protected function searchAuditLog(string $modelClass, string $modelCode): bool
     {
-        foreach (MiniLog::read('audit') as $log) {
-            if ($log['context']['model-class'] === $modelClass && $log['context']['model-code'] === $modelCode) {
-                return true;
-            }
-        }
-
-        return false;
+        return LogAudit::table()
+            ->whereEq('model', $modelClass)
+            ->whereEq('modelcode', $modelCode)
+            ->count() === 1;
     }
 }


### PR DESCRIPTION
# Descripción
- Problema

Ahora mismo cuando se crea una factura, se añade al log del canal audit un mensaje indicando quién ha modificado la factura y los datos de contexto. El problema viene cuando por algún motivo no se llega a guardar la factura (por ejemplo si no hay stock) y se deshace la transacción. La factura no se crea, pero el mensaje si se añade al canal audit.

- Solución

Crear un modelo LogAudit para guardar directamente en base de datos estos datos de auditoría. De esta forma, si se rechaza la transacción, se rechazan también los datos de auditoría.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
