### PR TITLE
Renombrada la variable para los ganchos de twig

### DIFF
--- a/Core/View/Master/MenuBgTemplate.html.twig
+++ b/Core/View/Master/MenuBgTemplate.html.twig
@@ -37,11 +37,11 @@
     {% block body %}
         {{ parent() }}
     {% endblock %}
-    {% for item in getIncludeViews('MenuTemplate', 'JsFooter') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'JsFooter') %}
+        {% include includeView['path'] %}
     {% endfor %}
-    {% for item in getIncludeViews('MenuTemplate', 'BodyEnd') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'BodyEnd') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {{ debugBarRender.render() | raw }}
     <br/>

--- a/Core/View/Master/MenuBghTemplate.html.twig
+++ b/Core/View/Master/MenuBghTemplate.html.twig
@@ -37,11 +37,11 @@
     {% block body %}
         {{ parent() }}
     {% endblock %}
-    {% for item in getIncludeViews('MenuTemplate', 'JsFooter') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'JsFooter') %}
+        {% include includeView['path'] %}
     {% endfor %}
-    {% for item in getIncludeViews('MenuTemplate', 'BodyEnd') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'BodyEnd') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {{ debugBarRender.render() | raw }}
     <br/>

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -23,8 +23,8 @@
       xml:lang="{{ constant('FS_LANG') | slice(0, 2) }}">
 <head>
     {{ GoogleTagManager.head() }}
-    {% for item in getIncludeViews('MenuTemplate', 'HeadFirst') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'HeadFirst') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {% block meta %}
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -39,8 +39,8 @@
         <link rel="apple-touch-icon" sizes="180x180"
               href="{{ asset('Dinamic/Assets/Images/apple-icon-180x180.png') }}"/>
     {% endblock %}
-    {% for item in getIncludeViews('MenuTemplate', 'CssBefore') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'CssBefore') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {% block css %}
         <link rel="stylesheet" href="{{ asset('node_modules/bootstrap/dist/css/bootstrap.min.css') }}"/>
@@ -51,11 +51,11 @@
     {% for css in assetManager.get('css') %}
         <link rel="stylesheet" href="{{ css }}"/>
     {% endfor %}
-    {% for item in getIncludeViews('MenuTemplate', 'CssAfter') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'CssAfter') %}
+        {% include includeView['path'] %}
     {% endfor %}
-    {% for item in getIncludeViews('MenuTemplate', 'JsHeadBefore') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'JsHeadBefore') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {% block javascripts %}
         <script src="{{ asset('node_modules/jquery/dist/jquery.min.js') }}"></script>
@@ -70,21 +70,21 @@
     {% for js in assetManager.get('js') %}
         <script src="{{ js }}"></script>
     {% endfor %}
-    {% for item in getIncludeViews('MenuTemplate', 'JsHeadAfter') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'JsHeadAfter') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {% if debugBarRender %}
         {{ debugBarRender.renderHead() | raw }}
     {% endif %}
-    {% for item in getIncludeViews('MenuTemplate', 'HeadEnd') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'HeadEnd') %}
+        {% include includeView['path'] %}
     {% endfor %}
 </head>
 {% block fullBody %}
     <body>
     {{ GoogleTagManager.body() }}
-    {% for item in getIncludeViews('MenuTemplate', 'BodyFirst') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'BodyFirst') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {% block navbar %}
         <nav class="navbar navbar-expand navbar-dark bg-primary sticky-top d-print-none">
@@ -103,8 +103,8 @@
                     </ul>
                     <ul class="navbar-nav flex-row ml-auto">
                         {% block navbarMenuIcon %}
-                            {% for item in getIncludeViews('MenuTemplate', 'MenuIconBefore') %}
-                                {% include item['path'] %}
+                            {% for includeView in getIncludeViews('MenuTemplate', 'MenuIconBefore') %}
+                                {% include includeView['path'] %}
                             {% endfor %}
                             <li class="nav-item{{ template == 'MegaSearch.html.twig' ? ' active' : '' }}"
                                 title="{{ trans('search') }}">
@@ -132,8 +132,8 @@
                                         <i class="fas fa-envelope fa-fw" aria-hidden="true"></i>
                                         {{ trans('send-mail') }}
                                     </a>
-                                    {% for item in getIncludeViews('MenuTemplate', 'MenuIconUser') %}
-                                        {% include item['path'] %}
+                                    {% for includeView in getIncludeViews('MenuTemplate', 'MenuIconUser') %}
+                                        {% include includeView['path'] %}
                                     {% endfor %}
                                     <div class="dropdown-divider"></div>
                                     <a class="dropdown-item" href="{{ asset('login') }}?action=logout&multireqtoken={{ formToken(false) }}">
@@ -141,8 +141,8 @@
                                     </a>
                                 </div>
                             </li>
-                            {% for item in getIncludeViews('MenuTemplate', 'MenuIconAfter') %}
-                                {% include item['path'] %}
+                            {% for includeView in getIncludeViews('MenuTemplate', 'MenuIconAfter') %}
+                                {% include includeView['path'] %}
                             {% endfor %}
                         {% endblock %}
                     </ul>
@@ -170,11 +170,11 @@
     </div>
     {% block body %}
     {% endblock %}
-    {% for item in getIncludeViews('MenuTemplate', 'JsFooter') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'JsFooter') %}
+        {% include includeView['path'] %}
     {% endfor %}
-    {% for item in getIncludeViews('MenuTemplate', 'BodyEnd') %}
-        {% include item['path'] %}
+    {% for includeView in getIncludeViews('MenuTemplate', 'BodyEnd') %}
+        {% include includeView['path'] %}
     {% endfor %}
     {% if debugBarRender %}
         {{ debugBarRender.render() | raw }}

--- a/Core/View/Master/PanelController.html.twig
+++ b/Core/View/Master/PanelController.html.twig
@@ -79,8 +79,8 @@
                 {% if fsc.hasData and firstView.settings.btnPrint %}
                     {{ _self.printButton(fsc, firstView, i18n) }}
                 {% endif %}
-                {% for item in getIncludeViews('PanelController', 'topButtons') %}
-                    {% include item['path'] %}
+                {% for includeView in getIncludeViews('PanelController', 'topButtons') %}
+                    {% include includeView['path'] %}
                 {% endfor %}
             </div>
             {# -- Top right text -- #}

--- a/Core/View/Master/PanelControllerTop.html.twig
+++ b/Core/View/Master/PanelControllerTop.html.twig
@@ -79,8 +79,8 @@
                 {% if fsc.hasData and firstView.settings.btnPrint %}
                     {{ _self.printButton(fsc, firstView, i18n) }}
                 {% endif %}
-                {% for item in getIncludeViews('PanelControllerTop', 'topButtons') %}
-                    {% include item['path'] %}
+                {% for includeView in getIncludeViews('PanelControllerTop', 'topButtons') %}
+                    {% include includeView['path'] %}
                 {% endfor %}
             </div>
             {# -- Top right text -- #}

--- a/Core/View/Tab/DocFiles.html.twig
+++ b/Core/View/Tab/DocFiles.html.twig
@@ -26,8 +26,8 @@
                                     <p class="text-muted mb-0">
                                         {{ trans('help-server-accepts-filesize', {'%size%': currentView.model.getMaxFileUpload()}) }}
                                     </p>
-                                    {% for item in getIncludeViews('DocFiles', 'formAddBody') %}
-                                        {% include item['path'] %}
+                                    {% for includeView in getIncludeViews('DocFiles', 'formAddBody') %}
+                                        {% include includeView['path'] %}
                                     {% endfor %}
                                 </div>
                                 <div class="col text-right">
@@ -78,8 +78,8 @@
                                 <textarea name="observations" class="form-control"
                                           placeholder="{{ trans('observations') }}">{{ docfile.observations | raw }}</textarea>
                                 </div>
-                                {% for item in getIncludeViews('DocFiles', 'formEditBody') %}
-                                    {% include item['path'] %}
+                                {% for includeView in getIncludeViews('DocFiles', 'formEditBody') %}
+                                    {% include includeView['path'] %}
                                 {% endfor %}
                                 <p class="card-text text-muted">
                                     {% if docfile.nick %}


### PR DESCRIPTION
Este cambio no afecta en nada que pueda fallar, pero si un plugin añade un gancho al twig y en su plugin ese gancho dentro tiene una variable llamada "item" igual a la variable del gancho del core eso es un problema ya que se suplantan, de este modo la variable del core tiene un nombre menos común y menos problemática.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.