### PR TITLE
Sustituido bootbox por el modal de bootstrap

### DIFF
--- a/Core/Assets/JS/Custom.js
+++ b/Core/Assets/JS/Custom.js
@@ -49,25 +49,61 @@ function animateSpinner(animation, result = null) {
 }
 
 function confirmAction(viewName, action, title, message, cancel, confirm) {
-    bootbox.confirm({
-        title: title,
-        message: message,
-        closeButton: false,
-        buttons: {
-            cancel: {
-                label: '<i class="fa-solid fa-times"></i> ' + cancel
-            },
-            confirm: {
-                label: '<i class="fa-solid fa-check"></i> ' + confirm,
-                className: "btn-warning"
-            }
-        },
-        callback: function (result) {
-            if (result) {
-                $("#form" + viewName + " :input[name=\"action\"]").val(action);
-                $("#form" + viewName).submit();
-            }
+    // Si ya existe un modal con el ID 'dynamicModal', lo eliminamos
+    const existingModal = document.getElementById('dynamicConfirmActionModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    // Crear el HTML del modal como string usando los parámetros
+    const modalHTML = `
+    <div class="modal fade" id="dynamicConfirmActionModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="dynamicConfirmActionModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="dynamicConfirmActionModalLabel">${title}</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            ${message}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary btn-spin-action" data-bs-dismiss="modal">${cancel}</button>
+            <button type="button" id="saveDynamicConfirmActionModalBtn" class="btn btn-danger btn-spin-action">${confirm}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+    // Insertar el modal en el body
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+
+    // Crear una instancia del modal y mostrarlo
+    const myModal = new bootstrap.Modal(document.getElementById('dynamicConfirmActionModal'));
+    myModal.show();
+
+    // Añadir comportamiento al botón de "Guardar cambios"
+    document.getElementById('saveDynamicConfirmActionModalBtn').addEventListener('click', function () {
+        // Selecciona el formulario basado en viewName
+        const form = document.getElementById("form" + viewName);
+
+        // Asigna el valor del campo input[name="action"]
+        const actionInput = form.querySelector('input[name="action"]');
+        if (actionInput) {
+            actionInput.value = action;
         }
+
+        // Envía el formulario
+        form.submit();
+
+        // Cierra el modal
+        myModal.hide();
+    });
+
+    // Eliminar el modal del DOM cuando se cierra
+    document.getElementById('dynamicConfirmActionModal').addEventListener('hidden.bs.modal', function () {
+        document.getElementById('dynamicConfirmActionModal').remove();
     });
 }
 

--- a/Core/Assets/JS/EditListView.js
+++ b/Core/Assets/JS/EditListView.js
@@ -1,6 +1,6 @@
 /*!
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2020 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -22,24 +22,52 @@ var editListViewDeleteMessage = "";
 var editListViewDeleteTitle = "";
 
 function editListViewDelete(viewName) {
-    bootbox.confirm({
-        title: editListViewDeleteTitle,
-        message: editListViewDeleteMessage,
-        closeButton: false,
-        buttons: {
-            cancel: {
-                label: '<i class="fa-solid fa-times"></i> ' + editListViewDeleteCancel
-            },
-            confirm: {
-                label: '<i class="fa-solid fa-check"></i> ' + editListViewDeleteConfirm,
-                className: "btn-danger"
-            }
-        },
-        callback: function (result) {
-            if (result) {
-                editListViewSetAction(viewName, "delete");
-            }
-        }
+    // Si ya existe un modal con el ID 'dynamicEditListViewDeleteModal', lo eliminamos
+    const existingModal = document.getElementById('dynamicEditListViewDeleteModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    // Crear el HTML del modal como string usando los parámetros
+    const modalHTML = `
+    <div class="modal fade" id="dynamicEditListViewDeleteModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="dynamicEditListViewDeleteModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="dynamicEditListViewDeleteModal">${editListViewDeleteTitle}</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            ${editListViewDeleteMessage}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary btn-spin-action" data-bs-dismiss="modal">${editListViewDeleteCancel}</button>
+            <button type="button" id="saveDynamicEditListViewDeleteModalBtn" class="btn btn-danger btn-spin-action">${editListViewDeleteConfirm}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+    // Insertar el modal en el body
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+
+    // Crear una instancia del modal y mostrarlo
+    const myModal = new bootstrap.Modal(document.getElementById('dynamicEditListViewDeleteModal'));
+    myModal.show();
+
+    // Añadir comportamiento al botón de "Guardar cambios"
+    document.getElementById('saveDynamicEditListViewDeleteModalBtn').addEventListener('click', function () {
+        // Ejecutar la acción de eliminar
+        editListViewSetAction(viewName, "delete");
+
+        // Cierra el modal
+        myModal.hide();
+    });
+
+    // Eliminar el modal del DOM cuando se cierra
+    document.getElementById('dynamicEditListViewDeleteModal').addEventListener('hidden.bs.modal', function () {
+        document.getElementById('dynamicEditListViewDeleteModal').remove();
     });
 
     return false;

--- a/Core/Assets/JS/ListView.js
+++ b/Core/Assets/JS/ListView.js
@@ -1,6 +1,6 @@
 /*!
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2023 Carlos Garcia Gomez  <carlos@facturascripts.com>
+ * Copyright (C) 2017-2024 Carlos Garcia Gomez  <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -29,25 +29,52 @@ function listViewCheckboxes(viewName) {
 }
 
 function listViewDelete(viewName) {
-    bootbox.confirm({
-        title: listViewDeleteTitle,
-        message: listViewDeleteMessage,
-        closeButton: false,
-        buttons: {
-            cancel: {
-                label: '<i class="fa-solid fa-times"></i> ' + listViewDeleteCancel,
-                className: "btn-spin-action btn-secondary"
-            },
-            confirm: {
-                label: '<i class="fa-solid fa-check"></i> ' + listViewDeleteConfirm,
-                className: "btn-spin-action btn-danger"
-            }
-        },
-        callback: function (result) {
-            if (result) {
-                listViewSetAction(viewName, "delete");
-            }
-        }
+    // Si ya existe un modal con el ID 'dynamicListViewDeleteModal', lo eliminamos
+    const existingModal = document.getElementById('dynamicListViewDeleteModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    // Crear el HTML del modal como string usando los parámetros
+    const modalHTML = `
+    <div class="modal fade" id="dynamicListViewDeleteModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="dynamicListViewDeleteModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="dynamicConfirmActionModalLabel">${listViewDeleteTitle}</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            ${listViewDeleteMessage}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary btn-spin-action" data-bs-dismiss="modal">${listViewDeleteCancel}</button>
+            <button type="button" id="saveDynamicListViewDeleteModalBtn" class="btn btn-danger btn-spin-action">${listViewDeleteConfirm}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+    // Insertar el modal en el body
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+
+    // Crear una instancia del modal y mostrarlo
+    const myModal = new bootstrap.Modal(document.getElementById('dynamicListViewDeleteModal'));
+    myModal.show();
+
+    // Añadir comportamiento al botón de "Guardar cambios"
+    document.getElementById('saveDynamicListViewDeleteModalBtn').addEventListener('click', function () {
+        // Ejecutar la acción de eliminar
+        listViewSetAction(viewName, "delete");
+
+        // Cierra el modal
+        myModal.hide();
+    });
+
+    // Eliminar el modal del DOM cuando se cierra
+    document.getElementById('dynamicListViewDeleteModal').addEventListener('hidden.bs.modal', function () {
+        document.getElementById('dynamicListViewDeleteModal').remove();
     });
 
     return false;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@eastdesire/jscolor": "^2.5.2",
     "@fortawesome/fontawesome-free": "^6.6.0",
     "@ttskch/select2-bootstrap4-theme": "^1.5.2",
-    "bootbox": "6.*",
     "bootstrap": "5.*",
     "chart.js": "2.*",
     "jquery": "^3.6.4",


### PR DESCRIPTION
La dependencia de bootbox de npm tiene una vulnerabilidad desde hace años que no van a solucionar según su creador, ya que no la considera una vulnerabilidad. Con este  cambio se usa el modal directamente de bootstrap.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.