### PR TITLE
activar plugins en lote y deshabilitar todos los plugins

### DIFF
--- a/Core/Controller/AdminPlugins.php
+++ b/Core/Controller/AdminPlugins.php
@@ -89,6 +89,14 @@ class AdminPlugins extends Controller
                 $this->uploadPluginAction();
                 break;
 
+            case 'mass-add-plugins':
+                $this->massAddPluginsAction();
+                break;
+
+            case 'disable-all-plugins':
+                $this->disableAllPluginsAction();
+                break;
+
             default:
                 $this->extractPluginsZipFiles();
                 if (FS_DEBUG) {
@@ -234,5 +242,45 @@ class AdminPlugins extends Controller
             Tools::log()->notice('reloading');
             $this->redirect($this->url(), 3);
         }
+    }
+
+    private function massAddPluginsAction()
+    {
+        if (false === $this->permissions->allowUpdate) {
+            Tools::log()->warning('not-allowed-update');
+            return;
+        } elseif (false === $this->validateFormToken()) {
+            return;
+        }
+
+        $pluginsList = $this->request->request->get('plugins-list');
+        $pluginsList = explode(',', $pluginsList);
+
+        foreach ($pluginsList as $pluginName){
+            $pluginName = trim($pluginName);
+            if(false === Plugins::isEnabled($pluginName)){
+                Plugins::enable($pluginName);
+            }
+        }
+
+        Cache::clear();
+    }
+
+    private function disableAllPluginsAction()
+    {
+        if (false === $this->permissions->allowUpdate) {
+            Tools::log()->warning('not-allowed-update');
+            return;
+        } elseif (false === $this->validateFormToken()) {
+            return;
+        }
+
+        foreach (Plugins::list() as $plugin){
+            if($plugin->enabled){
+                Plugins::disable($plugin->name);
+            }
+        }
+
+        Cache::clear();
     }
 }

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -54,6 +54,23 @@
                         <span class="d-none d-sm-inline-block">{{ trans('rebuild') }}</span>
                     </a>
                 </div>
+                <div class="btn-group">
+                    <button class="btn btn-spin-action btn-sm btn-success" type="button" data-toggle="modal"
+                            data-target="#modalMassAddPlugins">
+                        <i class="fas fa-plus-square fa-fw" aria-hidden="true"></i>
+                        <span class="d-none d-sm-inline-block">{{ trans('mass-add-plugins') }}</span>
+                    </button>
+                </div>
+                <div class="btn-group">
+                    <form action="{{ fsc.url() }}" method="POST">
+                        {{ formToken() }}
+                        <input type="hidden" name="action" value="disable-all-plugins">
+                        <button class="btn btn-spin-action btn-sm btn-dark" type="submit">
+                            <i class="fas fa-minus-square fa-fw"></i>
+                            <span class="d-none d-sm-inline-block">{{ trans('disable-all-plugins') }}</span>
+                        </button>
+                    </form>
+                </div>
             </div>
             <div class="col-sm text-right">
                 <h1 class="h3">
@@ -145,6 +162,34 @@
             </div>
         </form>
     {% endif %}
+
+    <div class="modal" id="modalMassAddPlugins" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">{{ trans('mass-add-plugins') }}</h5>
+                    <button type="button" class="close" data-dismiss="modal">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form action="{{ fsc.url() }}" method="POST" id="mass-add-plugins-form">
+                        {{ formToken() }}
+                        <input type="hidden" name="action" value="mass-add-plugins">
+                        <div class="form-group">
+                            <label for="plugins-list">{{ trans('plugins-list') }}</label>
+                            <input type="text" class="form-control" id="plugins-list" name="plugins-list" autocomplete="off">
+                            <small class="form-text text-muted">Listado de plugins a instalar ordenados y separados por coma(ej: Backup,Anticipos,PrintTicket).</small>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('close') }}</button>
+                    <button type="submit" form="mass-add-plugins-form" class="btn btn-primary">{{ trans('continue') }}</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
# Descripción
- Se implementa la opción de activar plugins en lote.
- Se debe indicar en el input el nombre de los plugins ordenados y separados por coma.

- Se implementa poder deshabilitar todos los plugins que se encuentren habilitados.

![captura_pantalla](https://github.com/user-attachments/assets/8eb619bb-8747-4dbe-9544-5f20c20261a9)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
