### PR TITLE
bug strict autocomplete

### DIFF
--- a/Core/Lib/Widget/WidgetAutocomplete.php
+++ b/Core/Lib/Widget/WidgetAutocomplete.php
@@ -52,6 +52,13 @@ class WidgetAutocomplete extends WidgetSelect
      */
     public $strict = true;
 
+    public function __construct(array $data)
+    {
+        parent::__construct($data);
+
+        $this->strict = isset($data['strict']) ? ($data['strict'] == 'true') : true;
+    }
+
     /**
      * @param object $model
      * @param string $title
@@ -162,7 +169,6 @@ class WidgetAutocomplete extends WidgetSelect
         // according to the information entered by the user.
         parent::setSourceData($child, false);
         $this->fieldfilter = $child['fieldfilter'] ?? '';
-        $this->strict = isset($child['strict']) ? ($child['strict'] == 'true') : true;
     }
 
     /**


### PR DESCRIPTION
# Descripción
- se estaba obteniendo el parámetro strict desde el child/values.
- ahora se obtiene desde la etiqueta del widget tal y como se indica en la documentación.

![Captura](https://github.com/user-attachments/assets/f285ded4-b296-4cd0-96bc-f25bdfdcbe7e)

