### PR TITLE
minimizar numero de consultas a la base de datos

### DIFF
--- a/Core/Lib/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Lib/AjaxForms/CommonSalesPurchases.php
@@ -46,11 +46,6 @@ trait CommonSalesPurchases
     {
         $user = Session::user();
 
-        // si el usuario no existe, devolvemos false
-        if (false === $user->exists()) {
-            return false;
-        }
-
         // si el usuario es administrador, devolvemos true
         if ($user->admin) {
             return true;

--- a/Core/Model/LineaFacturaCliente.php
+++ b/Core/Model/LineaFacturaCliente.php
@@ -43,6 +43,15 @@ class LineaFacturaCliente extends SalesDocumentLine
     /** @var int */
     public $idlinearect;
 
+    /** @var Variante */
+    public Variante $variante;
+
+    /** @var Producto */
+    public Producto $producto;
+
+    /** @var FacturaCliente */
+    public FacturaCliente $documento;
+
     public function documentColumn(): string
     {
         return 'idfactura';
@@ -59,7 +68,7 @@ class LineaFacturaCliente extends SalesDocumentLine
     {
         // comprobamos si existe alguna factura rectificativa
         if ($this->has_refunded_quantity === null) {
-            $refunds = $this->getDocument()->getRefunds();
+            $refunds = $this->documento->getRefunds();
             $this->has_refunded_quantity = !empty($refunds);
         }
 

--- a/Core/View/Tab/RefundFacturaCliente.html.twig
+++ b/Core/View/Tab/RefundFacturaCliente.html.twig
@@ -166,7 +166,7 @@
                                 {% set refunded = line.refundedQuantity() %}
                                 <tr>
                                     <td class="align-middle">
-                                        <a href="{{ line.getProducto().url() }}">{{ line.referencia }}</a>
+                                        <a href="{{ line.producto.url() }}">{{ line.referencia }}</a>
                                         {{ line.descripcion | raw }}
                                     </td>
                                     <td class="align-middle text-end">


### PR DESCRIPTION
# Descripción

EN FACTURA CLIENTE

- Actualmente para obtenter la url del producto se consulta en la base de datos el producto por cada línea, tanto en documento como en vista rectificativa.
- También se consulta si existe el usuario en múltiples ocasiones, cuando ya se ha obtenido el usuario en la sesión. por lo que esta comprobación es redundante.
- En multiples localizaciones del codigo se consulta el producto y variante por linea.
- Esto hace que las consultas a la base de datos se multipliquen.


- Se ha refactorizado el código en el modelo FacturaCliente para obtener todas las variantes y productos de cada línea en una sola consulta, optimizando así el número de consultas a la base de datos.
- Se he eliminado la comprobación de que si el usuario existe. Ya que si se encuentra en la clase Session es porque existe.
- Se ha refactorizado el codigo que llamaba a getProducto para que acceda direcamente a ->producto evitando consultar a la base de datos.

- De esta forma, en una factura que tiene por ejemplo 500 lineas, se ha pasado de unas 1.000 consultas a la base de datos a solo unas 60 consultas.

![captura_pantalla](https://github.com/user-attachments/assets/51336c9c-7f43-4856-b84e-99b7650d52f4)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [] He ejecutado los tests unitarios.
