### PR TITLE
fix: fixed campos mal configurados and centered buttons

### DIFF
--- a/Core/View/ReportTaxes.html.twig
+++ b/Core/View/ReportTaxes.html.twig
@@ -168,7 +168,16 @@
                                         <input class="form-check-input" type="checkbox" value="1" name="column_number2"
                                                id="column_number2" checked>
                                         <label class="form-check-label" for="column_number2">
-                                            {{ trans('number') }}
+                                            {{ trans('number2') }}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" value="1" name="column_numsupplier"
+                                               id="column_numsupplier" checked>
+                                        <label class="form-check-label" for="column_numsupplier">
+                                            {{ trans('numsupplier') }}
                                         </label>
                                     </div>
                                 </div>
@@ -284,13 +293,13 @@
                         </div>
                         <div class="card-footer">
                             <div class="row">
-                                <div class="col-sm">
+                                <div class="col-sm d-flex justify-content-center">
                                     <button type="button" onclick="sendReportTaxes('purchases')"
                                             class="btn btn-lg btn-block btn-secondary btn-spin-action">
                                         {{ trans('purchases') }}
                                     </button>
                                 </div>
-                                <div class="col-sm">
+                                <div class="col-sm d-flex justify-content-center">
                                     <button type="button" onclick="sendReportTaxes('sales')"
                                             class="btn btn-lg btn-block btn-primary btn-spin-action">
                                         {{ trans('sales') }}


### PR DESCRIPTION
# Descripción

- Se ha modificado el formulario para que aparezca separado y aparezcan los dos campos dependiendo de si es ventas o compras.
- Se han centrado los dos botones.

Importante: no se han colocado directamente en la linea porque aparecerían los dos campos en vez de aparecer solo cuando deben.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
