### PR TITLE
actualizar spinner y toast

### DIFF
--- a/Core/View/Macro/Toasts.html.twig
+++ b/Core/View/Macro/Toasts.html.twig
@@ -1,4 +1,4 @@
-<div id="messages-toasts" style="z-index: 9999; position: fixed; bottom: 0; left: 50%; transform: translateX(-50%);"></div>
+<div id="messages-toasts" style="z-index: 9999; position: fixed; bottom: 2%; left: 50%; transform: translateX(-50%);"></div>
 
 <script>
     function setToast(message, style = 'info', title = '', time = 10000) {
@@ -36,9 +36,9 @@
                 break;
 
             case 'spinner':
-                styleHeader = 'bg-info text-white';
+                styleHeader = 'text-bg-info';
                 styleBorder = 'border border-info';
-                icon = '<i class="fa-solid fa-circle-notch fa-spin me-1"></i>';
+                icon = '<div class="spinner-border me-2 spinner-border-sm" role="status"></div>';
                 title = title !== '' ? title : '{{ trans('processing') }}';
                 break;
 
@@ -64,7 +64,7 @@
 
         let html = '<div class="toast toast-' + style + ' ' + styleBorder + '" style="margin: 15px auto 0 auto;" role="' + role + '" aria-live="' + live + '" aria-atomic="true" ' + delay + '>'
             + '<div class="toast-header ' + styleHeader + '">'
-            + '<strong class="mr-auto">' + icon + title + '</strong>'
+            + '<strong class="me-auto">' + icon + title + '</strong>'
             + '<button type="button" class="ms-4 btn btn-close ' + styleHeader + '" data-bs-dismiss="toast" aria-label="{{ trans('close') }}">'
             + ''
             + '</button>'


### PR DESCRIPTION
# Descripción

- Se ha añadido un pequeño margen inferior para que no se encuentre pegado el final de la pagina.
- Se ha actualizado las clases a bootstrap 5.
- Se ha añadido un spinner que se mueve cuando se muestra el toast de carga

ANTES:

![imagen](https://github.com/user-attachments/assets/2394432a-ae8b-4eae-946d-15df22b1c13d)


AHORA:
el spinner se mueve!!
![imagen](https://github.com/user-attachments/assets/b314e140-0529-4ecb-8ec3-9fbfa229d48d)

