### PR TITLE
refactor devolucion factura

### DIFF
--- a/Core/Controller/ApiCreateFacturaRectificativaCliente.php
+++ b/Core/Controller/ApiCreateFacturaRectificativaCliente.php
@@ -19,8 +19,9 @@
 
 namespace FacturaScripts\Core\Controller;
 
-use FacturaScripts\Core\Lib\Calculator;
+use FacturaScripts\Core\Params\RefundInvoiceParams;
 use FacturaScripts\Core\Response;
+use FacturaScripts\Core\Service\InvoiceManager;
 use FacturaScripts\Core\Template\ApiController;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Model\FacturaCliente;
@@ -82,90 +83,18 @@ class ApiCreateFacturaRectificativaCliente extends ApiController
             }
         }
 
-        // si no se especifican cantidades de las lineas,
-        // incluimos todas las lineas en la factura rectificativa.
-        if (empty($lines)) {
-            $lines = $invoiceLines;
-        }
+        $params = new RefundInvoiceParams(
+            lines: $lines,
+            codserie: $this->request->input('codserie', ''),
+            fecha: $this->request->input('fecha'),
+            hora: $this->request->input('hora'),
+            observaciones: $this->request->input('observaciones', ''),
+            idestado: $this->request->input('idestado', ''),
+            nick: $this->request->input('nick', ''),
+            includeAllLinesIfEmpty: true
+        );
 
-        $this->db()->beginTransaction();
-
-        if ($invoice->editable) {
-            foreach ($invoice->getAvailableStatus() as $status) {
-                if ($status->editable || !$status->activo) {
-                    continue;
-                }
-
-                $invoice->idestado = $status->idestado;
-                if (false === $invoice->save()) {
-                    $this->sendError('record-save-error', Response::HTTP_INTERNAL_SERVER_ERROR);
-                    $this->db()->rollback();
-                    return null;
-                }
-            }
-        }
-
-        $newRefund = new FacturaCliente();
-        $newRefund->loadFromData($invoice->toArray(), $invoice::dontCopyFields());
-        $newRefund->codigorect = $invoice->codigo;
-        $newRefund->codserie = $this->request->input('codserie') ?? $invoice->codserie;
-        $newRefund->idfacturarect = $invoice->idfactura;
-        $newRefund->nick = $this->request->input('nick');
-        $newRefund->observaciones = $this->request->input('observaciones');
-
-        $date = $this->request->input('fecha');
-        $hour = $this->request->input('hora');
-        if (false === $newRefund->setDate($date, $hour)) {
-            $this->sendError('error-set-date', Response::HTTP_BAD_REQUEST);
-            $this->db()->rollback();
-            return null;
-        }
-
-        if (false === $newRefund->save()) {
-            $this->sendError('record-save-error', Response::HTTP_INTERNAL_SERVER_ERROR);
-            $this->db()->rollback();
-            return null;
-        }
-
-        foreach ($lines as $line) {
-            $newLine = $newRefund->getNewLine($line->toArray());
-            $newLine->cantidad = 0 - (float)$this->request->input('refund_' . $line->id(), $line->cantidad);
-            $newLine->idlinearect = $line->idlinea;
-            if (false === $newLine->save()) {
-                $this->sendError('record-save-error', Response::HTTP_INTERNAL_SERVER_ERROR);
-                $this->db()->rollback();
-                return null;
-            }
-        }
-
-        $newLines = $newRefund->getLines();
-        $newRefund->idestado = $invoice->idestado;
-        if (false === Calculator::calculate($newRefund, $newLines, true)) {
-            $this->sendError('record-save-error', Response::HTTP_INTERNAL_SERVER_ERROR);
-            $this->db()->rollback();
-            return null;
-        }
-
-        // si la factura estaba pagada, marcamos los recibos de la nueva como pagados
-        if ($invoice->pagada) {
-            foreach ($newRefund->getReceipts() as $receipt) {
-                $receipt->pagado = true;
-                $receipt->save();
-            }
-        }
-
-        // asignamos el estado de la factura
-        $newRefund->idestado = $this->request->input('idestado');
-        if (false === $newRefund->save()) {
-            $this->sendError('record-save-error', Response::HTTP_INTERNAL_SERVER_ERROR);
-            $this->db()->rollback();
-            return null;
-        }
-
-        $this->db()->commit();
-        Tools::log()->notice('record-updated-correctly');
-
-        return $newRefund;
+        return InvoiceManager::createRefund($invoice, $params);
     }
 
     private function sendError(string $message, int $http_code): void

--- a/Core/Controller/EditFacturaCliente.php
+++ b/Core/Controller/EditFacturaCliente.php
@@ -7,8 +7,9 @@ namespace FacturaScripts\Core\Controller;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Lib\AjaxForms\SalesController;
-use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
+use FacturaScripts\Core\Params\RefundInvoiceParams;
+use FacturaScripts\Core\Service\InvoiceManager;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Lib\Accounting\InvoiceToAccounting;
 use FacturaScripts\Dinamic\Lib\ReceiptGenerator;
@@ -306,78 +307,22 @@ class EditFacturaCliente extends SalesController
                 $lines[] = $line;
             }
         }
-        if (empty($lines)) {
-            Tools::log()->warning('no-selected-item');
+
+        $params = new RefundInvoiceParams(
+            lines: $lines,
+            codserie: $this->request->input('codserie', ''),
+            fecha: $this->request->input('fecha'),
+            observaciones: $this->request->input('observaciones', ''),
+            idestado: $this->request->input('idestado', ''),
+            nick: $this->user->nick,
+            includeAllLinesIfEmpty: false
+        );
+
+        $newRefund = InvoiceManager::createRefund($invoice, $params);
+        if ($newRefund === null) {
             return true;
         }
 
-        $this->dataBase->beginTransaction();
-
-        if ($invoice->editable) {
-            foreach ($invoice->getAvailableStatus() as $status) {
-                if ($status->editable || !$status->activo) {
-                    continue;
-                }
-
-                $invoice->idestado = $status->idestado;
-                if (false === $invoice->save()) {
-                    Tools::log()->error('record-save-error');
-                    $this->dataBase->rollback();
-                    return true;
-                }
-            }
-        }
-
-        $newRefund = new FacturaCliente();
-        $newRefund->loadFromData($invoice->toArray(), $invoice::dontCopyFields());
-        $newRefund->codigorect = $invoice->codigo;
-        $newRefund->codserie = $this->request->input('codserie');
-        $newRefund->idfacturarect = $invoice->idfactura;
-        $newRefund->nick = $this->user->nick;
-        $newRefund->observaciones = $this->request->input('observaciones');
-        $newRefund->setDate($this->request->input('fecha'), date(Tools::HOUR_STYLE));
-        if (false === $newRefund->save()) {
-            Tools::log()->error('record-save-error');
-            $this->dataBase->rollback();
-            return true;
-        }
-
-        foreach ($lines as $line) {
-            $newLine = $newRefund->getNewLine($line->toArray());
-            $newLine->cantidad = 0 - (float)$this->request->input('refund_' . $line->id(), '0');
-            $newLine->idlinearect = $line->idlinea;
-            if (false === $newLine->save()) {
-                Tools::log()->error('record-save-error');
-                $this->dataBase->rollback();
-                return true;
-            }
-        }
-
-        $newLines = $newRefund->getLines();
-        if (false === Calculator::calculate($newRefund, $newLines, true)) {
-            Tools::log()->error('record-save-error');
-            $this->dataBase->rollback();
-            return true;
-        }
-
-        // si la factura estaba pagada, marcamos los recibos de la nueva como pagados
-        if ($invoice->pagada) {
-            foreach ($newRefund->getReceipts() as $receipt) {
-                $receipt->pagado = true;
-                $receipt->save();
-            }
-        }
-
-        // asignamos el estado de la factura
-        $newRefund->idestado = $this->request->input('idestado');
-        if (false === $newRefund->save()) {
-            Tools::log()->error('record-save-error');
-            $this->dataBase->rollback();
-            return true;
-        }
-
-        $this->dataBase->commit();
-        Tools::log()->notice('record-updated-correctly');
         $this->redirect($newRefund->url() . '&action=save-ok');
         return false;
     }

--- a/Core/Params/RefundInvoiceParams.php
+++ b/Core/Params/RefundInvoiceParams.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FacturaScripts\Core\Params;
+
+use FacturaScripts\Core\Model\LineaFacturaCliente;
+
+class RefundInvoiceParams
+{
+    /** @var LineaFacturaCliente[] */
+    public array $lines = [];
+
+    public string $codserie = '';
+
+    public string $fecha = '';
+
+    public ?string $hora = null;
+
+    public string $observaciones = '';
+
+    public string $idestado = '';
+
+    public string $nick = '';
+
+    public bool $includeAllLinesIfEmpty = false;
+
+    public function __construct(
+        array $lines = [],
+        string $codserie = '',
+        string $fecha = '',
+        ?string $hora = null,
+        string $observaciones = '',
+        string $idestado = '',
+        string $nick = '',
+        bool $includeAllLinesIfEmpty = false
+    ) {
+        $this->lines = $lines;
+        $this->codserie = $codserie;
+        $this->fecha = $fecha;
+        $this->hora = $hora;
+        $this->observaciones = $observaciones;
+        $this->idestado = $idestado;
+        $this->nick = $nick;
+        $this->includeAllLinesIfEmpty = $includeAllLinesIfEmpty;
+    }
+}

--- a/Core/Service/InvoiceManager.php
+++ b/Core/Service/InvoiceManager.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace FacturaScripts\Core\Service;
+
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Params\RefundInvoiceParams;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Dinamic\Lib\Calculator;
+use FacturaScripts\Dinamic\Model\FacturaCliente;
+
+class InvoiceManager
+{
+    private static ?DataBase $dataBase = null;
+
+    public static function createRefund(FacturaCliente $invoice, RefundInvoiceParams $params): ?FacturaCliente
+    {
+        if (empty($params->lines) && $params->includeAllLinesIfEmpty) {
+            $params->lines = $invoice->getLines();
+        }
+
+        if (empty($params->lines)) {
+            Tools::log()->warning('no-selected-item');
+            return null;
+        }
+
+        self::dataBase()->beginTransaction();
+
+        if (false === self::updateOriginalInvoiceStatus($invoice)) {
+            self::dataBase()->rollback();
+            return null;
+        }
+
+        $newRefund = self::createRefundInvoice($invoice, $params);
+        if ($newRefund === null) {
+            self::dataBase()->rollback();
+            return null;
+        }
+
+        if (false === self::createRefundLines($newRefund, $params)) {
+            self::dataBase()->rollback();
+            return null;
+        }
+
+        if (false === self::calculateRefundTotals($newRefund)) {
+            self::dataBase()->rollback();
+            return null;
+        }
+
+        if ($invoice->pagada) {
+            self::markReceiptsAsPaid($newRefund);
+        }
+
+        if (false === self::saveRefundState($newRefund, $invoice, $params)) {
+            self::dataBase()->rollback();
+            return null;
+        }
+
+        self::dataBase()->commit();
+        Tools::log()->notice('record-updated-correctly');
+
+        return $newRefund;
+    }
+
+    private static function dataBase(): DataBase
+    {
+        if (self::$dataBase === null) {
+            self::$dataBase = new DataBase();
+        }
+        return self::$dataBase;
+    }
+
+    private static function createRefundInvoice(FacturaCliente $invoice, RefundInvoiceParams $params): ?FacturaCliente
+    {
+        $newRefund = new FacturaCliente();
+        $newRefund->loadFromData($invoice->toArray(), $invoice::dontCopyFields());
+        $newRefund->codigorect = $invoice->codigo;
+        $newRefund->codserie = $params->codserie ?: $invoice->codserie;
+        $newRefund->idfacturarect = $invoice->idfactura;
+        $newRefund->nick = $params->nick;
+        $newRefund->observaciones = $params->observaciones;
+
+        $hour = $params->hora ?? date(Tools::HOUR_STYLE);
+        if (false === $newRefund->setDate($params->fecha, $hour)) {
+            Tools::log()->error('error-set-date');
+            return null;
+        }
+
+        if (false === $newRefund->save()) {
+            Tools::log()->error('record-save-error');
+            return null;
+        }
+
+        return $newRefund;
+    }
+
+    private static function createRefundLines(FacturaCliente $newRefund, RefundInvoiceParams $params): bool
+    {
+        foreach ($params->lines as $line) {
+            $quantity = $line->cantidad;
+
+            $newLine = $newRefund->getNewLine($line->toArray());
+            $newLine->cantidad = 0 - $quantity;
+            $newLine->idlinearect = $line->idlinea;
+
+            if (false === $newLine->save()) {
+                Tools::log()->error('record-save-error');
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function calculateRefundTotals(FacturaCliente $newRefund): bool
+    {
+        $newLines = $newRefund->getLines();
+        if (false === Calculator::calculate($newRefund, $newLines, true)) {
+            Tools::log()->error('record-save-error');
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function markReceiptsAsPaid(FacturaCliente $newRefund): void
+    {
+        foreach ($newRefund->getReceipts() as $receipt) {
+            $receipt->pagado = true;
+            $receipt->save();
+        }
+    }
+
+    private static function saveRefundState(FacturaCliente $newRefund, FacturaCliente $originalInvoice, RefundInvoiceParams $params): bool
+    {
+        $newRefund->idestado = $params->idestado ?: $originalInvoice->idestado;
+        if (false === $newRefund->save()) {
+            Tools::log()->error('record-save-error');
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function updateOriginalInvoiceStatus(FacturaCliente $invoice): bool
+    {
+        if (false === $invoice->editable) {
+            return true;
+        }
+
+        foreach ($invoice->getAvailableStatus() as $status) {
+            if ($status->editable || !$status->activo) {
+                continue;
+            }
+
+            $invoice->idestado = $status->idestado;
+            if (false === $invoice->save()) {
+                Tools::log()->error('record-save-error');
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
# Descripción
- Avanzamos implementando funciones mediante API, pero en algunos casos estamos duplicando código.
- En este caso he refactorizado la creación de una factura rectificativa, creando una sola clase y usándola tanto en el controlador principial, como en el controlador de la API.
- Como la tendencia en php es el tipado estricto he creado una clase DAO(RefundInvoiceParams) para evitar pasar arrays como parámetro difícilmente "tipables".
- De este modo también podemos testear mejor la creación de una devolución de factura.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
