### PR TITLE
Sustituido bootbox por el modal de bootstrap

### DIFF
--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -160,26 +160,59 @@
     {% if config('disable_rm_plugins', false) == false %}
         <script>
             function deletePlugin(pluginName) {
-                bootbox.confirm({
-                    title: "{{ trans('confirm-delete')|raw }}",
-                    message: "{{ trans('are-you-sure') }}",
-                    closeButton: false,
-                    buttons: {
-                        cancel: {
-                            label: "<i class='fa-solid fa-times'></i> {{ trans('cancel') }}"
-                        },
-                        confirm: {
-                            label: "<i class='fa-solid fa-check'></i> {{ trans('delete') }}",
-                            className: 'btn-danger'
-                        }
-                    },
-                    callback: function (result) {
-                        if (result) {
-                            animateSpinner('add');
-                            window.location = "{{ fsc.url() }}?action=remove" + "\u0026" + "plugin=" + pluginName
-                                + "\u0026" + "multireqtoken={{ formToken(false) }}";
-                        }
-                    }
+                // Si ya existe un modal con el ID 'dynamicAdminPluginsDeleteModal', lo eliminamos
+                const existingModal = document.getElementById('dynamicAdminPluginsDeleteModal');
+                if (existingModal) {
+                    existingModal.remove();
+                }
+
+                const editListViewDeleteCancel = "{{ trans('cancel') }}";
+                const editListViewDeleteConfirm = "{{ trans('delete') }}";
+                const editListViewDeleteMessage = "{{ trans('are-you-sure') }}";
+                const editListViewDeleteTitle = "{{ trans('confirm-delete')|raw }}";
+
+                // Crear el HTML del modal como string usando los parámetros
+                const modalHTML = `
+                    <div class="modal fade" id="dynamicAdminPluginsDeleteModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="dynamicAdminPluginsDeleteModalLabel" aria-hidden="true">
+                      <div class="modal-dialog">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <h5 class="modal-title" id="dynamicAdminPluginsDeleteModal">${editListViewDeleteTitle}</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                          </div>
+                          <div class="modal-body">
+                            ${editListViewDeleteMessage}
+                          </div>
+                          <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary btn-spin-action" data-bs-dismiss="modal">${editListViewDeleteCancel}</button>
+                            <button type="button" id="saveDynamicAdminPluginsDeleteModalBtn" class="btn btn-danger btn-spin-action">${editListViewDeleteConfirm}</button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  `;
+
+                // Insertar el modal en el body
+                document.body.insertAdjacentHTML('beforeend', modalHTML);
+
+                // Crear una instancia del modal y mostrarlo
+                const myModal = new bootstrap.Modal(document.getElementById('dynamicAdminPluginsDeleteModal'));
+                myModal.show();
+
+                // Añadir comportamiento al botón de "Guardar cambios"
+                document.getElementById('saveDynamicAdminPluginsDeleteModalBtn').addEventListener('click', function () {
+                    // Ejecutar la acción de eliminar
+                    animateSpinner('add');
+                    window.location = "{{ fsc.url() }}?action=remove" + "\u0026" + "plugin=" + pluginName
+                        + "\u0026" + "multireqtoken={{ formToken(false) }}";
+
+                    // Cierra el modal
+                    myModal.hide();
+                });
+
+                // Eliminar el modal del DOM cuando se cierra
+                document.getElementById('dynamicAdminPluginsDeleteModal').addEventListener('hidden.bs.modal', function () {
+                    document.getElementById('dynamicAdminPluginsDeleteModal').remove();
                 });
             }
 

--- a/Core/View/EditPageOption.html.twig
+++ b/Core/View/EditPageOption.html.twig
@@ -143,35 +143,6 @@
     </style>
 {% endblock %}
 
-{% block javascripts %}
-    {{ parent() }}
-    <script>
-        function deleteOptions() {
-            bootbox.confirm({
-                title: "{{ trans('confirm-delete')|raw }}",
-                message: "{{ trans('are-you-sure') }}",
-                closeButton: false,
-                buttons: {
-                    cancel: {
-                        label: "<i class='fa-solid fa-times'></i> {{ trans('cancel') }}"
-                    },
-                    confirm: {
-                        label: "<i class='fa-solid fa-check'></i> {{ trans('delete') }}",
-                        className: 'btn-danger'
-                    }
-                },
-                callback: function (result) {
-                    if (result) {
-                        animateSpinner('add');
-                        document.main_form.action.value = 'delete';
-                        document.main_form.submit();
-                    }
-                }
-            });
-        }
-    </script>
-{% endblock %}
-
 {% macro editGroupColumn(col) %}
     <tr>
         <td title="{{ trans('title') }}">

--- a/Core/View/Master/EditView.html.twig
+++ b/Core/View/Master/EditView.html.twig
@@ -24,33 +24,6 @@
     {% set fieldCount = fieldCount + group.columns | length %}
 {% endfor %}
 
-<script>
-    function editViewDelete(viewName) {
-        bootbox.confirm({
-            title: "{{ trans('confirm-delete') }}",
-            message: "{{ trans('are-you-sure') }}",
-            closeButton: false,
-            buttons: {
-                cancel: {
-                    label: '<i class="fa-solid fa-times"></i> {{ trans('cancel') }}'
-                },
-                confirm: {
-                    label: '<i class="fa-solid fa-check"></i> {{ trans('confirm') }}',
-                    className: "btn-danger"
-                }
-            },
-            callback: function (result) {
-                if (result) {
-                    $("#form" + viewName + " :input[name=\"action\"]").val("delete");
-                    $("#form" + viewName).submit();
-                }
-            }
-        });
-
-        return false;
-    }
-</script>
-
 {# -- Row header -- #}
 <div class="row">
     {% set row = currentView.getRow('header') %}

--- a/Core/View/Master/MenuTemplate.html.twig
+++ b/Core/View/Master/MenuTemplate.html.twig
@@ -60,8 +60,6 @@
     {% block javascripts %}
         <script src="{{ asset('node_modules/jquery/dist/jquery.min.js') }}"></script>
         <script src="{{ asset('node_modules/bootstrap/dist/js/bootstrap.bundle.min.js') }}"></script>
-        <script src="{{ asset('node_modules/bootbox/dist/bootbox.min.js') }}"></script>
-        <script src="{{ asset('node_modules/bootbox/dist/bootbox.locales.min.js') }}"></script>
         <script src="{{ asset('node_modules/pace-js/pace.min.js') }}"></script>
         <script src="{{ asset('node_modules/@fortawesome/fontawesome-free/js/all.min.js') }}"></script>
         <script src="{{ asset('Dinamic/Assets/JS/Custom.js') }}?v=6"></script>


### PR DESCRIPTION
# Descripción
- Sustituido bootbox por el modal de bootstrap
- quedaba algún código de bootbox sin borrar y el delete de los plugins no estaba implementado con bootstrap