### PR TITLE
Fix: Contacto no incluye tipoidfiscal para clientes y proveedores nuevos

### DIFF
--- a/Core/Model/Contacto.php
+++ b/Core/Model/Contacto.php
@@ -167,6 +167,7 @@ class Contacto extends Base\Contact
             $cliente->nombre = $this->fullName();
             $cliente->observaciones = $this->observaciones;
             $cliente->personafisica = $this->personafisica;
+            $cliente->tipoidfiscal = $this->tipoidfiscal;
             $cliente->razonsocial = empty($this->empresa) ? $this->fullName() : $this->empresa;
             $cliente->telefono1 = $this->telefono1;
             $cliente->telefono2 = $this->telefono2;
@@ -198,6 +199,7 @@ class Contacto extends Base\Contact
             $proveedor->nombre = $this->fullName();
             $proveedor->observaciones = $this->observaciones;
             $proveedor->personafisica = $this->personafisica;
+            $proveedor->tipoidfiscal = $this->tipoidfiscal;
             $proveedor->razonsocial = empty($this->empresa) ? $this->fullName() : $this->empresa;
             $proveedor->telefono1 = $this->telefono1;
             $proveedor->telefono2 = $this->telefono2;


### PR DESCRIPTION
Corregido el problema donde, al crear un cliente o proveedor a partir de un contacto nuevo, no se estaba considerando el campo tipoidfiscal. Esto ocasionaba errores en la creación de clientes desde el módulo TPV. Ahora se garantiza que el tipoidfiscal se registre correctamente en todos los casos.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
