### PR TITLE
Agregar seguridad a las cookies

### DIFF
--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -371,7 +371,15 @@ class Controller implements ControllerInterface
         if (false === $user->verifyLogkey($logKey)) {
             Tools::log()->warning('login-cookie-fail');
             // eliminamos la cookie
-            setcookie('fsNick', '', time() - FS_COOKIES_EXPIRE, '/');
+            $expiration = time() - FS_COOKIES_EXPIRE;
+            $options = [
+                'expires' => $expiration,
+                'path' => Tools::config('route', '/'),
+                'httponly' => true,
+                'secure' => true,
+                'samesite' => 'Strict'
+            ];
+            setcookie('fsNick', '', $options);
             return false;
         }
 

--- a/Core/Base/Controller.php
+++ b/Core/Base/Controller.php
@@ -371,9 +371,8 @@ class Controller implements ControllerInterface
         if (false === $user->verifyLogkey($logKey)) {
             Tools::log()->warning('login-cookie-fail');
             // eliminamos la cookie
-            $expiration = time() - FS_COOKIES_EXPIRE;
             $options = [
-                'expires' => $expiration,
+                'expires' => time() - FS_COOKIES_EXPIRE,
                 'path' => Tools::config('route', '/'),
                 'httponly' => true,
                 'secure' => true,

--- a/Core/Controller/Login.php
+++ b/Core/Controller/Login.php
@@ -301,9 +301,8 @@ class Login implements ControllerInterface
         }
 
         // save cookies
-        $expiration = time() + (int)Tools::config('cookies_expire', 31536000);
         $options = [
-            'expires' => $expiration,
+            'expires' => time() + (int)Tools::config('cookies_expire', 31536000),
             'path' => Tools::config('route', '/'),
             'httponly' => true,
             'secure' => true,

--- a/Core/Controller/Login.php
+++ b/Core/Controller/Login.php
@@ -302,9 +302,16 @@ class Login implements ControllerInterface
 
         // save cookies
         $expiration = time() + (int)Tools::config('cookies_expire', 31536000);
-        setcookie('fsNick', $user->nick, $expiration, Tools::config('route', '/'));
-        setcookie('fsLogkey', $user->logkey, $expiration, Tools::config('route', '/'));
-        setcookie('fsLang', $user->langcode, $expiration, Tools::config('route', '/'));
+        $options = [
+            'expires' => $expiration,
+            'path' => Tools::config('route', '/'),
+            'httponly' => true,
+            'secure' => true,
+            'samesite' => 'Strict'
+        ];
+        setcookie('fsNick', $user->nick, $options);
+        setcookie('fsLogkey', $user->logkey, $options);
+        setcookie('fsLang', $user->langcode, $options);
 
         // redirect to the user's main page
         if (empty($user->homepage)) {
@@ -320,9 +327,17 @@ class Login implements ControllerInterface
         }
 
         // remove cookies
-        setcookie('fsNick', '', time() - 3600, Tools::config('route', '/'));
-        setcookie('fsLogkey', '', time() - 3600, Tools::config('route', '/'));
-        setcookie('fsLang', '', time() - 3600, Tools::config('route', '/'));
+        $expiration = time() - 3600;
+        $options = [
+            'expires' => $expiration,
+            'path' => Tools::config('route', '/'),
+            'httponly' => true,
+            'secure' => true,
+            'samesite' => 'Strict'
+        ];
+        setcookie('fsNick', '', $options);
+        setcookie('fsLogkey', '', $options);
+        setcookie('fsLang', '', $options);
 
         // restart token
         $multiRequestProtection = new MultiRequestProtection();

--- a/Core/Controller/Login.php
+++ b/Core/Controller/Login.php
@@ -327,9 +327,8 @@ class Login implements ControllerInterface
         }
 
         // remove cookies
-        $expiration = time() - 3600;
         $options = [
-            'expires' => $expiration,
+            'expires' => time() - 3600,
             'path' => Tools::config('route', '/'),
             'httponly' => true,
             'secure' => true,


### PR DESCRIPTION
# Descripción
- HttpOnly: Esta bandera impide que las cookies sean accesibles a través de JavaScript, lo que reduce el riesgo de ataques de XSS (Cross-Site Scripting).
- Secure: Esta bandera asegura que las cookies solo se envíen a través de conexiones HTTPS, lo que protege contra ataques de sniffing en redes no seguras.
- SameSite: La opción SameSite ayuda a mitigar ataques de CSRF (Cross-Site Request Forgery) al restringir cuándo se envían las cookies con solicitudes entre sitios.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
