### PR TITLE
orden por defecto en SalesModal

### DIFF
--- a/Core/Base/AjaxForms/SalesModalHTML.php
+++ b/Core/Base/AjaxForms/SalesModalHTML.php
@@ -261,6 +261,9 @@ class SalesModalHTML
             case 'stock_desc':
                 $sql .= " ORDER BY 8 DESC";
                 break;
+            default:
+                $sql .= " ORDER BY 8 DESC";
+                break;
         }
 
         $results = $dataBase->selectLimit($sql);

--- a/Core/Lib/AjaxForms/SalesModalHTML.php
+++ b/Core/Lib/AjaxForms/SalesModalHTML.php
@@ -257,6 +257,9 @@ class SalesModalHTML
             case 'stock_desc':
                 $sql .= " ORDER BY 8 DESC";
                 break;
+            default:
+                $sql .= " ORDER BY 8 DESC";
+                break;
         }
 
         $results = $dataBase->selectLimit($sql);


### PR DESCRIPTION
## Descripción
Orden stock por defecto en SalesModalHTML.php, tanto la deprecated como en Lib.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

