### PR TITLE
Perf: Reemplazar datalist pesados por autocomplete masivamente en Edi…

### DIFF
--- a/Core/XMLView/EditDireccionContacto.xml
+++ b/Core/XMLView/EditDireccionContacto.xml
@@ -47,17 +47,17 @@
                 <widget type="text" fieldname="codpostal" maxlength="10"/>
             </column>
             <column name="city" order="160">
-                <widget type="datalist" fieldname="ciudad">
-                    <values source="ciudades" fieldcode="ciudad" fieldtitle="ciudad" limit="9000"/>
+                <widget type="autocomplete" fieldname="ciudad">
+                    <values source="ciudades" fieldcode="ciudad" fieldtitle="ciudad"/>
                 </widget>
             </column>
             <column name="province" order="170">
-                <widget type="datalist" fieldname="provincia">
+                <widget type="autocomplete" fieldname="provincia">
                     <values source="provincias" fieldcode="provincia" fieldtitle="provincia"/>
                 </widget>
             </column>
             <column name="country" titleurl="ListPais" order="180">
-                <widget type="select" fieldname="codpais" onclick="EditPais">
+                <widget type="autocomplete" fieldname="codpais" onclick="EditPais">
                     <values source="paises" fieldcode="codpais" fieldtitle="nombre"/>
                 </widget>
             </column>


### PR DESCRIPTION
**Problema**:
La vista [EditDireccionContacto.xml estaba utilizando widgets de tipo `datalist` (para provincias y ciudades) y `select` cargando miles de opciones simultáneas. Al renderizar las direcciones usando un `ListView`, se inyectaban decenas de miles de nodos DOM innecesarios ocultos por fila, lo que colapsaba el procesamiento de Javascript del navegador y producía bloqueos y demoras de más de 2 segundos en la interfaz.

# Descripción
Se han reemplazado las 3 columnas para utilizar el componente `<widget type="autocomplete">`. El Autocomplete mantiene el formulario optimizado con un único campo de texto de entrada mientras facilita dinámicamente la búsqueda y el autocompletado nativo mediante AJAX (solo cuando el usuario teclea), sin perjudicar la carga del DOM. Esto devuelve el rendimiento y la fluidez a la pestaña de Lista de Contactos.



## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [ x] He revisado mi código antes de enviarlo.
- [ x] He probado que funciona correctamente en mi PC.
- [x ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

