### PR TITLE
agregar timestamp al archivo crash

### DIFF
--- a/Core/CrashReport.php
+++ b/Core/CrashReport.php
@@ -110,12 +110,19 @@ final class CrashReport
             return;
         }
 
-        // guardamos los datos en un archivo en MyFiles
-        $file_name = 'crash_' . $info['hash'] . '.json';
-        $file_path = Tools::folder('MyFiles', $file_name);
-        if (file_exists($file_path)) {
+        // comprobamos si ya existe un archivo crash para este hash
+        $crash_pattern = 'crash_*_' . $info['hash'] . '.json';
+        $existing_files = glob(Tools::folder('MyFiles', $crash_pattern));
+
+        if (!empty($existing_files)) {
+            // si existe algún archivo con este hash, no hacemos nada
             return;
         }
+
+        // guardamos los datos en un archivo en MyFiles con timestamp
+        $timestamp = date('YmdHis');
+        $file_name = 'crash_' . $timestamp . '_' . $info['hash'] . '.json';
+        $file_path = Tools::folder('MyFiles', $file_name);
 
         file_put_contents($file_path, json_encode($info, JSON_PRETTY_PRINT));
     }


### PR DESCRIPTION
# Descripción

Agregar timestamp a nombres de archivos crash y mejorar detección de duplicados

Cambios realizados:

Mejora en nomenclatura: Agregado prefijo de timestamp a archivos crash (crash_{timestamp}_{hash}.json)
Detección mejorada de duplicados: Reemplazado file_exists() con búsqueda por patrón glob() para detectar archivos crash existentes independientemente del timestamp
Formato compacto de timestamp: Usado formato YmdHis para nombres de archivo más cortos manteniendo orden cronológico

Beneficios:

Previene sobrescritura de archivos crash con mismo hash pero diferentes timestamps
Mantiene ordenamiento cronológico de archivos en listados de directorio
Preserva la lógica existente de prevención de duplicados
Convención de nomenclatura más limpia y compacta

Detalles técnicos:

Búsqueda por patrón: crash_*_{hash}.json para encontrar archivos existentes por hash
Formato timestamp: YmdHis (ej., 20250918143025)
Compatible con la lógica existente de detección de crashes

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.