### PR TITLE
fix(chore): :bug: incluir funciones de extensiones

### DIFF
--- a/Core/Lib/Widget/RowStatistics.php
+++ b/Core/Lib/Widget/RowStatistics.php
@@ -77,7 +77,8 @@ class RowStatistics extends VisualItem
             return ' ERROR';
         }
 
-        $value = method_exists($controller, $data['function']) ? $controller->{$data['function']}() : '-';
+        $funciones_extensiones = array_column($controller::$extensions, 'name');
+        $value = method_exists($controller, $data['function']) || in_array($data['function'], $funciones_extensiones) ? $controller->{$data['function']}() : '-';
         return ' <a href="' . $link . '"' . $divID . ' class="btn ' . $color . ' ' . $class . ' mb-2">' . $icon . $label . ' ' . $value . '</a>';
     }
 }

--- a/Core/Template/ExtensionsTrait.php
+++ b/Core/Template/ExtensionsTrait.php
@@ -31,7 +31,7 @@ trait ExtensionsTrait
      *
      * @var array
      */
-    protected static $extensions = [];
+    public static $extensions = [];
 
     /**
      * Executes the first matched extension.


### PR DESCRIPTION
# Descripción
- Actualmente no se verifica si existe la funcion en el array de extensiones.
- Ahora se pueden incluir rows de estadistica sin tener que extender el modelo existente. ahora se puede hacer con extensiones.

Ejemplo de plugin:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<view>
    <rows>
        <row type="statistics">
            <datalabel icon="fa-solid fa-person-circle-plus" label="customer-points" function="getPuntos"/>
        </row>
    </rows>
</view>
```
Extension:
```php
class EditCliente
{
    public function getPuntos(): \Closure
    {
        return function () {
            return '999';
        };
    }
}
```


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
