### PR TITLE
Corregido bug al marcar el selected en el widgetSelect

### DIFF
--- a/Core/Lib/Widget/WidgetSelect.php
+++ b/Core/Lib/Widget/WidgetSelect.php
@@ -288,20 +288,23 @@ class WidgetSelect extends BaseWidget
             . ' data-limit="' . $this->limit . '"'
             . '>';
 
+        // guardamos el valor original en otra variable para modificarla
+        $modelValues = $this->value;
+
         // si el value del modelo es un booleano, lo convertimos a string
-        if (is_bool($this->value)) {
-            $this->value = $this->value ? '1' : '0';
+        if (is_bool($modelValues)) {
+            $modelValues = $modelValues ? '1' : '0';
         }
 
         // separamos el value del modelo por comas para poder seleccionar varios valores
         // necesario si activamos el modo multiple
-        $modelValues = explode(',', $this->value);
+        $modelValues = explode(',', $modelValues);
 
         $found = false;
         foreach ($this->values as $option) {
             $title = empty($option['title']) ? $option['value'] : $option['title'];
 
-            if (in_array($option['value'], $modelValues)) {
+            if (in_array($option['value'], $modelValues) && (!$found || $this->multiple)) {
                 $found = true;
                 $html .= '<option value="' . $option['value'] . '" selected>' . $title . '</option>';
                 continue;

--- a/Core/Lib/Widget/WidgetSelect.php
+++ b/Core/Lib/Widget/WidgetSelect.php
@@ -288,12 +288,20 @@ class WidgetSelect extends BaseWidget
             . ' data-limit="' . $this->limit . '"'
             . '>';
 
+        // si el value del modelo es un booleano, lo convertimos a string
+        if (is_bool($this->value)) {
+            $this->value = $this->value ? '1' : '0';
+        }
+
+        // separamos el value del modelo por comas para poder seleccionar varios valores
+        // necesario si activamos el modo multiple
+        $modelValues = explode(',', $this->value);
+
         $found = false;
         foreach ($this->values as $option) {
             $title = empty($option['title']) ? $option['value'] : $option['title'];
 
-            // don't use strict comparison (===)
-            if (!empty($this->value) && in_array($option['value'], explode(',', $this->value))) {
+            if (in_array($option['value'], $modelValues)) {
                 $found = true;
                 $html .= '<option value="' . $option['value'] . '" selected>' . $title . '</option>';
                 continue;
@@ -303,7 +311,8 @@ class WidgetSelect extends BaseWidget
         }
 
         // value not found?
-        if (!$found && !empty($this->value) && !empty($this->source)) {
+        // don't use strict comparison (===)
+        if (!$this->multiple && !$found && $this->value != '' && !empty($this->source)) {
             $html .= '<option value="' . $this->value . '" selected>'
                 . static::$codeModel->getDescription($this->source, $this->fieldcode, $this->value, $this->fieldtitle)
                 . '</option>';


### PR DESCRIPTION
El widgetSelect está guardando bien los datos, pero al pintar y marcar el option selected falla. No lo hace bien cuando el value del modelo, osea el dato que guarda es un booleano, ya que debe convertir el booleano a string para poder hacer correctamente la comparación. Este cambio es necesario cuando se introdujo la opción de múltiple.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.