### PR TITLE
limpiar cache consultas mysql en newcode

### DIFF
--- a/Core/Model/Base/ModelClass.php
+++ b/Core/Model/Base/ModelClass.php
@@ -237,6 +237,13 @@ abstract class ModelClass extends ModelCore
             $field = self::$dataBase->getEngine()->getSQL()->sql2Int($field);
         }
 
+        // Limpiamos la caché de consultas de MySQL para asegurarnos
+        // de obtener los datos más recientes.
+        if(strtolower(FS_DB_TYPE) === 'mysql') {
+            $sql = 'RESET QUERY CACHE;';
+            self::$dataBase->exec($sql);
+        }
+
         // Search for new code value
         $sqlWhere = DataBaseWhere::getSQLWhere($where);
         $sql = 'SELECT MAX(' . $field . ') as cod FROM ' . static::tableName() . $sqlWhere . ';';


### PR DESCRIPTION
# Descripción
- Debido al sistema de cache de mysql el método newCode, en algunas ocasiones, no devuelve el nuevo código correctamente cuando existen al menos dos procesos ejecutando la aplicación al mismo tiempo.
- Cada vez es más común el uso de plugins para realizar trabajos en segundo plano desde el Cron.
- Es por ello que ahora se borrar la cache de consultas justo antes de solicitar a la base de datos el valor máximo del campo.
- Hasta donde yo sé, solo afecta a mysql.

En el video se puede observar como falla creando clientes cada segundo, pero en dos procesos diferentes.

![Animation](https://github.com/user-attachments/assets/e779d05b-9e82-4bb0-bc98-257d0f06a312)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
