### PR TITLE
bug: comparar arrays de valores al comprobar match

### DIFF
--- a/Core/Lib/Widget/WidgetSelect.php
+++ b/Core/Lib/Widget/WidgetSelect.php
@@ -369,8 +369,34 @@ class WidgetSelect extends BaseWidget
             $value2 = $value2 ? '1' : '0';
         }
 
-        // use string comparison to avoid type juggling (e.g., "01" != "1")
-        return (string)$value1 === (string)$value2;
+        // Convertir a string para comparación consistente
+        $value1 = (string)$value1;
+        $value2 = (string)$value2;
+
+        if ($this->multiple && (str_contains($value1, ',') || str_contains($value2, ','))) {
+            return $this->multipleMatch($value1, $value2);
+        }
+
+        return $value1 === $value2;
+    }
+
+    /**
+     * Cuando es un select multiple, compara los valores
+     * tratandolos como arrays.
+     * ej. $value1 = '3' y $value2 = '2,3'
+     *
+     * @param string $value1
+     * @param string $value2
+     *
+     * @return bool
+     */
+    protected function multipleMatch(string $value1, string $value2): bool
+    {
+        $array1 = array_map('trim', explode(',', $value1));
+        $array2 = array_map('trim', explode(',', $value2));
+
+        // array_intersect retorna los elementos comunes
+        return !empty(array_intersect($array1, $array2));
     }
 
     /**


### PR DESCRIPTION
# Descripción
- Al comparar valuesMatch lo estaba haciendo sin comparar la posibilidad que vinieran multiples valores como ocurre en los select multiples.
- Ahora transforma los valores en array y los compara correctamente para devolver si coinciden y marcar como selected.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
