### PR TITLE
sobreescribir opciones default con lo guardado en BBDD

### DIFF
--- a/Core/Controller/EditPageOption.php
+++ b/Core/Controller/EditPageOption.php
@@ -166,15 +166,12 @@ class EditPageOption extends Controller
      */
     protected function loadPageOptions()
     {
-        if ($this->selectedUser && false === $this->loadPageOptionsForUser()) {
-            VisualItemLoadEngine::installXML($this->selectedViewName, $this->model);
+        $user = new User();
+        if(false === $user->loadFromCode($this->selectedUser)){
+            $user = false;
         }
 
-        if (empty($this->selectedUser) && false === $this->loadPageOptionsForAll()) {
-            VisualItemLoadEngine::installXML($this->selectedViewName, $this->model);
-        }
-
-        VisualItemLoadEngine::loadArray($this->columns, $this->modals, $this->rows, $this->model);
+        VisualItemLoadEngine::loadPageOptions($this->selectedViewName, $this->model, $this->columns, $this->modals, $this->rows, $user);
     }
 
     protected function loadSelectedViewName()

--- a/Core/Lib/ExtendedController/BaseView.php
+++ b/Core/Lib/ExtendedController/BaseView.php
@@ -353,21 +353,12 @@ abstract class BaseView
      */
     public function loadPageOptions($user = false)
     {
-        if (false === is_bool($user)) {
-            // sets user security level for use in render
-            VisualItem::setLevel($user->level);
-        }
+        $viewName = explode('-', $this->name)[0];
 
-        $orderBy = ['nick' => 'ASC'];
-        $where = $this->getPageWhere($user);
-        if ($this->pageOption->loadFromCode('', $where, $orderBy)) {
-            $this->settings['customized'] = true;
-        } else {
-            $viewName = explode('-', $this->name)[0];
-            VisualItemLoadEngine::installXML($viewName, $this->pageOption);
-        }
+        $isCustomized = false;
+        VisualItemLoadEngine::loadPageOptions($viewName, $this->pageOption, $this->columns, $this->modals, $this->rows, $user, $isCustomized);
 
-        VisualItemLoadEngine::loadArray($this->columns, $this->modals, $this->rows, $this->pageOption);
+        $this->settings['customized'] = $isCustomized;
     }
 
     public function setSettings(string $key, $value): BaseView


### PR DESCRIPTION
# Descripción
- Actualmente si existe una vista personalizada, no se muestran los campos de un nuevo plugin hasta que no se borra esa vista personalizada ya que se ignora los xml cuando hay vista guardada en BBDD.
- Hemos cambiado la forma de obtener las opciones de pagina obteniendo en primer lugar las opciones desde el XML y sobreescribiendolas con lo que hay guardado en la BBDD.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
