### PR TITLE
Parche emergente para el bug de no poder subir imágen en product image.

### DIFF
--- a/Core/Lib/ExtendedController/ProductImagesTrait.php
+++ b/Core/Lib/ExtendedController/ProductImagesTrait.php
@@ -65,7 +65,9 @@ trait ProductImagesTrait
             }
 
             try {
-                $uploadFile->move(FS_FOLDER . DIRECTORY_SEPARATOR . 'MyFiles', $uploadFile->getClientOriginalName());
+                $folder = Tools::folder('MyFiles');
+                Tools::folderCheckOrCreate($folder);
+                $uploadFile->move($folder . DIRECTORY_SEPARATOR, $uploadFile->getClientOriginalName());
                 $idfile = $this->createAttachedFile($uploadFile->getClientOriginalName());
                 if (empty($idfile)) {
                     Tools::log()->error('record-save-error');


### PR DESCRIPTION
Al parecer, al subir una imagen no se revisa la existencia de myFiles. Este parche soluciona ese problema.

- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
