### PR TITLE
Tarea #3506 - eliminar barra al inicio y al final

### DIFF
--- a/Core/Tools.php
+++ b/Core/Tools.php
@@ -211,6 +211,11 @@ class Tools
             return self::config('folder') ?? '';
         }
 
+        // eliminamos barras al incio y al final
+        $folders = array_map(function($folder) {
+            return ltrim(rtrim($folder, '/\\'), '/\\');
+        }, $folders);
+
         array_unshift($folders, self::config('folder'));
         return implode(DIRECTORY_SEPARATOR, $folders);
     }

--- a/Test/Core/ToolsTest.php
+++ b/Test/Core/ToolsTest.php
@@ -78,6 +78,16 @@ final class ToolsTest extends TestCase
         $this->assertEquals(FS_FOLDER, Tools::folder());
         $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('Test'));
 
+        // comprobamos que elimina barras al inicio y al final
+        $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('/Test'));
+        $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('/Test/'));
+        $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('Test/'));
+        $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('\\Test'));
+        $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('\\Test\\'));
+        $this->assertEquals(FS_FOLDER . DIRECTORY_SEPARATOR . 'Test', Tools::folder('Test\\'));
+        $expected = FS_FOLDER . DIRECTORY_SEPARATOR . 'Test1' . DIRECTORY_SEPARATOR . 'test2';
+        $this->assertEquals($expected, Tools::folder('/Test1/', '/test2'));
+
         // creamos la carpeta MyFiles/Test/Folder1
         $folder1 = Tools::folder('MyFiles', 'Test', 'Folder1');
         $this->assertTrue(Tools::folderCheckOrCreate($folder1));


### PR DESCRIPTION
# Descripción
Hay que corregir la función Tools::folder(). Esta función devuelve la carpeta de trabajo, y si le pasas carpetas como parámetro, las concatena. El problema es que si esas carpetas empiezan o terminan por /, les añade la barra igualmente al concatenar, por lo que terminas con una ruta con barras duplicadas. Debe quitar las barras al principio o final de las carpetas antes de concatenas.


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
