### PR TITLE
actualizar y usar phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   "require-dev": {
     "phpunit/phpunit": "9.*",
     "squizlabs/php_codesniffer": "3.*",
-    "phpstan/phpstan": "^0.12.93"
+    "phpstan/phpstan": "^2.1"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+define('FS_CODPAIS', '');
+define('FS_COOKIES_EXPIRE', '');
+define('FS_DB_FOREIGN_KEYS', '');
+define('FS_DB_HOST', '');
+define('FS_DB_NAME', '');
+define('FS_DB_PASS', '');
+define('FS_DB_PORT', '');
+define('FS_DB_TYPE', '');
+define('FS_DB_TYPE_CHECK', '');
+define('FS_DB_USER', '');
+define('FS_DEBUG', '');
+define('FS_FOLDER', '');
+define('FS_ITEM_LIMIT', '');
+define('FS_LANG', '');
+define('FS_NF0', '');
+define('FS_NF1', '');
+define('FS_ROUTE', '');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+parameters:
+    level: 1
+    paths:
+        - Core
+    scanDirectories:
+        - Dinamic
+    bootstrapFiles:
+        - phpstan-bootstrap.php
+    ignoreErrors:
+        -
+            identifier: new.static
+        -
+            identifier: empty.variable
+        -
+            identifier: isset.variable


### PR DESCRIPTION
# Descripción
- actualizar y usar phpstan, ya que también tenemos una github action configurada.
- el archivo `phpstan-bootstrap.php` solo es para definir las constantes, no es necesario asignarle valor.
- se usa un level muy bajo para no tener que dedicarle mucho tiempo a tipar todo.

<img width="1035" height="929" alt="imagen" src="https://github.com/user-attachments/assets/70fb5eba-37c0-4b13-b7ff-6b8c422a2236" />

