### PR TITLE
add api endpoint uploadFiles

### DIFF
--- a/Core/Controller/ApiRoot.php
+++ b/Core/Controller/ApiRoot.php
@@ -26,7 +26,7 @@ use FacturaScripts\Core\Tools;
 class ApiRoot extends ApiController
 {
     /** @var array */
-    private static $custom_resources = ['crearFacturaCliente', 'exportarFacturaCliente'];
+    private static $custom_resources = ['crearFacturaCliente', 'exportarFacturaCliente', 'uploadFiles'];
 
     public static function addCustomResource(string $name): void
     {

--- a/Core/Controller/ApiUploadFiles.php
+++ b/Core/Controller/ApiUploadFiles.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Controller;
+
+use FacturaScripts\Core\Response;
+use FacturaScripts\Core\Template\ApiController;
+use FacturaScripts\Core\UploadedFile;
+use FacturaScripts\Dinamic\Model\AttachedFile;
+
+class ApiUploadFiles extends ApiController
+{
+    protected function runResource(): void
+    {
+        if (!in_array($this->request->method(), ['POST', 'PUT'])) {
+            $this->response->setHttpCode(Response::HTTP_METHOD_NOT_ALLOWED);
+            $this->response->setContent(json_encode([
+                'status' => 'error',
+                'message' => 'Method not allowed',
+            ]));
+            return;
+        }
+
+        $uploadedFiles = [];
+        $files = $this->request->files->getArray('files');
+        foreach ($files as $file) {
+            /** @var UploadedFile $file */
+            if($uploadedFile = $this->uploadFile($file)){
+                $uploadedFiles[] = $uploadedFile;
+            }
+        }
+
+        // devolvemos la respuesta
+        $this->response->setContent(json_encode([
+            'files' => $uploadedFiles,
+        ]));
+    }
+
+    private function uploadFile(UploadedFile $uploadFile): ?AttachedFile
+    {
+        if (false === $uploadFile->isValid()) {
+            return null;
+        }
+
+        // exclude php files
+        if (in_array($uploadFile->getClientMimeType(), ['application/x-php', 'text/x-php'])) {
+            return null;
+        }
+
+        // check if the file already exists
+        $destiny = FS_FOLDER . '/MyFiles/';
+        $destinyName = $uploadFile->getClientOriginalName();
+        if (file_exists($destiny . $destinyName)) {
+            $destinyName = mt_rand(1, 999999) . '_' . $destinyName;
+        }
+
+        // move the file to the MyFiles folder
+        if ($uploadFile->move($destiny, $destinyName)) {
+            $file = new AttachedFile();
+            $file->path = $destinyName;
+            if ($file->save()) {
+                return $file;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -294,6 +294,7 @@ final class Kernel
             '/api' => 'ApiRoot',
             '/api/3/crearFacturaCliente' => 'ApiCreateFacturaCliente',
             '/api/3/exportarFacturaCliente/*' => 'ApiExportFacturaCliente',
+            '/api/3/uploadFiles' => 'ApiUploadFiles',
             '/api/*' => 'ApiRoot',
             '/Core/Assets/*' => 'Files',
             '/cron' => 'Cron',


### PR DESCRIPTION
# Descripción
- Permite subir varios archivos a la vez o uno solo por la API.
- Los guarda en el directorio MyFiles y en la base de datos 
- devuelve un array con los campos del modelo AttachedFile de los archivos subidos.
- siempre, ya se envie uno o varios archivos, como nombre de parametro será `files[]`

![imagen](https://github.com/user-attachments/assets/40e1f8eb-06c5-4d41-8494-6432e32330ac)

![imagen](https://github.com/user-attachments/assets/3104c287-ef4a-4665-a71b-ae1b1d543701)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
