### PR TITLE
Devolver Status 404 en los métodos GET PUT DELETE

### DIFF
--- a/Core/Lib/API/APIModel.php
+++ b/Core/Lib/API/APIModel.php
@@ -49,7 +49,7 @@ class APIModel extends APIResourceClass
     public function doDELETE(): bool
     {
         if (empty($this->params) || false === $this->model->loadFromCode($this->params[0])) {
-            $this->setError(Tools::lang()->trans('record-not-found'));
+            $this->setError(Tools::lang()->trans('record-not-found'), null, Response::HTTP_NOT_FOUND);
             return false;
         }
 
@@ -90,7 +90,7 @@ class APIModel extends APIResourceClass
 
         // record not found
         if (false === $this->model->loadFromCode($this->params[0])) {
-            $this->setError(Tools::lang()->trans('record-not-found'));
+            $this->setError(Tools::lang()->trans('record-not-found'), null, Response::HTTP_NOT_FOUND);
             return false;
         }
 
@@ -138,7 +138,7 @@ class APIModel extends APIResourceClass
         $param0 = empty($this->params) ? '' : $this->params[0];
         $code = $values[$field] ?? $param0;
         if (false === $this->model->loadFromCode($code)) {
-            $this->setError(Tools::lang()->trans('record-not-found'));
+            $this->setError(Tools::lang()->trans('record-not-found'), null, Response::HTTP_NOT_FOUND);
             return false;
         } elseif (empty($values)) {
             $this->setError(Tools::lang()->trans('no-data-received-form'));


### PR DESCRIPTION
# Descripción
Cambios en el método setError() clase APIModel para devolver un status 404 en el caso de no encontrar el registro.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.