### PR TITLE
Agregar Scope a los modelos

### DIFF
--- a/Core/Template/ModelClass.php
+++ b/Core/Template/ModelClass.php
@@ -33,6 +33,8 @@ use JetBrains\PhpStorm\Deprecated;
 
 abstract class ModelClass
 {
+    use ScopeTrait;
+
     /**
      * The model's attributes.
      *
@@ -200,8 +202,13 @@ abstract class ModelClass
             return false;
         }
 
+        // Apply global scopes
+        $where = [];
+        $where = static::applyGlobalScopesToWhere($where);
+
         $deleted = static::table()
             ->whereEq(static::primaryColumn(), $this->id())
+            ->where($where)
             ->delete();
         if (false === $deleted) {
             return false;
@@ -226,8 +233,13 @@ abstract class ModelClass
             return false;
         }
 
+        // Apply global scopes
+        $where = [];
+        $where = static::applyGlobalScopesToWhere($where);
+
         return static::table()
                 ->whereEq(static::primaryColumn(), $this->id())
+                ->where($where)
                 ->count() > 0;
     }
 
@@ -317,8 +329,13 @@ abstract class ModelClass
             return false;
         }
 
+        // Apply global scopes
+        $where = [];
+        $where = static::applyGlobalScopesToWhere($where);
+
         $data = static::table()
             ->whereEq(static::primaryColumn(), $code)
+            ->where($where)
             ->first();
         if (empty($data)) {
             $this->clear();
@@ -395,6 +412,9 @@ abstract class ModelClass
 
     public function loadWhere(array $where, array $order = []): bool
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         $data = static::table()
             ->where($where)
             ->orderMulti($order)
@@ -430,6 +450,9 @@ abstract class ModelClass
             $where[] = Where::regexp($field, '^-?[0-9]+$');
             $field = self::$dataBase->getEngine()->getSQL()->sql2Int($field);
         }
+
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
 
         // Search for new code value
         $sqlWhere = Where::multiSqlLegacy($where);
@@ -585,8 +608,13 @@ abstract class ModelClass
             return false;
         }
 
+        // Apply global scopes
+        $where = [];
+        $where = static::applyGlobalScopesToWhere($where);
+
         $updated = static::table()
             ->whereEq(static::primaryColumn(), $this->id())
+            ->where($where)
             ->update($values);
         if (false === $updated) {
             return false;
@@ -725,6 +753,10 @@ abstract class ModelClass
         }
 
         $modelClass = '\\FacturaScripts\\Dinamic\\Model\\' . $modelName;
+
+        // Apply global scopes
+        $where = $modelClass::applyGlobalScopesToWhere($where);
+
         $where[] = Where::eq($foreignKey, $this->id());
         return $modelClass::all($where, $order);
     }
@@ -816,8 +848,13 @@ abstract class ModelClass
             return false;
         }
 
+        // Apply global scopes
+        $where = [];
+        $where = static::applyGlobalScopesToWhere($where);
+
         $updated = static::table()
             ->whereEq(static::primaryColumn(), $this->id())
+            ->where($where)
             ->update($this->toArray());
         if (false === $updated) {
             return false;

--- a/Core/Template/ModelTrait.php
+++ b/Core/Template/ModelTrait.php
@@ -52,6 +52,9 @@ trait ModelTrait
      */
     public static function all(array $where = [], array $order = [], int $offset = 0, int $limit = 0): array
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         $data = self::table()
             ->where($where)
             ->orderMulti($order)
@@ -69,6 +72,9 @@ trait ModelTrait
 
     public static function count(array $where = []): int
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         return self::table()
             ->where($where)
             ->count();
@@ -82,6 +88,9 @@ trait ModelTrait
 
     public static function deleteWhere(array $where): bool
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         return self::table()
             ->where($where)
             ->delete();
@@ -89,8 +98,14 @@ trait ModelTrait
 
     public static function find($code): ?static
     {
+        $where = [];
+
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         $data = self::table()
             ->whereEq(static::primaryColumn(), $code)
+            ->where($where)
             ->first();
 
         return $data ? new static($data) : null;
@@ -98,6 +113,9 @@ trait ModelTrait
 
     public static function findWhere(array $where, array $order = []): ?static
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         $data = self::table()
             ->where($where)
             ->orderMulti($order)
@@ -117,6 +135,9 @@ trait ModelTrait
 
     public static function findOrCreate(array $where, array $data = []): ?static
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         $row = self::table()
             ->where($where)
             ->first();
@@ -166,6 +187,9 @@ trait ModelTrait
 
     public static function totalSum(string $field, array $where = []): float
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         return self::table()
             ->where($where)
             ->sum($field);
@@ -173,6 +197,9 @@ trait ModelTrait
 
     public static function updateOrCreate(array $where, array $data): ?static
     {
+        // Apply global scopes
+        $where = static::applyGlobalScopesToWhere($where);
+
         $row = self::table()
             ->where($where)
             ->first();

--- a/Core/Template/ScopeTrait.php
+++ b/Core/Template/ScopeTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace FacturaScripts\Core\Template;
+
+trait ScopeTrait
+{
+    /**
+     * Callbacks de Scopes que se aplicarán a las consultas de todos los modelos que extiendan esta base.
+     * Cada callback tiene la firma: function(array &$where, string $modelClass): void
+     * y se espera que añada condiciones DataBaseWhere a $where.
+     * @var array<int, callable>
+     */
+    protected static array $globalScopes = [];
+
+    /**
+     * Bandera para deshabilitar temporalmente los Scopes dentro de un contexto de ejecución dado.
+     *
+     * @var bool
+     */
+    protected static bool $disableGlobalScopes = false;
+
+    /**
+     * Ejecutar un callback sin aplicar los Scopes.
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public static function withoutGlobalScopes(callable $callback): mixed
+    {
+        $prev = self::$disableGlobalScopes;
+        self::$disableGlobalScopes = true;
+        try {
+            return $callback();
+        } finally {
+            self::$disableGlobalScopes = $prev;
+        }
+    }
+
+    /**
+     * Registrar un callable de Scope que pueda modificar el array "where" de las consultas.
+     *
+     * @param callable $scope function(array &$where, string $modelClass): void
+     */
+    public static function addGlobalScope(callable $scope): void
+    {
+        self::$globalScopes[] = $scope;
+    }
+
+    /**
+     * Aplica los Scopes registrados al array "where" proporcionado.
+     *
+     * @param array $where
+     * @return array
+     */
+    protected static function applyGlobalScopesToWhere(array $where = []): array
+    {
+        if (self::$disableGlobalScopes || empty(self::$globalScopes)) {
+            return $where;
+        }
+
+        foreach (self::$globalScopes as $scope) {
+            // scope is expected to append DataBaseWhere instances or similar structures
+            $scope($where, static::class);
+        }
+
+        return $where;
+    }
+
+}

--- a/Test/Core/Model/GlobalScopeTest.php
+++ b/Test/Core/Model/GlobalScopeTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace FacturaScripts\Test\Core\Model;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Model\Cliente;
+use FacturaScripts\Core\Template\ModelClass;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+
+class GlobalScopeTest extends TestCase
+{
+    use LogErrorsTrait;
+    use RandomDataTrait;
+
+    private ?string $clienteOnCode;
+    private ?string $clienteOffCode;
+
+    protected function setUp(): void
+    {
+        // Crear dos clientes: uno activo (debaja = false) y otro dado de baja (debaja = true)
+        $on = $this->getRandomCustomer();
+        $on->riesgomax = 10.0;
+        $this->assertTrue($on->save());
+        $this->clienteOnCode = $on->codcliente;
+
+        $off = $this->getRandomCustomer();
+        $off->fechabaja = Tools::date();
+        // Establece un valor numérico para probar totalSum
+        $off->riesgomax = 10.0;
+        $this->assertTrue($off->save());
+        $this->clienteOffCode = $off->codcliente;
+
+        // Registrar un Scope global que oculte clientes con debaja = true
+        ModelClass::addGlobalScope(function (array &$where, string $modelClass): void {
+            // Aplicar solo al modelo Cliente para evitar afectar a otros modelos que puedan usarse en otro lugar
+            if ($modelClass === Cliente::class) {
+                $where[] = new DataBaseWhere('debaja', false);
+            }
+        });
+    }
+
+    /**
+     * Comprobamos que el metodo all() devuelve unicamente los que estan dado de alta
+     * por lo que esta aplicando el Scope correctamente
+     *
+     * @return void
+     */
+    public function testAllIsFilteredByGlobalScope(): void
+    {
+        $all = Cliente::all();
+
+        foreach ($all as $cli) {
+            $this->assertFalse($cli->debaja);
+        }
+    }
+
+    public function testCountIsFilteredByGlobalScope(): void
+    {
+        $model = new Cliente();
+        $countAll = ModelClass::withoutGlobalScopes(function () use ($model) {
+            return $model->count();
+        });
+        $countScoped = $model->count();
+        $this->assertGreaterThan($countScoped - 1, $countAll);
+        $this->assertGreaterThanOrEqual(1, $countScoped);
+    }
+
+    public function testGetAndLoadFromCodeRespectGlobalScope(): void
+    {
+        $c = new Cliente();
+
+        // find() para el cliente dado de baja debe devolver false debido al Scope
+        $this->assertNull($c->find($this->clienteOffCode));
+
+        // load() para el cliente dado de baja debe devolver false y limpiar los atributos
+        $this->assertFalse($c->load($this->clienteOffCode));
+
+        // Sin Scopes, deberíamos poder obtenerlo
+        $found = ModelClass::withoutGlobalScopes(function () {
+            $tmp = new Cliente();
+            return $tmp->find($this->clienteOffCode);
+        });
+        $this->assertNotNull($found);
+    }
+
+    public function testTotalSumIsFilteredByGlobalScope(): void
+    {
+        $model = new Cliente();
+        $sumScoped = $model->totalSum('riesgomax');
+        $sumAll = ModelClass::withoutGlobalScopes(function () use ($model) {
+            return $model->totalSum('riesgomax');
+        });
+
+        $this->assertSame(10.0, (float)$sumScoped);
+        $this->assertSame(20.0, (float)$sumAll);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+
+        // Eliminar los clientes creados (saltando los Scopes globales para asegurar que podemos encontrarlos)
+        ModelClass::withoutGlobalScopes(function () {
+            if ($this->clienteOnCode) {
+                $c = new Cliente();
+                if ($c->load($this->clienteOnCode)) {
+                    $c->delete();
+                }
+            }
+            if ($this->clienteOffCode) {
+                $c = new Cliente();
+                if ($c->load($this->clienteOffCode)) {
+                    $c->delete();
+                }
+            }
+        });
+
+        // Restablecer los Scopes globales mediante reflexión para evitar impactar a otras pruebas
+        $ref = new \ReflectionClass(ModelClass::class);
+        if ($ref->hasProperty('globalScopes')) {
+            $prop = $ref->getProperty('globalScopes');
+            $prop->setAccessible(true);
+            $prop->setValue([]);
+        }
+        if ($ref->hasProperty('disableGlobalScopes')) {
+            $prop2 = $ref->getProperty('disableGlobalScopes');
+            $prop2->setAccessible(true);
+            $prop2->setValue(false);
+        }
+    }
+}


### PR DESCRIPTION
# Descripción
- En ocasiones queremos que un modelo ejecute todo el tiempo en las consultas a la base de datos un where y por ello se debe aplicar globalmente.
- Por ejemplo hacemos un plugin y agregamos la columna idempresa a la tabla clientes. Pues agregamos un where global para que los usuarios solo vean/modifiquen/eliminen los clientes de su propia empresa.
- Se implementa la posibildad de ejecutar consultas sin aplicar el Scope(metodo withoutGlobalScopes())

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
