### PR TITLE
Corregido patrón regular al revisar ordenaciones con COALESCE

### DIFF
--- a/Core/DbQuery.php
+++ b/Core/DbQuery.php
@@ -297,7 +297,7 @@ final class DbQuery
             // permitimos LOWER(), UPPER(), CAST() y COALESCE()
             if (preg_match('/^(LOWER|UPPER)\([a-zA-Z0-9_.]+\)$/i', $field) ||
                 preg_match('/^CAST\([a-zA-Z0-9_.]+ AS [a-zA-Z0-9_ ]+\)$/i', $field) ||
-                preg_match('/^COALESCE\([a-zA-Z0-9_., ]+\)$/i', $field)) {
+                preg_match("/^COALESCE\([a-zA-Z0-9_.]+\s*,\s*(?:'[^']*'|-?\d+(?:\.\d+)?)\)$/i", $field)) {
                 $this->orderBy[] = $field . ' ' . $order;
                 return $this;
             }


### PR DESCRIPTION
# Descripción
- Permitir valores entre comillas en el segundo parámetro del Coalesce. Esto es necesario para cuando el campo al que se quiere hacer COALESCE es varchar.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
