### PR TITLE
corregir las dimensiones de la imagen

### DIFF
--- a/Core/View/Installer/Redir.html.twig
+++ b/Core/View/Installer/Redir.html.twig
@@ -25,7 +25,7 @@
     <div class="row justify-content-center align-items-center min-vh-100">
         <div class="col-md-6">
             <div class="card shadow">
-                <img src="Core/Assets/Images/installed.png" class="card-img-top" alt="installation-completed"
+                <img src="Core/Assets/Images/installed.png" class="card-img-top m-auto w-50" alt="installation-completed"
                      loading="lazy"/>
                 <div class="card-body">
                     <p class="lead text-center mb-4">


### PR DESCRIPTION
actualmente se pierde el botón cuando se cambia el tamaño de la pantalla. se ha modificado el tamaño y alineado de la imagen para que siempre se vea el botón.


https://github.com/user-attachments/assets/006ff71f-3148-4cdc-9062-e077186c73e3

