### PR TITLE
Añadir los métodos join, groupBy y having

### DIFF
--- a/Core/Base/DataBase/MysqlEngine.php
+++ b/Core/Base/DataBase/MysqlEngine.php
@@ -206,6 +206,7 @@ class MysqlEngine extends DataBaseEngine
 
     /**
      * Escapes the column name.
+     * If it has table.column sintax, it escapes it too.
      *
      * @param mysqli $link
      * @param string $name
@@ -214,6 +215,14 @@ class MysqlEngine extends DataBaseEngine
      */
     public function escapeColumn($link, $name): string
     {
+        // Si el nombre contiene un punto, asumimos que es 'tabla.columna'
+        if (strpos($name, '.') !== false) {
+            $parts = explode('.', $name);
+            // Escapamos cada parte individualmente
+            return '`' . implode('`.`', $parts) . '`';
+        }
+
+        // Si no hay punto, escapamos el nombre completo
         return '`' . $name . '`';
     }
 

--- a/Core/Base/DataBase/PostgresqlEngine.php
+++ b/Core/Base/DataBase/PostgresqlEngine.php
@@ -156,7 +156,8 @@ class PostgresqlEngine extends DataBaseEngine
     }
 
     /**
-     * Escapes the column name.
+     * Escapes the column name for PostgreSQL.
+     * Supports "table.column" syntax.
      *
      * @param resource $link
      * @param string $name
@@ -165,6 +166,14 @@ class PostgresqlEngine extends DataBaseEngine
      */
     public function escapeColumn($link, $name): string
     {
+        // Si el nombre contiene un punto, asumimos que es 'tabla.columna'
+        if (strpos($name, '.') !== false) {
+            $parts = explode('.', $name);
+            // Escapamos cada parte individualmente con comillas dobles
+            return '"' . implode('"."', $parts) . '"';
+        }
+
+        // Si no hay punto, escapamos el nombre completo
         return '"' . $name . '"';
     }
 

--- a/Core/DbQuery.php
+++ b/Core/DbQuery.php
@@ -188,6 +188,14 @@ final class DbQuery
         return $this;
     }
 
+    /**
+     * Añade una cláusula HAVING a la consulta.
+     * 
+     * CUIDADO: Se deben de escapar los campos manualmente y colocar la condición (posgre SQL no soporta aliases en having)
+     * 
+     * Modo de uso:
+     * $query->having('FUNC(' . $db->escapeColumn($field) ' . ') > 0');
+     */
     public function having(string $having): self
     {
         $this->having = $having;

--- a/Test/Core/DbQueryTest.php
+++ b/Test/Core/DbQueryTest.php
@@ -473,14 +473,14 @@ final class DbQueryTest extends TestCase
                 .' SUM(' . $this->db()->escapeColumn('precio') . ') as total_precio'
             )
             ->groupBy('codfamilia')
-            ->having('total_precio > 25')
+            ->having('SUM(' . $this->db()->escapeColumn('precio') . ') > 25')
             ->whereLike('codfamilia', 'FAM%');
 
         $sql = 'SELECT ' . $this->db()->escapeColumn('codfamilia') . ', SUM(' . $this->db()->escapeColumn('precio') . ') AS ' . $this->db()->escapeColumn('total_precio')
             . ' FROM ' . $this->db()->escapeColumn('productos')
             . ' WHERE ' . Where::like('codfamilia', 'FAM%')->sql()
             . ' GROUP BY ' . $this->db()->escapeColumn('codfamilia')
-            . ' HAVING total_precio > 25';
+            . ' HAVING SUM(' . $this->db()->escapeColumn('precio') . ') > 25';
         $this->assertEquals($sql, $query->sql());
 
         $results = $query->get();

--- a/Test/Core/DbQueryTest.php
+++ b/Test/Core/DbQueryTest.php
@@ -21,11 +21,14 @@ namespace FacturaScripts\Test\Core;
 
 use FacturaScripts\Core\Base\DataBase;
 use FacturaScripts\Core\DbQuery;
-use FacturaScripts\Core\Model\LogMessage;
-use FacturaScripts\Core\Model\Pais;
+use FacturaScripts\Dinamic\Model\LogMessage;
 use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\Familia;
 use FacturaScripts\Dinamic\Model\Producto;
+use FacturaScripts\Dinamic\Model\Impuesto;
+use FacturaScripts\Dinamic\Model\Cliente;
+use FacturaScripts\Dinamic\Model\Pais;
+use FacturaScripts\Dinamic\Model\Serie;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -581,6 +584,17 @@ final class DbQueryTest extends TestCase
         }
 
         return $this->db;
+    }
+
+    protected function setUp(): void
+    {
+        new Serie();
+        new Cliente();
+        new Pais();
+        new Impuesto();
+        new Producto();
+        new Familia();
+
     }
 
     protected function tearDown(): void

--- a/Test/Core/DbQueryTest.php
+++ b/Test/Core/DbQueryTest.php
@@ -468,12 +468,15 @@ final class DbQueryTest extends TestCase
 
         // construimos la consulta con groupBy y having
         $query = DbQuery::table('productos')
-            ->selectRaw('`codfamilia`, SUM(`precio`) as total_precio')
+            ->select(
+                'codfamilia,'
+                .' SUM(' . $this->db()->escapeColumn('precio') . ') as total_precio'
+            )
             ->groupBy('codfamilia')
             ->having('total_precio > 25')
             ->whereLike('codfamilia', 'FAM%');
 
-        $sql = 'SELECT ' . $this->db()->escapeColumn('codfamilia') . ', SUM(' . $this->db()->escapeColumn('precio') . ') as total_precio'
+        $sql = 'SELECT ' . $this->db()->escapeColumn('codfamilia') . ', SUM(' . $this->db()->escapeColumn('precio') . ') AS ' . $this->db()->escapeColumn('total_precio')
             . ' FROM ' . $this->db()->escapeColumn('productos')
             . ' WHERE ' . Where::like('codfamilia', 'FAM%')->sql()
             . ' GROUP BY ' . $this->db()->escapeColumn('codfamilia')
@@ -541,11 +544,11 @@ final class DbQueryTest extends TestCase
 
         // construimos la consulta con groupBy
         $query = DbQuery::table('productos')
-            ->selectRaw('`codfamilia`, COUNT(*) as total_productos')
+            ->select('codfamilia, COUNT(*) AS total_productos')
             ->groupBy('codfamilia')
             ->whereLike('codfamilia', 'FAM%');
 
-        $sql = 'SELECT ' . $this->db()->escapeColumn('codfamilia') . ', COUNT(*) as total_productos'
+        $sql = 'SELECT ' . $this->db()->escapeColumn('codfamilia') . ', COUNT(*) AS ' . $this->db()->escapeColumn('total_productos')
             . ' FROM ' . $this->db()->escapeColumn('productos')
             . ' WHERE ' . Where::like('codfamilia', 'FAM%')->sql()
             . ' GROUP BY ' . $this->db()->escapeColumn('codfamilia');


### PR DESCRIPTION
# Descripción
- Se ha agregado la función `setUp` para inicializar las tablas antes de los tests (prevenir ser skipeados)
- Se han verificado los métodos groupBy y having
  - Se ha agregado indicaciones en el método having
- Se han testeado los tres métodos
- Se ha agregado un 'warning' para indicar el modo de uso para funciones (en la documentación de la función `select()`).
- Para conseguir implementar la funcionalidad de join se han realizado varios cambios extra
  - Se ha agregado un filtrado más correcto:
```
`tabla`.`columna`
```
   - Se ha modificado también la función select para tener soporte para el `AS`, ejemplo:
 ```
`tabla`.`columna` AS `nombreAlias`
`columna` AS `nombreAlias`
```

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
