### PR TITLE
Añadido parámetro totals

### DIFF
--- a/Core/Lib/Widget/WidgetMoney.php
+++ b/Core/Lib/Widget/WidgetMoney.php
@@ -31,9 +31,13 @@ class WidgetMoney extends WidgetNumber
 {
     protected $coddivisa;
 
-    public function showTableTotals(): bool
+    /** @param array $data */
+    public function __construct($data)
     {
-        return true;
+        parent::__construct($data);
+        if (false === isset($data['totals'])) {
+            $this->showTotals = true;
+        }
     }
 
     /** @param object $model */

--- a/Core/Lib/Widget/WidgetNumber.php
+++ b/Core/Lib/Widget/WidgetNumber.php
@@ -51,6 +51,13 @@ class WidgetNumber extends BaseWidget
     public $min;
 
     /**
+     * Indicates if the totals should be shown.
+     *
+     * @var bool
+     */
+    public $showTotals;
+
+    /**
      * Indicates the step value
      *
      * @var string
@@ -66,6 +73,7 @@ class WidgetNumber extends BaseWidget
         $this->decimal = (int)($data['decimal'] ?? FS_NF0);
         $this->max = $data['max'] ?? '';
         $this->min = $data['min'] ?? '';
+        $this->showTotals = isset($data['totals']) && strtolower($data['totals']) === 'true';
         $this->step = $data['step'] ?? 'any';
     }
 
@@ -82,6 +90,14 @@ class WidgetNumber extends BaseWidget
     public function processFormData(&$model, $request)
     {
         $model->{$this->fieldname} = (float)$request->request->get($this->fieldname);
+    }
+
+    /**
+     * @return bool
+     */
+    public function showTableTotals(): bool
+    {
+        return $this->showTotals;
     }
 
     /**


### PR DESCRIPTION
# Descripción
Añadido un parámetro opcional a las columnas que usan widgets de tipo numérico (number y money) con el nombre de totals. Este parámetro permite indicar si se desea el cálculo de total de la columna en las vistas List.

Por defecto si no se indica se establece el actual estado:
- Los widgets number no calcula totales
- Los widgets money calcula totales

Si se informa true o false, se puede añadir o desactivar el cálculo de totales tanto porque se desee incluir el total o porque se desee desactivar el calculo por defecto.

### Ejemplos
        <column name="quantity" display="right" order="150">
            <widget type="number" fieldname="cantidad" totals="true"/>
        </column>

        <column name="price" display="right" order="170">
            <widget type="money" fieldname="pvpunitario" totals="false"/>
        </column>



## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
