### PR TITLE
no escapar funciones de myslq

### DIFF
--- a/Core/Base/DataBase/MysqlEngine.php
+++ b/Core/Base/DataBase/MysqlEngine.php
@@ -214,7 +214,13 @@ class MysqlEngine extends DataBaseEngine
      */
     public function escapeColumn($link, $name): string
     {
-        return '`' . $name . '`';
+        if (preg_match('/\w+\s*\(.*\)/', $name)) {
+            // Si $name tiene parentesis como una función (e.g., lower(menu)), no la escapamos con comillas invertidas.
+            return $name;
+        } else {
+            // Si es un nombre de columna simple, lo escapamos con comillas invertidas.
+            return '`' . str_replace('`', '``', $name) . '`';
+        }
     }
 
     /**


### PR DESCRIPTION
# Descripción
- en algunos casos usamos funciones de mysql en los campos y se le añade las comillas invertidas. Ahora verifica si es una funcion de myslq y no le añade las comillas.

por ejemplo:
```php
$where = [new DataBaseWhere('showonmenu', true)];
$order = [
    'lower(menu)' => 'ASC',
    'lower(submenu)' => 'ASC',
    'ordernum' => 'ASC',
    'lower(title)' => 'ASC'
];
```
