### PR TITLE
Tarea #3501 - add maxString and minString

### DIFF
--- a/Core/DbQuery.php
+++ b/Core/DbQuery.php
@@ -233,12 +233,16 @@ final class DbQuery
 
     public function max(string $field, ?int $decimals = null): float
     {
-        $this->fields = 'MAX(' . self::db()->escapeColumn($field) . ') as _max';
-
-        $row = $this->first();
+        $max = $this->maxString($field);
         return is_null($decimals) ?
-            (float)$row['_max'] :
-            round((float)$row['_max'], $decimals);
+            (float)$max:
+            round((float)$max, $decimals);
+    }
+
+    public function maxString(string $field): string
+    {
+        $this->fields = 'MAX(' . self::db()->escapeColumn($field) . ') as _max';
+        return $this->first()['_max'];
     }
 
     public function maxArray(string $field, string $groupByKey): array
@@ -250,12 +254,16 @@ final class DbQuery
 
     public function min(string $field, ?int $decimals = null): float
     {
-        $this->fields = 'MIN(' . self::db()->escapeColumn($field) . ') as _min';
-
-        $row = $this->first();
+        $min = $this->minString($field);
         return is_null($decimals) ?
-            (float)$row['_min'] :
-            round((float)$row['_min'], $decimals);
+            (float)$min:
+            round((float)$min, $decimals);
+    }
+
+    public function minString(string $field): string
+    {
+        $this->fields = 'MIN(' . self::db()->escapeColumn($field) . ') as _min';
+        return $this->first()['_min'];
     }
 
     public function minArray(string $field, string $groupByKey): array

--- a/Test/Core/DbQueryTest.php
+++ b/Test/Core/DbQueryTest.php
@@ -264,6 +264,40 @@ final class DbQueryTest extends TestCase
         $this->assertTrue($done);
     }
 
+    public function testMaxMinString()
+    {
+        // si no existe la tabla de impuestos, saltamos el test
+        if (false === $this->db()->tableExists('impuestos')) {
+            $this->markTestSkipped('Table impuestos does not exist.');
+        }
+
+        $data = [
+            ['codimpuesto' => 'test1', 'descripcion' => 'test1', 'iva' => 29.99, 'recargo' => 0],
+            ['codimpuesto' => 'test2', 'descripcion' => 'test2', 'iva' => 11.5, 'recargo' => 2.3],
+            ['codimpuesto' => 'test3', 'descripcion' => 'test3', 'iva' => 3.76, 'recargo' => 0.5]
+        ];
+
+        // insertamos 3 impuestos
+        $done = DbQuery::table('impuestos')->insert($data);
+        $this->assertTrue($done);
+
+        $maxString = DbQuery::table('impuestos')
+            ->whereIn('codimpuesto', ['test1', 'test2', 'test3'])
+            ->maxString('codimpuesto');
+        $this->assertEquals('test3', $maxString);
+
+        $minString = DbQuery::table('impuestos')
+            ->whereIn('codimpuesto', ['test1', 'test2', 'test3'])
+            ->minString('codimpuesto');
+        $this->assertEquals('test1', $minString);
+
+        // eliminamos los impuestos
+        $done = DbQuery::table('impuestos')
+            ->whereIn('codimpuesto', ['test1', 'test2', 'test3'])
+            ->delete();
+        $this->assertTrue($done);
+    }
+
     public function testDelete(): void
     {
         // si no existe la tabla de impuestos, saltamos el test


### PR DESCRIPTION
# Descripción
- Los métodos max() y min() de la clase DbQuery devuelven siempre un float, pero en ocaciones queremos operar con cadenas, fechas o bien horas, por lo que hay que añadir los métodos maxString() y minString() que no hagan esta conversión a float que hacen los métodos max() y min().

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
