### PR TITLE
crear grupo de tests lentos

### DIFF
--- a/Test/Core/Data/AccountImportTest.php
+++ b/Test/Core/Data/AccountImportTest.php
@@ -30,6 +30,9 @@ use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group lentos
+ */
 final class AccountImportTest extends TestCase
 {
     use LogErrorsTrait;

--- a/Test/Core/Lib/AccountingCreationTest.php
+++ b/Test/Core/Lib/AccountingCreationTest.php
@@ -41,6 +41,9 @@ final class AccountingCreationTest extends TestCase
         self::installAccountingPlan();
     }
 
+    /**
+     * @group lentos
+     */
     public function testCreateCustomer()
     {
         // creamos un cliente

--- a/Test/Core/Lib/ViesTest.php
+++ b/Test/Core/Lib/ViesTest.php
@@ -22,6 +22,9 @@ namespace FacturaScripts\Test\Core\Lib;
 use FacturaScripts\Core\Lib\Vies;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group lentos
+ */
 final class ViesTest extends TestCase
 {
     public function testCheck(): void

--- a/Test/Core/Model/AgenteTest.php
+++ b/Test/Core/Model/AgenteTest.php
@@ -86,6 +86,9 @@ final class AgenteTest extends TestCase
         $this->assertTrue($agent->delete(), 'agent-cant-delete-3');
     }
 
+    /**
+     * @group lentos
+     */
     public function testVies(): void
     {
         // creamos un agente sin cifnif

--- a/Test/Core/Model/ClienteTest.php
+++ b/Test/Core/Model/ClienteTest.php
@@ -178,6 +178,9 @@ final class ClienteTest extends TestCase
         $this->assertEquals([1, 5], $cliente->getPaymentDays(), 'cliente-has-payment-days');
     }
 
+    /**
+     * @group lentos
+     */
     public function testVies(): void
     {
         // creamos un cliente sin cifnif

--- a/Test/Core/Model/ContactoTest.php
+++ b/Test/Core/Model/ContactoTest.php
@@ -195,6 +195,9 @@ final class ContactoTest extends TestCase
         $this->assertTrue($contact->delete(), 'contact-cant-delete');
     }
 
+    /**
+     * @group lentos
+     */
     public function testVies(): void
     {
         // creamos un contacto sin cif/nif

--- a/Test/Core/Model/EjercicioCierreTest.php
+++ b/Test/Core/Model/EjercicioCierreTest.php
@@ -43,6 +43,9 @@ final class EjercicioCierreTest extends TestCase
         self::removeTaxRegularization();
     }
 
+    /**
+     * @group lentos
+     */
     public function testCloseExercise()
     {
         // creamos una nueva empresa

--- a/Test/Core/Model/FacturaClienteTest.php
+++ b/Test/Core/Model/FacturaClienteTest.php
@@ -800,6 +800,9 @@ final class FacturaClienteTest extends TestCase
         $this->assertTrue($customer->delete());
     }
 
+    /**
+     * @group lentos
+     */
     public function testSetIntraCommunity(): void
     {
         // comprobamos primero si el VIES funciona

--- a/Test/Core/Model/FacturaProveedorTest.php
+++ b/Test/Core/Model/FacturaProveedorTest.php
@@ -574,6 +574,9 @@ final class FacturaProveedorTest extends TestCase
         $this->assertTrue($supplier->delete());
     }
 
+    /**
+     * @group lentos
+     */
     public function testSetIntraCommunity(): void
     {
         // comprobamos si el VIES funciona

--- a/Test/Core/Model/ProveedorTest.php
+++ b/Test/Core/Model/ProveedorTest.php
@@ -152,6 +152,9 @@ final class ProveedorTest extends TestCase
         $this->assertTrue($proveedor->delete(), 'proveedor-cant-delete');
     }
 
+    /**
+     * @group lentos
+     */
     public function testVies(): void
     {
         // creamos un proveedor sin cif/nif

--- a/Test/Core/PluginsTest.php
+++ b/Test/Core/PluginsTest.php
@@ -26,6 +26,9 @@ use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group lentos
+ */
 final class PluginsTest extends TestCase
 {
     use LogErrorsTrait;


### PR DESCRIPTION
# Descripción
- He usado esta herramienta para detectar los tests lentos y los he marcado para que se excluyan cuando deseemos lanzar los tests y que se ejecuten rapidamente.

ejecución normal: `vendor/bin/phpunit`
ejecución excluyendo lentos: `vendor/bin/phpunit --exclude-group=lentos`

Herramienta detectar tests lentos:
`https://github.com/johnkary/phpunit-speedtrap/tree/v4.0.1`

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
