### PR TITLE
actualizar valor del input en tiempo real sin strictmode

### DIFF
--- a/Core/Assets/JS/WidgetAutocomplete.js
+++ b/Core/Assets/JS/WidgetAutocomplete.js
@@ -83,7 +83,7 @@ $(document).ready(function () {
         // pueda pulsar tab o cambiar a otro input sin tener que
         // seleccionar ninguna opcion(ni si quiera la opción de su propia busqueda)
         $(this).on("keyup", function (event) {
-            if(data.strict === "0") {
+            if(data.strict === "0" && event.key !== "Enter") {
                 $("form[id=" + formId + "] input[name=" + data.field + "]").val(event.target.value);
             }
         });

--- a/Core/Assets/JS/WidgetAutocomplete.js
+++ b/Core/Assets/JS/WidgetAutocomplete.js
@@ -76,5 +76,16 @@ $(document).ready(function () {
                 return false;
             }
         });
+
+        // cuando el modo estricto se encuentra deshabilitado
+        // actualizamos el valor del input mientras escribe
+        // por si el usuario no encuentra ningún item en el select
+        // pueda pulsar tab o cambiar a otro input sin tener que
+        // seleccionar ninguna opcion(ni si quiera la opción de su propia busqueda)
+        $(this).on("keyup", function (event) {
+            if(data.strict === "0") {
+                $("form[id=" + formId + "] input[name=" + data.field + "]").val(event.target.value);
+            }
+        });
     });
 });


### PR DESCRIPTION
# Descripción
- actualizar valor del input en tiempo real sin strictmode
- ahora cuando el autocomplete se configura para que no sea estricto y se puedan añadir valores que no se encuentran en las opciones del select hay que pulsar sobre la opción que aparece por defecto cuando no encuentra ningún valor. esta opción el mismo valor que se ha escrito como busqueda. si no se pulsa sobre ese valor no se actualiza el valor y por tanto no se guardan los datos.
- para evitar este comportamiento y que el usuario pueda cambiar con tab o cambiar de foco a otro input conservando los valores introducidos como busque se ha implementado la actualización del valor del input en tiempo real siempre que strict=false.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
