### PR TITLE
corregir barra url

### DIFF
--- a/Core/Lib/MyFilesToken.php
+++ b/Core/Lib/MyFilesToken.php
@@ -49,7 +49,7 @@ class MyFilesToken
 
         // si no se encuentra MyFiles en el path, lo agregamos
         if (false === stripos($path, 'MyFiles')) {
-            $path = 'MyFiles' . DIRECTORY_SEPARATOR . $path;
+            $path = 'MyFiles/' . $path;
         }
 
         return $path . '?myft=' . MyFilesToken::get($path, $permanent, $expiration);


### PR DESCRIPTION
# Descripción
- El método devuelve una URL por lo que la barra siempre es `/`, independientemente del sistema de archivos usado.
