### PR TITLE
agregar padding a las alertas del login

### DIFF
--- a/Core/View/Master/MicroTemplate.html.twig
+++ b/Core/View/Master/MicroTemplate.html.twig
@@ -67,10 +67,12 @@
             {% block messages %}
                 {% include 'Macro/Toasts.html.twig' %}
                 {% from 'Macro/Utils.html.twig' import message as showMessage %}
-                {{ showMessage(log, ['error', 'critical'], 'danger') }}
-                {{ showMessage(log, ['warning'], 'warning') }}
-                {{ showMessage(log, ['notice'], 'success') }}
-                {{ showMessage(log, ['info'], 'info') }}
+                <div class="px-2 pt-2">
+                    {{ showMessage(log, ['error', 'critical'], 'danger') }}
+                    {{ showMessage(log, ['warning'], 'warning') }}
+                    {{ showMessage(log, ['notice'], 'success') }}
+                    {{ showMessage(log, ['info'], 'info') }}
+                </div>
             {% endblock %}
             {% block body %}
             {% endblock %}


### PR DESCRIPTION
# Descripción
- agregar padding a las alertas del login

ANTES:

![imagen](https://github.com/user-attachments/assets/bc6fa800-6b6a-4b74-895b-59db683d7ac4)

DESPUÉS:

![imagen](https://github.com/user-attachments/assets/5a09dc6a-2e3e-4ac2-b0b0-e8bee6cf7c7d)

