### PR TITLE
Corregido bug al mostrar el nuevo precio de la tarifa

### DIFF
--- a/Core/Model/Join/TarifaProducto.php
+++ b/Core/Model/Join/TarifaProducto.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2019-2022 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2019-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -43,9 +43,7 @@ use FacturaScripts\Dinamic\Model\Variante;
 class TarifaProducto extends JoinModel
 {
 
-    /**
-     * @var Tarifa[]
-     */
+    /** @var Tarifa[] */
     private static $rates = [];
 
     public function __construct(array $data = [])
@@ -81,10 +79,7 @@ class TarifaProducto extends JoinModel
         return $rate;
     }
 
-    /**
-     * @return float
-     */
-    public function priceInRate()
+    public function priceInRate(): float
     {
         // intentamos obtener la variante para aplicar mejor la tarifa
         $variant = new Variante();
@@ -116,7 +111,8 @@ class TarifaProducto extends JoinModel
             'margen' => 'variantes.margen',
             'precio' => 'variantes.precio',
             'referencia' => 'variantes.referencia',
-            'stockfis' => 'variantes.stockfis'
+            'stockfis' => 'variantes.stockfis',
+            'preciotarifa'=> 0,
         ];
     }
 


### PR DESCRIPTION
Desde EditTarifa la columna de nuevo precio de la tarifa no muestra nada, proque la columna que no existe en el modelo se debe añadir al joinModel para poder calcularla.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.