### PR TITLE
"Reemplaza ALL_LIMIT por getLimit en CodeModel"

### DIFF
--- a/Core/Controller/EditProducto.php
+++ b/Core/Controller/EditProducto.php
@@ -29,6 +29,7 @@ use FacturaScripts\Core\Lib\ProductType;
 use FacturaScripts\Core\Model\ProductoImagen;
 use FacturaScripts\Dinamic\Lib\RegimenIVA;
 use FacturaScripts\Dinamic\Model\Atributo;
+use FacturaScripts\Dinamic\Model\CodeModel;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -63,6 +64,10 @@ class EditProducto extends EditController
     protected function createViews()
     {
         parent::createViews();
+
+        // establecemos el límite de registros a 9999, para el select de atributos
+        CodeModel::setLimit(9999);
+
         $this->createViewsVariants();
         $this->createViewsProductImages();
         $this->createViewDocFiles();

--- a/Core/Controller/ListCliente.php
+++ b/Core/Controller/ListCliente.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2023 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -103,14 +103,14 @@ class ListCliente extends ListController
         $this->addFilterSelect($viewName, 'codpais', 'country', 'codpais', Paises::codeModel());
 
         $provinces = $this->codeModel->all('contactos', 'provincia', 'provincia');
-        if (count($provinces) >= CodeModel::ALL_LIMIT) {
+        if (count($provinces) >= CodeModel::getLimit()) {
             $this->addFilterAutocomplete($viewName, 'provincia', 'province', 'provincia', 'contactos', 'provincia');
         } else {
             $this->addFilterSelect($viewName, 'provincia', 'province', 'provincia', $provinces);
         }
 
         $cities = $this->codeModel->all('contactos', 'ciudad', 'ciudad');
-        if (count($cities) >= CodeModel::ALL_LIMIT) {
+        if (count($cities) >= CodeModel::getLimit()) {
             $this->addFilterAutocomplete($viewName, 'ciudad', 'city', 'ciudad', 'contactos', 'ciudad');
         } else {
             $this->addFilterSelect($viewName, 'ciudad', 'city', 'ciudad', $cities);

--- a/Core/Lib/Widget/WidgetDatalist.php
+++ b/Core/Lib/Widget/WidgetDatalist.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -82,7 +82,7 @@ class WidgetDatalist extends WidgetSelect
         $this->fieldcode = $child['fieldcode'] ?? 'id';
         $this->fieldfilter = $child['fieldfilter'] ?? $this->fieldfilter;
         $this->fieldtitle = $child['fieldtitle'] ?? $this->fieldcode;
-        $this->limit = $child['limit'] ?? CodeModel::ALL_LIMIT;
+        $this->limit = $child['limit'] ?? CodeModel::getLimit();
         if ($loadData && $this->source) {
             static::$codeModel::setLimit($this->limit);
             $values = static::$codeModel->all($this->source, $this->fieldcode, $this->fieldtitle, false);

--- a/Core/Lib/Widget/WidgetSelect.php
+++ b/Core/Lib/Widget/WidgetSelect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -336,7 +336,7 @@ class WidgetSelect extends BaseWidget
         $this->fieldcode = $child['fieldcode'] ?? 'id';
         $this->fieldfilter = $child['fieldfilter'] ?? $this->fieldfilter;
         $this->fieldtitle = $child['fieldtitle'] ?? $this->fieldcode;
-        $this->limit = $child['limit'] ?? CodeModel::ALL_LIMIT;
+        $this->limit = $child['limit'] ?? CodeModel::getLimit();
         if ($loadData && $this->source) {
             static::$codeModel::setLimit($this->limit);
             $values = static::$codeModel->all($this->source, $this->fieldcode, $this->fieldtitle, !$this->required);

--- a/Core/Model/AtributoValor.php
+++ b/Core/Model/AtributoValor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2015-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2015-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -79,7 +79,7 @@ class AtributoValor extends Base\ModelClass
 
         $sql = 'SELECT DISTINCT ' . $field . ' AS code, ' . $this->primaryDescriptionColumn() . ' AS description, codatributo, orden '
             . 'FROM ' . static::tableName() . ' ORDER BY codatributo ASC, orden ASC';
-        foreach (self::$dataBase->selectLimit($sql, CodeModel::ALL_LIMIT) as $d) {
+        foreach (self::$dataBase->selectLimit($sql, CodeModel::getLimit()) as $d) {
             $results[] = new CodeModel($d);
         }
 

--- a/Core/Model/Base/ModelClass.php
+++ b/Core/Model/Base/ModelClass.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -74,7 +74,7 @@ abstract class ModelClass extends ModelCore
 
         $sql = 'SELECT DISTINCT ' . $field . ' AS code, ' . $this->primaryDescriptionColumn() . ' AS description '
             . 'FROM ' . static::tableName() . ' ORDER BY 2 ASC';
-        foreach (self::$dataBase->selectLimit($sql, CodeModel::ALL_LIMIT) as $d) {
+        foreach (self::$dataBase->selectLimit($sql, CodeModel::getLimit()) as $d) {
             $results[] = new CodeModel($d);
         }
 

--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2018-2024 Carlos García Gómez <carlos@facturascripts.com>
+ * Copyright (C) 2018-2025 Carlos García Gómez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -151,7 +151,7 @@ class Variante extends Base\ModelClass
             . DataBaseWhere::getSQLWhere($where)
             . " ORDER BY v." . $field . " ASC";
 
-        foreach (self::$dataBase->selectLimit($sql, CodeModel::ALL_LIMIT) as $data) {
+        foreach (self::$dataBase->selectLimit($sql, CodeModel::getLimit()) as $data) {
             $data['description'] = $this->getAttributeDescription(
                 $data['idatributovalor1'],
                 $data['idatributovalor2'],


### PR DESCRIPTION
Se actualizó el uso de `CodeModel::ALL_LIMIT` por `CodeModel::getLimit()` en varias clases para mejorar la flexibilidad del límite de registros. Además, se incrementó el límite de registros a 9999 en `EditProducto` para el select de atributos. También se actualizaron los años en los encabezados de copyright.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.