### PR TITLE
agregando patron de anyo 2

### DIFF
--- a/Core/Lib/CodePatterns.php
+++ b/Core/Lib/CodePatterns.php
@@ -67,6 +67,7 @@ class CodePatterns
             '{HORA}' => Tools::hour($hora),
             '{FECHAHORA}' => Tools::dateTime($fecha . ' ' . $hora),
             '{ANYO}' => date('Y', strtotime($fecha)),
+            '{ANYO2}' => date('y', strtotime($fecha)),
             '{DIA}' => date('d', strtotime($fecha)),
             '{EJE}' => $ejercicio,
             '{EJE2}' => substr($ejercicio, -2),

--- a/Core/Model/SecuenciaDocumento.php
+++ b/Core/Model/SecuenciaDocumento.php
@@ -138,6 +138,7 @@ class SecuenciaDocumento extends ModelClass
             '{HORA}' => Tools::hour(),
             '{FECHAHORA}' => Tools::dateTime(Tools::date() . ' ' . Tools::hour()),
             '{ANYO}' => date('Y'),
+            '{ANYO2}' => date('y'),
             '{DIA}' => date('d'),
             '{EJE}' => $this->codejercicio,
             '{EJE2}' => substr($this->codejercicio ?? '', -2),
@@ -168,7 +169,7 @@ class SecuenciaDocumento extends ModelClass
         }
 
         // si el patrón no tiene ejercicio o fecha, mostramos un aviso
-        $codes = ['{EJE}', '{EJE2}', '{ANYO}', '{FECHA}', '{FECHAHORA}'];
+        $codes = ['{EJE}', '{EJE2}', '{ANYO}', '{ANYO2}','{FECHA}', '{FECHAHORA}'];
         $found = false;
         foreach ($codes as $code) {
             if (false !== strpos($this->patron, $code)) {


### PR DESCRIPTION
# Descripción


Se ha realizado una mejora en la gestión de patrones de código para documentos, añadiendo el soporte para el patrón `{ANYO2}` en dos ubicaciones clave del sistema:

- En el archivo SecuenciaDocumento.php, dentro del método `generateCode()`, se ha añadido la clave:
  ```php
  '{ANYO2}' => date('y'),
  ```
  Esto permite que los códigos generados para documentos puedan incluir el año en formato de dos dígitos, facilitando la personalización de la numeración de documentos según las necesidades del usuario.

- En el archivo CodePatterns.php, dentro del método `trans()`, se ha añadido:
  ```php
  '{ANYO2}' => date('y', strtotime($fecha)),
  ```
  De esta forma, al transformar textos con patrones, también se puede utilizar `{ANYO2}` para obtener el año de la fecha correspondiente en formato de dos dígitos.

Con estos cambios, se mejora la flexibilidad y personalización de los patrones de código en FacturaScripts, permitiendo a los usuarios adaptar los formatos de numeración a sus preferencias o requerimientos legales.

---

## Description (english)

## Descripción

Se ha realizado una mejora en la gestión de patrones de código para documentos, añadiendo el soporte para el patrón `{ANYO2}` en dos ubicaciones clave del sistema:

- En el archivo SecuenciaDocumento.php, dentro del método `generateCode()`, se ha añadido la clave:
  ```php
  '{ANYO2}' => date('y'),
  ```
  Esto permite que los códigos generados para documentos puedan incluir el año en formato de dos dígitos, facilitando la personalización de la numeración de documentos según las necesidades del usuario.

- En el archivo CodePatterns.php, dentro del método `trans()`, se ha añadido:
  ```php
  '{ANYO2}' => date('y', strtotime($fecha)),
  ```
  De esta forma, al transformar textos con patrones, también se puede utilizar `{ANYO2}` para obtener el año de la fecha correspondiente en formato de dos dígitos.

Con estos cambios, se mejora la flexibilidad y personalización de los patrones de código en FacturaScripts, permitiendo a los usuarios adaptar los formatos de numeración a sus preferencias o requerimientos legales.

---

## Description (english)

A new feature has been added to the code pattern system for documents, supporting the `{ANYO2}` pattern in two key places:

- In SecuenciaDocumento.php, inside the `generateCode()` method, the following line was added:
  ```php
  '{ANYO2}' => date('y'),
  ```
  This allows generated document codes to include the year in two-digit format, making document numbering more customizable.

- In CodePatterns.php, inside the `trans()` method, the following was added:
  ```php
  '{ANYO2}' => date('y', strtotime($fecha)),
  ```
  This enables the `{ANYO2}` pattern to be used when transforming texts, extracting the two-digit year from the relevant date.

These changes improve the flexibility and customization of code patterns in FacturaScripts, allowing users to adapt document numbering formats to their needs.

---

## ¿Cómo has probado los cambios?

- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

---

### How has the changes been tested? (english)

- [x] I have reviewed my code before sending it.
- [x] I have tested it on my PC.
- [x ] I have tested it on an empty database.
- [ ] I have run the unit tests.



