### PR TITLE
activar plugins requeridos al mismo tiempo

### DIFF
--- a/Core/Controller/AdminPlugins.php
+++ b/Core/Controller/AdminPlugins.php
@@ -142,6 +142,17 @@ class AdminPlugins extends Controller
         }
 
         $pluginName = $this->request->get('plugin', '');
+
+        if($this->request->getBool('multienable')){
+            $plugin = Plugins::get($pluginName);
+            foreach ($plugin->require as $requiredPluginName) {
+                if(Plugins::isInstalled($requiredPluginName) && !Plugins::isEnabled($requiredPluginName)){
+                    Plugins::enable($requiredPluginName);
+                    Cache::clear();
+                }
+            }
+        }
+
         Plugins::enable($pluginName);
         Cache::clear();
     }

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -153,6 +153,21 @@
             </div>
         </form>
     {% endif %}
+
+    <div id="modal-multi-plugin" class="modal" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-body"></div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ trans('cancel') }}</button>
+                    <a id="link-multi-plugin" class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');">
+                        <i class="fa-solid fa-toggle-on me-1" aria-hidden="true"></i>
+                        <span class="d-none d-sm-inline-block">{{ trans('enable-all') }}</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block javascripts %}
@@ -210,6 +225,20 @@
                         $(value).toggle($(querySelectorPluginName, value).text().toLowerCase().trim().includes(query));
                     });
                 });
+            }
+
+            function modalMultiPlugin(pluginName, pluginsToEnable) {
+                const pluginsToEnableArray = JSON.parse(pluginsToEnable);
+
+                let modal = $('#modal-multi-plugin');
+                let modalBody = $(modal).find('.modal-body');
+                modalBody.html(
+                    `El plugin ${pluginName} requiere estos plugins: ${pluginsToEnableArray.join(', ')}<br/>`
+                    + `¿Desea habilitarlos también?`
+                );
+                $('#link-multi-plugin').attr('href', '{{ fsc.url() }}?action=enable&multireqtoken={{ formToken(false) }}&multienable=true&plugin=' + pluginName);
+
+                modal.modal('show');
             }
         </script>
     {% endif %}
@@ -374,19 +403,33 @@
                                             {{ trans('update') }}
                                         </a>
                                         <div class="dropdown-divider"></div>
-                                        <a class="dropdown-item"
-                                           href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                            <i class="fa-solid fa-check fa-fw me-1" aria-hidden="true"></i>
-                                            {{ trans('enable') }}
-                                        </a>
+                                        {% if plugin.require %}
+                                            <button class="dropdown-item" onclick="modalMultiPlugin('{{ plugin.name }}', '{{ plugin.require|json_encode }}');">
+                                                <i class="fa-solid fa-check fa-fw me-1" aria-hidden="true"></i>
+                                                {{ trans('enable') }}
+                                            </button>
+                                        {% else %}
+                                            <a class="dropdown-item"
+                                               href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                                <i class="fa-solid fa-check fa-fw me-1" aria-hidden="true"></i>
+                                                {{ trans('enable') }}
+                                            </a>
+                                        {% endif %}
                                     </div>
                                 </div>
                             {% else %}
-                                <a class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');"
-                                   href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
-                                    <i class="fa-solid fa-toggle-on me-1" aria-hidden="true"></i>
-                                    <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
-                                </a>
+                                {% if plugin.require %}
+                                    <button type="button" class="btn btn-sm btn-success btn-spin-action" onclick="modalMultiPlugin('{{ plugin.name }}', '{{ plugin.require|json_encode }}');">
+                                        <i class="fa-solid fa-toggle-on me-1" aria-hidden="true"></i>
+                                        <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
+                                    </button>
+                                {% else %}
+                                    <a class="btn btn-sm btn-success btn-spin-action" onclick="animateSpinner('add');"
+                                       href="{{ url }}?action=enable&amp;plugin={{ plugin.name }}&amp;multireqtoken={{ formToken(false) }}">
+                                        <i class="fa-solid fa-toggle-on me-1" aria-hidden="true"></i>
+                                        <span class="d-none d-sm-inline-block">{{ trans('enable') }}</span>
+                                    </a>
+                                {% endif %}
                             {% endif %}
                         {% else %}
                             {{ plugin.compatibilityDescription() }}


### PR DESCRIPTION
# Descripción
- Activar plugins requeridos al mismo tiempo que se instala un plugin.

![Captura Pantalla](https://github.com/user-attachments/assets/43842d7d-998f-4e2b-80e0-926457f5bda4)


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
