### PR TITLE
descargar todos los plugins de una vez

### DIFF
--- a/Core/View/Updater.html.twig
+++ b/Core/View/Updater.html.twig
@@ -72,6 +72,16 @@
         </div>
         <div class="row">
             <div class="col-sm">
+                {% set hasUndownloaded = fsc.updaterItems|reduce((carry, item) => carry or not item.downloaded, false) %}
+                {% if hasUndownloaded %}
+                    <div class="d-flex justify-content-end mb-1">
+                        <a href="{{ fsc.url() }}?action=download-all-plugins"
+                           class="btn btn-spin-action btn-sm btn-secondary"
+                           onclick="animateSpinner('add')">
+                            <i class="fa-solid fa-download fa-fw me-1" aria-hidden="true"></i>{{ trans('download-all-plugins') }}
+                        </a>
+                    </div>
+                {% endif %}
                 <div class="card shadow-sm mb-4">
                     <div class="table-responsive">
                         <table class="table table-hover mb-0">


### PR DESCRIPTION
# Descripción
- Actualmente si se tienen muchos plugins instalados se tiene que ir uno a uno descargando y despues uno a uno instalando.
- Con esta modificación se pueden descargar todas las actualizaciones en una sola request para después ir uno a uno instalando.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.