### PR TITLE
Tarea #3851 end point crear factura rectificativa

### DIFF
--- a/Core/Controller/ApiCreateFacturaRectificativaCliente.php
+++ b/Core/Controller/ApiCreateFacturaRectificativaCliente.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Lib\Calculator;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Core\Template\ApiController;
+use FacturaScripts\Dinamic\Model\Cliente;
+use FacturaScripts\Dinamic\Model\FacturaCliente;
+
+class ApiCreateFacturaRectificativaCliente extends ApiController
+{
+    protected function runResource(): void
+    {
+        // si el método no es POST o PUT, devolvemos un error
+        if (!in_array($this->request->getMethod(), ['POST', 'PUT'])) {
+            $this->response->setStatusCode(Response::HTTP_METHOD_NOT_ALLOWED);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Method not allowed',
+            ]));
+            return;
+        }
+
+        // comprobamos que los datos necesarios nos llegan en la request
+        $camposNecesarios = ['codcliente', 'codigorect'];
+        foreach ($camposNecesarios as $keyCampo) {
+            $datosCampo = $this->request->get($keyCampo);
+            if (empty($datosCampo)) {
+                $this->response->setStatusCode(Response::HTTP_BAD_REQUEST);
+                $this->response->setContent(json_encode([
+                    'status' => 'error',
+                    'message' => "$keyCampo field is required",
+                ]));
+                return;
+            }
+        }
+
+        // comprobamos que la factura a rectificar existe
+        $facturaARectificar = new FacturaCliente();
+        $idfactura = $this->request->get('codigorect');
+        if(false === $facturaARectificar->loadFromCode($idfactura)){
+            $this->response->setStatusCode(Response::HTTP_NOT_FOUND);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Invoice to refound not found',
+            ]));
+            return;
+        }
+
+
+        // cargamos el cliente
+        $codcliente = $this->request->get('codcliente');
+        $cliente = new Cliente();
+        if (!$cliente->loadFromCode($codcliente)) {
+            $this->response->setStatusCode(Response::HTTP_NOT_FOUND);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Customer not found',
+            ]));
+            return;
+        }
+
+        // creamos la factura
+        $factura->setSubject($cliente);
+
+        // asignamos el almacén
+        $codalmacen = $this->request->get('codalmacen');
+        if ($codalmacen && false === $factura->setWarehouse($codalmacen)) {
+            $this->response->setStatusCode(Response::HTTP_NOT_FOUND);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Warehouse not found',
+            ]));
+            return;
+        }
+
+        // asignamos la fecha
+        $fecha = $this->request->get('fecha');
+        $hora = $this->request->get('hora', $factura->hora);
+        if ($fecha && false === $factura->setDate($fecha, $hora)) {
+            $this->response->setStatusCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Invalid date',
+            ]));
+            return;
+        }
+
+        // asignamos la divisa
+        $coddivisa = $this->request->get('coddivisa');
+        if ($coddivisa) {
+            $factura->setCurrency($coddivisa);
+        }
+
+        // asignamos el resto de campos del modelo
+        foreach ($factura->getModelFields() as $key => $field) {
+            if ($this->request->request->has($key)) {
+                $factura->{$key} = $this->request->request->get($key);
+            }
+        }
+
+        $db = new DataBase();
+        $db->beginTransaction();
+
+        // guardamos la factura
+        if (false === $factura->save()) {
+            $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Error saving the invoice',
+            ]));
+            $db->rollback();
+            return;
+        }
+
+        // guardamos las líneas
+        if (false === $this->saveLines($factura)) {
+            $db->rollback();
+            return;
+        }
+
+        // ¿Está pagada?
+        if ($this->request->get('pagada', false)) {
+            foreach ($factura->getReceipts() as $receipt) {
+                $receipt->pagado = true;
+                $receipt->save();
+            }
+
+            // recargamos la factura
+            $factura->loadFromCode($factura->idfactura);
+        }
+
+        $db->commit();
+
+        // devolvemos la respuesta
+        $this->response->setContent(json_encode([
+            'doc' => $factura->toArray(),
+            'lines' => $factura->getLines(),
+        ]));
+    }
+
+    protected function saveLines(FacturaCliente &$factura): bool
+    {
+        if (!$this->request->request->has('lineas')) {
+            $this->response->setStatusCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'lineas field is required',
+            ]));
+            return false;
+        }
+
+        $lineData = $this->request->request->get('lineas');
+        $lineas = json_decode($lineData, true);
+        if (!is_array($lineas)) {
+            $this->response->setStatusCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Invalid lines',
+            ]));
+            return false;
+        }
+
+        $newLines = [];
+        foreach ($lineas as $line) {
+            $newLine = empty($line['referencia'] ?? '') ?
+                $factura->getNewLine() :
+                $factura->getNewProductLine($line['referencia']);
+
+            $newLine->cantidad = (float)($line['cantidad'] ?? 1);
+            $newLine->descripcion = $line['descripcion'] ?? $newLine->descripcion ?? '?';
+            $newLine->pvpunitario = (float)($line['pvpunitario'] ?? $newLine->pvpunitario);
+            $newLine->dtopor = (float)($line['dtopor'] ?? $newLine->dtopor);
+            $newLine->dtopor2 = (float)($line['dtopor2'] ?? $newLine->dtopor2);
+
+            if (!empty($line['excepcioniva'] ?? '')) {
+                $newLine->excepcioniva = $line['excepcioniva'];
+            }
+
+            if (!empty($line['codimpuesto'] ?? '')) {
+                $newLine->codimpuesto = $line['codimpuesto'];
+            }
+
+            if (!empty($line['suplido'] ?? '')) {
+                $newLine->suplido = (bool)$line['suplido'];
+            }
+
+            if (!empty($line['mostrar_cantidad'] ?? '')) {
+                $newLine->mostrar_cantidad = (bool)$line['mostrar_cantidad'];
+            }
+
+            if (!empty($line['mostrar_precio'] ?? '')) {
+                $newLine->mostrar_precio = (bool)$line['mostrar_precio'];
+            }
+
+            if (!empty($line['salto_pagina'] ?? '')) {
+                $newLine->salto_pagina = (bool)$line['salto_pagina'];
+            }
+
+            $newLines[] = $newLine;
+        }
+
+        // actualizamos los totales y guardamos
+        if (false === Calculator::calculate($factura, $newLines, true)) {
+            $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Error calculating the invoice',
+            ]));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Core/Controller/ApiRoot.php
+++ b/Core/Controller/ApiRoot.php
@@ -26,7 +26,7 @@ use FacturaScripts\Core\Tools;
 class ApiRoot extends ApiController
 {
     /** @var array */
-    private static $custom_resources = ['crearFacturaCliente', 'exportarFacturaCliente'];
+    private static $custom_resources = ['crearFacturaCliente', 'exportarFacturaCliente', 'crearFacturaRectificativaCliente'];
 
     public static function addCustomResource(string $name): void
     {

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -293,6 +293,7 @@ final class Kernel
             '/AdminPlugins' => 'AdminPlugins',
             '/api' => 'ApiRoot',
             '/api/3/crearFacturaCliente' => 'ApiCreateFacturaCliente',
+            '/api/3/crearFacturaRectificativaCliente' => 'ApiCreateFacturaRectificativaCliente',
             '/api/3/exportarFacturaCliente/*' => 'ApiExportFacturaCliente',
             '/api/*' => 'ApiRoot',
             '/Core/Assets/*' => 'Files',


### PR DESCRIPTION
# Descripción
- Añadir un endpoint a la API para crear facturas rectificativas. Se le debe pasar por parámetro el id de la factura a rectificar, la fecha, el motivo y las cantidades de las líneas (si no se asignan cantidades, se debe asumir que es completa)

- Me queda la duda si estos campos tienen que ser opcionales, requeridos o el valor la factura anterior: codserie, nick y observaciones.

- Lo he implementado copiando el método \FacturaScripts\Core\Controller\EditFacturaCliente::newRefundAction() y adaptandolo a la API.

![imagen](https://github.com/user-attachments/assets/1f4e3ea7-b9b9-4248-95b4-d1f0c6f80308)
