### PR TITLE
agregar lazy loading al WidgetLibrary

### DIFF
--- a/Core/Lib/Widget/WidgetLibrary.php
+++ b/Core/Lib/Widget/WidgetLibrary.php
@@ -185,7 +185,7 @@ class WidgetLibrary extends BaseWidget
 
             if ($file->isImage()) {
                 $html .= '<div class="media">'
-                    . '<img src="' . $file->url('download-permanent') . '" class="mr-3" alt="' . $file->filename
+                    . '<img loading="lazy" src="' . $file->url('download-permanent') . '" class="mr-3" alt="' . $file->filename
                     . '" width="64" type="button" onclick="' . $js . '" title="' . Tools::lang()->trans('select') . '">'
                     . '<div class="media-body">'
                     . '<h5 class="text-break mt-0">' . $file->filename . '</h5>'


### PR DESCRIPTION
# Descripción
- Al usar el WidgetLibrary carga todas las imágenes que se encuentren en la biblioteca en el modal aumentando la carga de la página.
- Usando lazy loading solo se cargan las imágenes cuando se el modal es visible y se van mostrando las imágenes. 
- De esta forma se evita cargar las imágenes en cada request si no es necesario hacer uso del Widget.

![Animation](https://github.com/user-attachments/assets/e122538d-0dda-4d86-827f-c807ef5c101d)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
