### PR TITLE
limitar caracteres en campos al guardar en base de datos

### DIFF
--- a/Core/Model/Base/ModelClass.php
+++ b/Core/Model/Base/ModelClass.php
@@ -400,6 +400,13 @@ abstract class ModelClass extends ModelCore
             if (isset($this->{$field['name']})) {
                 $fieldName = $field['name'];
                 $fieldValue = $values[$fieldName] ?? $this->{$fieldName};
+                
+                if(strpos($field['type'], 'varchar') !== false){
+                    $patron = '/\(\s*(\d+)\s*\)/';
+                    preg_match($patron, $field['type'], $coincidencias);
+                    $longitudMaxima = $coincidencias[1];
+                    $fieldValue = Tools::truncarString($fieldValue, $longitudMaxima);
+                }
 
                 $insertFields[] = self::$dataBase->escapeColumn($fieldName);
                 $insertValues[] = self::$dataBase->var2str($fieldValue);
@@ -451,6 +458,14 @@ abstract class ModelClass extends ModelCore
             if ($field['name'] !== static::primaryColumn()) {
                 $fieldName = $field['name'];
                 $fieldValue = $values[$fieldName] ?? $this->{$fieldName};
+
+                if(strpos($field['type'], 'varchar') !== false){
+                    $patron = '/\(\s*(\d+)\s*\)/';
+                    preg_match($patron, $field['type'], $coincidencias);
+                    $longitudMaxima = $coincidencias[1];
+                    $fieldValue = Tools::truncarString($fieldValue, $longitudMaxima);
+                }
+
                 $sql .= $coma . ' ' . self::$dataBase->escapeColumn($fieldName) . ' = ' . self::$dataBase->var2str($fieldValue);
                 $coma = ', ';
             }

--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -680,26 +680,4 @@ class Tools
             return $settings;
         });
     }
-
-    /**
-     * Corta un texto a una longitud específica.
-     *
-     * @param string $string|null
-     * @param int $longitudMaxima
-     *
-     * @return string|null
-     */
-    public static function truncarString(?string $string, int $longitudMaxima): ?string
-    {
-        if (!is_string($string)){
-            return $string;
-        }
-
-        $longitudActual = mb_strlen($string);
-        if ($longitudActual > $longitudMaxima) {
-            $string = substr($string, 0, $longitudMaxima);
-        }
-
-        return $string;
-    }
 }

--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -680,4 +680,26 @@ class Tools
             return $settings;
         });
     }
+
+    /**
+     * Corta un texto a una longitud específica.
+     *
+     * @param string $string|null
+     * @param int $longitudMaxima
+     *
+     * @return string|null
+     */
+    public static function truncarString(?string $string, int $longitudMaxima): ?string
+    {
+        if (!is_string($string)){
+            return $string;
+        }
+
+        $longitudActual = mb_strlen($string);
+        if ($longitudActual > $longitudMaxima) {
+            $string = substr($string, 0, $longitudMaxima);
+        }
+
+        return $string;
+    }
 }

--- a/Test/Core/Model/ClienteTest.php
+++ b/Test/Core/Model/ClienteTest.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Cliente;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -208,6 +209,26 @@ final class ClienteTest extends TestCase
         // eliminamos
         $this->assertTrue($address->delete());
         $this->assertTrue($cliente->delete());
+    }
+
+    public function testLimitarCamposSegunTabla()
+    {
+        $texto = Tools::randomString(200);
+
+        $cliente = new Cliente();
+        $cliente->nombre = $texto;
+        $cliente->cifnif = '12345678A';
+        $this->assertTrue($cliente->save(), 'cliente-cant-save');
+
+        $cliente->loadFromCode($cliente->codcliente);
+
+        // comprobamos que se ha limitado el nombre a 100 caracteres ya que en la tabla es varchar(100)
+        $this->assertEquals(substr($texto, 0, 100), $cliente->nombre);
+        $this->assertNotEquals($texto, $cliente->nombre);
+
+        // eliminamos
+        $this->assertTrue($cliente->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($cliente->delete(), 'cliente-cant-delete');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
# Descripción
Antes se minimizaban los errores de introducir mas caracteres de los que permite el campo en la base de datos con los inputs de formularios.
Cada vez mas se usa la API y plugins que obtienes los datos de API´s y ya no existe limite al guardar en la base de datos, lo que hace que se generen errores al insertar los datos por exceso de caracteres.
Ahora si el campo es varchar se obtiene la longitud del campo y se limita el string a esta longitud evitando así errores.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
