### PR TITLE
Refactor ButtonBlock and NewMail classes to improve shortcode handling and block registration

### DIFF
--- a/Core/Lib/Email/BaseBlock.php
+++ b/Core/Lib/Email/BaseBlock.php
@@ -41,6 +41,15 @@ abstract class BaseBlock
 
     abstract public function render(bool $footer = false): string;
 
+    /**
+     * Crea una instancia del bloque a partir de los atributos y contenido de un shortcode.
+     * Las subclases deben sobreescribir este método para mapear correctamente sus parámetros.
+     */
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static($content);
+    }
+
     public function setVerificode(string $code): void
     {
         $this->verificode = $code;

--- a/Core/Lib/Email/BoxBlock.php
+++ b/Core/Lib/Email/BoxBlock.php
@@ -41,6 +41,11 @@ class BoxBlock extends BaseBlock
         $this->blocks = $blocks;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static([], $attrs['css'] ?? '', $attrs['style'] ?? '');
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Core/Lib/Email/ButtonBlock.php
+++ b/Core/Lib/Email/ButtonBlock.php
@@ -45,6 +45,16 @@ class ButtonBlock extends BaseBlock
         $this->href = $href;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static(
+            $attrs['label'] ?? $content,
+            $attrs['href'] ?? '',
+            $attrs['css'] ?? '',
+            $attrs['style'] ?? ''
+        );
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Core/Lib/Email/ButtonBlock.php
+++ b/Core/Lib/Email/ButtonBlock.php
@@ -35,14 +35,14 @@ class ButtonBlock extends BaseBlock
     protected $label;
 
     /** @var string */
-    protected $link;
+    protected $href;
 
-    public function __construct(string $label, string $link, string $css = '', string $style = '')
+    public function __construct(string $label, string $href, string $css = '', string $style = '')
     {
         $this->css = $css;
         $this->style = $style;
         $this->label = $label;
-        $this->link = $link;
+        $this->href = $href;
     }
 
     public function render(bool $footer = false): string
@@ -50,16 +50,16 @@ class ButtonBlock extends BaseBlock
         $this->footer = $footer;
         $return = $this->pipe('render');
         return $return ?? '<span class="' . (empty($this->css) ? 'btn w-100' : $this->css) . '">'
-        . '<a href="' . $this->link() . '">' . $this->label . '</a></span>';
+        . '<a href="' . $this->buildHref() . '">' . $this->label . '</a></span>';
     }
 
-    protected function link(): string
+    protected function buildHref(): string
     {
-        $query = parse_url($this->link, PHP_URL_QUERY);
+        $query = parse_url($this->href, PHP_URL_QUERY);
         if ($query) {
-            return $this->link . '&verificode=' . $this->verificode;
+            return $this->href . '&verificode=' . $this->verificode;
         }
 
-        return $this->link . '?verificode=' . $this->verificode;
+        return $this->href . '?verificode=' . $this->verificode;
     }
 }

--- a/Core/Lib/Email/HtmlBlock.php
+++ b/Core/Lib/Email/HtmlBlock.php
@@ -39,6 +39,11 @@ class HtmlBlock extends BaseBlock
         $this->html = $html;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static($attrs['html'] ?? $content);
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Core/Lib/Email/NewMail.php
+++ b/Core/Lib/Email/NewMail.php
@@ -24,14 +24,15 @@ use FacturaScripts\Core\Html;
 use FacturaScripts\Core\Model\User;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Validator;
-use FacturaScripts\Dinamic\Lib\Email\HtmlBlock as DinHtmlBlock;
-use FacturaScripts\Dinamic\Lib\Email\TextBlock as DinTextBlock;
 use FacturaScripts\Dinamic\Model\AttachedFile;
 use FacturaScripts\Dinamic\Model\EmailNotification;
 use FacturaScripts\Dinamic\Model\EmailSent;
 use FacturaScripts\Dinamic\Model\Empresa;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -58,6 +59,21 @@ class NewMail
     /** @var string */
     public $fromNick;
 
+    /** @var string */
+    public $signature;
+
+    /** @var string */
+    public $text;
+
+    /** @var string */
+    public $title;
+
+    /** @var string */
+    public $verificode;
+
+    /** @var array<string, callable> */
+    private static $blockHandlers = [];
+
     /** @var BaseBlock[] */
     protected $footerBlocks = [];
 
@@ -70,32 +86,25 @@ class NewMail
     /** @var PHPMailer */
     protected $mail;
 
-    /** @var array */
-    private static $mailer = ['mail' => 'Mail', 'sendmail' => 'SendMail', 'smtp' => 'SMTP'];
-
-    /** @var array<string, callable> */
-    private static $blockHandlers = [];
-
     /** @var BaseBlock[] */
     protected $mainBlocks = [];
 
-    /** @var string */
-    public $signature;
+    /** @var array */
+    private static $mailer = ['mail' => 'Mail', 'sendmail' => 'SendMail', 'smtp' => 'SMTP'];
 
     /** @var string */
     protected static $template = 'NewTemplate.html.twig';
 
-    /** @var string */
-    public $text;
-
-    /** @var string */
-    public $title;
-
-    /** @var string */
-    public $verificode;
-
     public function __construct()
     {
+        static::addBlockHandler('BoxBlock');
+        static::addBlockHandler('ButtonBlock');
+        static::addBlockHandler('HtmlBlock');
+        static::addBlockHandler('SpaceBlock');
+        static::addBlockHandler('TableBlock');
+        static::addBlockHandler('TextBlock');
+        static::addBlockHandler('TitleBlock');
+
         $this->empresa = Empresas::default();
 
         $this->fromEmail = Tools::settings('email', 'email');
@@ -137,25 +146,6 @@ class NewMail
     }
 
     /**
-     * Registra un handler personalizado para un tipo de shortcode de bloque.
-     * El callable recibe (array $attrs, string $content) y debe devolver un BaseBlock o null.
-     * Ejemplo: NewMail::addBlockHandler('myblock', fn($attrs, $content) => new MyBlock($content));
-     */
-    public static function addBlockHandler(string $tag, callable $handler): void
-    {
-        self::$blockHandlers[strtolower($tag)] = $handler;
-    }
-
-    public static function addMailer(string $key, string $name): void
-    {
-        if (array_key_exists($key, self::$mailer)) {
-            return;
-        }
-
-        self::$mailer[$key] = $name;
-    }
-
-    /**
      * @deprecated since version 2023.09
      */
     public function addAddress(string $email, string $name = ''): NewMail
@@ -181,6 +171,19 @@ class NewMail
     public function addBCC(string $email, string $name = ''): NewMail
     {
         return $this->bcc($email, $name);
+    }
+
+    /**
+     * Registra un handler personalizado para un tipo de shortcode de bloque.
+     * El callable recibe (array $attrs, string $content) y debe devolver un BaseBlock o null.
+     * Ejemplo: NewMail::addBlockHandler('myblock', fn($attrs, $content) => new MyBlock($content));
+     */
+    public static function addBlockHandler(string $tag): void
+    {
+        $className = '\\FacturaScripts\\Dinamic\\Lib\\Email\\' . $tag;
+        if (false === isset(self::$blockHandlers[$tag]) && class_exists($className)) {
+            self::$blockHandlers[$tag] = $className;
+        }
     }
 
     /**
@@ -211,6 +214,15 @@ class NewMail
         $this->mainBlocks[] = $block;
 
         return $this;
+    }
+
+    public static function addMailer(string $key, string $name): void
+    {
+        if (array_key_exists($key, self::$mailer)) {
+            return;
+        }
+
+        self::$mailer[$key] = $name;
     }
 
     /**
@@ -255,12 +267,6 @@ class NewMail
         return new static();
     }
 
-    public static function getAttachmentPath(?string $email, string $folder): string
-    {
-        $path = 'MyFiles/Email/{{email}}/' . $folder . '/';
-        return str_replace('{{email}}', $email, $path);
-    }
-
     /**
      * Devuelve los nombres de los archivos adjuntos.
      */
@@ -272,6 +278,12 @@ class NewMail
         }
 
         return $names;
+    }
+
+    public static function getAttachmentPath(?string $email, string $folder): string
+    {
+        $path = 'MyFiles/Email/{{email}}/' . $folder . '/';
+        return str_replace('{{email}}', $email, $path);
     }
 
     /**
@@ -319,6 +331,22 @@ class NewMail
         }
 
         return self::$mailer;
+    }
+
+    /**
+     * Devuelve los bloques del cuerpo del correo.
+     */
+    public function getMainBlocks(): array
+    {
+        // si no hay texto, devolvemos los bloques principales tal cual
+        if (empty($this->text)) {
+            return $this->mainBlocks;
+        }
+
+        // procesamos el texto: shortcodes, html y texto plano
+        $this->replaceTextToBlock();
+
+        return $this->mainBlocks;
     }
 
     public static function getTemplate(): string
@@ -424,9 +452,6 @@ class NewMail
             }
         }
 
-        // procesamos los shortcodes de bloque en el texto antes de renderizar
-        $this->replaceTextToBlock();
-
         $this->renderHTML();
         $this->mail->msgHTML($this->html);
 
@@ -483,13 +508,6 @@ class NewMail
         return $this;
     }
 
-    public function subject(string $subject): NewMail
-    {
-        $this->title = $subject;
-
-        return $this;
-    }
-
     public static function setTemplate(string $template): void
     {
         static::$template = $template;
@@ -521,6 +539,13 @@ class NewMail
         return $return;
     }
 
+    public function subject(string $subject): NewMail
+    {
+        $this->title = $subject;
+
+        return $this;
+    }
+
     /**
      * Pruebe la conexión PHPMailer.
      *
@@ -548,108 +573,133 @@ class NewMail
     }
 
     /**
-     * Busca shortcodes de bloque en el texto del email y los convierte en objetos BaseBlock.
-     * Sintaxis: [blockTipo atributos]contenido[/blockTipo] o [blockTipo atributos] (auto-cierre)
-     * Ejemplos:
-     *   [blockTitle type="h2"]Bienvenido[/blockTitle]
-     *   [blockText]Párrafo de texto[/blockText]
-     *   [blockHtml]<ul><li>item</li></ul>[/blockHtml]
-     *   [blockButton label="Reservar" href="https://..."]
-     *   [blockSpace height="20"]
-     * Los plugins pueden registrar tipos adicionales con NewMail::addBlockHandler().
+     * Añade un HtmlBlock si el texto contiene etiquetas HTML, o un TextBlock si es texto plano.
+     * Siempre usa la clase Dinamic para que los plugins puedan sobreescribirla.
      */
-    protected function replaceTextToBlock(): void
+    protected function addTextOrHtmlBlock(string $text): void
     {
-        if (empty($this->text)) {
+        if (strip_tags($text) !== $text) {
+            $className = self::$blockHandlers['HtmlBlock'] ?? null;
+            if ($className !== null) {
+                $this->addMainBlock(new $className($text));
+            }
             return;
         }
 
-        // buscamos shortcodes con o sin contenido interior: [blockXxx attrs]...[/blockXxx] o [blockXxx attrs]
-        preg_match_all(
-            '/\[block(\w+)([^\]]*)\](?:(.*?)\[\/block\1\])?/s',
-            $this->text,
-            $matches,
-            PREG_OFFSET_CAPTURE
-        );
-
-        // si no hay shortcodes, no hacemos nada
-        if (empty($matches[0])) {
-            return;
-        }
-
-        // guardamos los bloques existentes para añadirlos al final
-        $existingBlocks = $this->mainBlocks;
-        $this->mainBlocks = [];
-        $text = $this->text;
-        $this->text = '';
-        $lastPos = 0;
-
-        foreach ($matches[0] as $idx => $match) {
-            $fullMatch = $match[0];
-            $offset = $match[1];
-            $blockType = $matches[1][$idx][0];
-            $attrsStr = $matches[2][$idx][0];
-            $content = $matches[3][$idx][0] ?? '';
-
-            // texto antes del shortcode → TextBlock
-            $before = trim(substr($text, $lastPos, $offset - $lastPos));
-            if ('' !== $before) {
-                $this->addMainBlock(new TextBlock($before));
-            }
-            $lastPos = $offset + strlen($fullMatch);
-
-            // creamos el bloque correspondiente al shortcode
-            $attrs = static::parseShortcodeAttributes($attrsStr);
-            $block = $this->createBlockFromShortcode($blockType, $attrs, $content);
-            if ($block !== null) {
-                $this->addMainBlock($block);
-            }
-        }
-
-        // texto restante tras el último shortcode → TextBlock
-        $remaining = trim(substr($text, $lastPos));
-        if ('' !== $remaining) {
-            $this->addMainBlock(new TextBlock($remaining));
-        }
-
-        // reañadimos los bloques que existían antes
-        foreach ($existingBlocks as $block) {
-            $this->mainBlocks[] = $block;
+        $className = self::$blockHandlers['TextBlock'] ?? null;
+        if ($className !== null) {
+            $this->addMainBlock(new $className($text));
         }
     }
 
     /**
-     * Instancia el bloque correspondiente al tipo de shortcode.
-     * Los plugins pueden ampliar los tipos usando NewMail::addBlockHandler().
+     * Convierte un valor de string (proveniente de un atributo de shortcode) al tipo PHP indicado.
+     */
+    protected static function castShortcodeValue(string $value, string $type): mixed
+    {
+        return match ($type) {
+            'float' => (float)$value,
+            'int'   => (int)$value,
+            'bool'  => in_array(strtolower($value), ['true', '1', 'yes'], true),
+            'array' => [],
+            default => $value,
+        };
+    }
+
+    /**
+     * Instancia el bloque correspondiente al tipo de shortcode buscando en el registro de handlers.
+     * Usa Reflection para inspeccionar el constructor de la clase Dinamic correspondiente
+     * y pasar los parámetros correctos desde los atributos del shortcode y su contenido.
+     * El primer parámetro no array y no encontrado en attrs recibe el contenido entre etiquetas.
      */
     protected function createBlockFromShortcode(string $type, array $attrs, string $content): ?BaseBlock
     {
-        // primero comprobamos si hay un handler registrado por un plugin
-        $lowerType = strtolower($type);
-        if (isset(self::$blockHandlers[$lowerType])) {
-            return (self::$blockHandlers[$lowerType])($attrs, $content);
+        // los tags se registran con sufijo 'Block' (ej: 'TitleBlock')
+        $tag = $type . 'Block';
+        $className = null;
+        foreach (self::$blockHandlers as $handlerTag => $handlerClass) {
+            if (strcasecmp($handlerTag, $tag) === 0) {
+                $className = $handlerClass;
+                break;
+            }
         }
 
-        // tipos nativos del core
-        switch ($lowerType) {
-            case 'title':
-                return new TitleBlock($content, $attrs['type'] ?? 'h2', $attrs['css'] ?? '', $attrs['style'] ?? '');
-            case 'text':
-                return new TextBlock($content, $attrs['css'] ?? '', $attrs['style'] ?? '');
-            case 'html':
-                return new HtmlBlock($content);
-            case 'button':
-                return new ButtonBlock(
-                    $attrs['label'] ?? $content,
-                    $attrs['href'] ?? '',
-                    $attrs['css'] ?? '',
-                    $attrs['style'] ?? ''
-                );
-            case 'space':
-                return new SpaceBlock((float)($attrs['height'] ?? 30));
+        // si no hay handler registrado, ignoramos el shortcode
+        if ($className === null) {
+            return null;
         }
 
-        return null;
+        // usamos reflection para instanciar la clase con los parámetros correctos
+        try {
+            $reflection = new ReflectionClass($className);
+            $constructor = $reflection->getConstructor();
+
+            if ($constructor === null) {
+                return $reflection->newInstance();
+            }
+
+            $args = [];
+            $isFirst = true;
+
+            foreach ($constructor->getParameters() as $param) {
+                $name = $param->getName();
+                $typeName = $param->getType() instanceof ReflectionNamedType
+                    ? $param->getType()->getName()
+                    : 'string';
+
+                // si el atributo existe en el shortcode, lo usamos directamente
+                if (array_key_exists($name, $attrs)) {
+                    $args[] = static::castShortcodeValue($attrs[$name], $typeName);
+                    $isFirst = false;
+                    continue;
+                }
+
+                // el primer parámetro no-array sin attr correspondiente recibe el contenido entre etiquetas
+                if ($isFirst) {
+                    $isFirst = false;
+                    if ($typeName !== 'array' && $content !== '') {
+                        $args[] = static::castShortcodeValue($content, $typeName);
+                        continue;
+                    }
+                }
+
+                // usamos el valor por defecto si existe
+                if ($param->isDefaultValueAvailable()) {
+                    $args[] = $param->getDefaultValue();
+                    continue;
+                }
+
+                // sin attr, sin contenido y sin default → valor cero del tipo
+                $args[] = static::zeroValueForType($typeName);
+            }
+
+            return $reflection->newInstanceArgs($args);
+        } catch (ReflectionException $e) {
+            Tools::log()->warning('email-block-reflection-error', [
+                '%block%' => $className,
+                '%error%' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Devuelve los bloques del pie del correo.
+     */
+    protected function getFooterBlocks(): array
+    {
+        $signature = Tools::fixHtml($this->signature);
+        if (empty($signature)) {
+            return $this->footerBlocks;
+        }
+
+        // usamos la clase Dinamic para que los plugins puedan sobreescribirla
+        $className = self::$blockHandlers['TextBlock'] ?? null;
+        if ($className === null) {
+            return $this->footerBlocks;
+        }
+
+        return array_merge($this->footerBlocks, [new $className($signature, 'text-footer')]);
     }
 
     /**
@@ -664,37 +714,6 @@ class NewMail
             $attrs[$key] = $matches[2][$i];
         }
         return $attrs;
-    }
-
-    /**
-     * Devuelve los bloques del pie del correo.
-     */
-    protected function getFooterBlocks(): array
-    {
-        $signature = Tools::fixHtml($this->signature);
-        return empty($signature)
-            ? $this->footerBlocks
-            : array_merge($this->footerBlocks, [new TextBlock($signature, 'text-footer')]);
-    }
-
-    /**
-     * Devuelve los bloques del cuerpo del correo.
-     */
-    protected function getMainBlocks(): array
-    {
-        // si no hay texto, devolvemos los bloques principales
-        if (empty($this->text)) {
-            return $this->mainBlocks;
-        }
-
-        // buscamos si en el texto hay algo de html
-        $textWithoutHtml = strip_tags($this->text);
-        if ($textWithoutHtml !== $this->text) {
-            return array_merge([new DinHtmlBlock($this->text)], $this->mainBlocks);
-        }
-
-        // si no hay html, devolvemos el texto como bloque de texto
-        return array_merge([new DinTextBlock($this->text, 'pb-15')], $this->mainBlocks);
     }
 
     /**
@@ -723,6 +742,83 @@ class NewMail
             'mainBlocks' => $this->getMainBlocks(),
             'title' => $this->title
         ]);
+    }
+
+    /**
+     * Busca shortcodes de bloque en el texto del email y los convierte en objetos BaseBlock.
+     * También detecta HTML entre bloques y lo envuelve en HtmlBlock; el texto plano va a TextBlock.
+     * Sintaxis: [blockTipo atributos]contenido[/blockTipo] o [blockTipo atributos] (auto-cierre)
+     * Ejemplos:
+     *   [blockTitle type="h2"]Bienvenido[/blockTitle]
+     *   [blockText]Párrafo de texto[/blockText]
+     *   [blockHtml]<ul><li>item</li></ul>[/blockHtml]
+     *   [blockButton label="Reservar" href="https://..."]
+     *   [blockSpace height="20"]
+     * Los plugins pueden registrar tipos adicionales con NewMail::addBlockHandler().
+     */
+    protected function replaceTextToBlock(): void
+    {
+        if (empty($this->text)) {
+            return;
+        }
+
+        // buscamos shortcodes con o sin contenido interior: [blockXxx attrs]...[/blockXxx] o [blockXxx attrs]
+        preg_match_all(
+            '/\[block(\w+)([^\]]*)\](?:(.*?)\[\/block\1\])?/s',
+            $this->text,
+            $matches,
+            PREG_OFFSET_CAPTURE
+        );
+
+        // guardamos los bloques existentes para añadirlos al final
+        $existingBlocks = $this->mainBlocks;
+        $this->mainBlocks = [];
+        $text = $this->text;
+        $this->text = '';
+
+        // si no hay shortcodes, procesamos el texto completo como html o texto plano
+        if (empty($matches[0])) {
+            $this->addTextOrHtmlBlock($text);
+            foreach ($existingBlocks as $block) {
+                $this->mainBlocks[] = $block;
+            }
+            return;
+        }
+
+        $lastPos = 0;
+
+        foreach ($matches[0] as $idx => $match) {
+            $fullMatch = $match[0];
+            $offset = $match[1];
+            $blockType = $matches[1][$idx][0];
+            $attrsStr = $matches[2][$idx][0];
+            $content = $matches[3][$idx][0] ?? '';
+
+            // texto antes del shortcode → HtmlBlock si contiene html, TextBlock si es texto plano
+            $before = trim(substr($text, $lastPos, $offset - $lastPos));
+            if ('' !== $before) {
+                $this->addTextOrHtmlBlock($before);
+            }
+            $lastPos = $offset + strlen($fullMatch);
+
+            // creamos el bloque correspondiente al shortcode
+            $attrs = static::parseShortcodeAttributes($attrsStr);
+            $block = $this->createBlockFromShortcode($blockType, $attrs, $content);
+            if ($block !== null) {
+                $this->addMainBlock($block);
+            }
+        }
+
+        // texto restante tras el último shortcode → HtmlBlock si contiene html, TextBlock si es texto plano
+        $remaining = trim(substr($text, $lastPos));
+        if ('' !== $remaining) {
+            $this->addTextOrHtmlBlock($remaining);
+        }
+
+        // reañadimos los bloques que existían antes
+        foreach ($existingBlocks as $block) {
+            $this->mainBlocks[] = $block;
+        }
     }
 
     /**
@@ -811,5 +907,19 @@ class NewMail
         }
 
         return [];
+    }
+
+    /**
+     * Devuelve el valor neutro para un tipo PHP dado (usado cuando no hay attr ni default).
+     */
+    protected static function zeroValueForType(string $type): mixed
+    {
+        return match ($type) {
+            'float' => 0.0,
+            'int'   => 0,
+            'bool'  => false,
+            'array' => [],
+            default => '',
+        };
     }
 }

--- a/Core/Lib/Email/NewMail.php
+++ b/Core/Lib/Email/NewMail.php
@@ -30,9 +30,6 @@ use FacturaScripts\Dinamic\Model\EmailSent;
 use FacturaScripts\Dinamic\Model\Empresa;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionNamedType;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -593,28 +590,10 @@ class NewMail
     }
 
     /**
-     * Convierte un valor de string (proveniente de un atributo de shortcode) al tipo PHP indicado.
-     */
-    protected static function castShortcodeValue(string $value, string $type): mixed
-    {
-        return match ($type) {
-            'float' => (float)$value,
-            'int'   => (int)$value,
-            'bool'  => in_array(strtolower($value), ['true', '1', 'yes'], true),
-            'array' => [],
-            default => $value,
-        };
-    }
-
-    /**
-     * Instancia el bloque correspondiente al tipo de shortcode buscando en el registro de handlers.
-     * Usa Reflection para inspeccionar el constructor de la clase Dinamic correspondiente
-     * y pasar los parámetros correctos desde los atributos del shortcode y su contenido.
-     * El primer parámetro no array y no encontrado en attrs recibe el contenido entre etiquetas.
+     * Instancia el bloque correspondiente al tipo de shortcode delegando en su método fromShortcode().
      */
     protected function createBlockFromShortcode(string $type, array $attrs, string $content): ?BaseBlock
     {
-        // los tags se registran con sufijo 'Block' (ej: 'TitleBlock')
         $tag = $type . 'Block';
         $className = null;
         foreach (self::$blockHandlers as $handlerTag => $handlerClass) {
@@ -624,63 +603,11 @@ class NewMail
             }
         }
 
-        // si no hay handler registrado, ignoramos el shortcode
         if ($className === null) {
             return null;
         }
 
-        // usamos reflection para instanciar la clase con los parámetros correctos
-        try {
-            $reflection = new ReflectionClass($className);
-            $constructor = $reflection->getConstructor();
-
-            if ($constructor === null) {
-                return $reflection->newInstance();
-            }
-
-            $args = [];
-            $isFirst = true;
-
-            foreach ($constructor->getParameters() as $param) {
-                $name = $param->getName();
-                $typeName = $param->getType() instanceof ReflectionNamedType
-                    ? $param->getType()->getName()
-                    : 'string';
-
-                // si el atributo existe en el shortcode, lo usamos directamente
-                if (array_key_exists($name, $attrs)) {
-                    $args[] = static::castShortcodeValue($attrs[$name], $typeName);
-                    $isFirst = false;
-                    continue;
-                }
-
-                // el primer parámetro no-array sin attr correspondiente recibe el contenido entre etiquetas
-                if ($isFirst) {
-                    $isFirst = false;
-                    if ($typeName !== 'array' && $content !== '') {
-                        $args[] = static::castShortcodeValue($content, $typeName);
-                        continue;
-                    }
-                }
-
-                // usamos el valor por defecto si existe
-                if ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
-                    continue;
-                }
-
-                // sin attr, sin contenido y sin default → valor cero del tipo
-                $args[] = static::zeroValueForType($typeName);
-            }
-
-            return $reflection->newInstanceArgs($args);
-        } catch (ReflectionException $e) {
-            Tools::log()->warning('email-block-reflection-error', [
-                '%block%' => $className,
-                '%error%' => $e->getMessage(),
-            ]);
-            return null;
-        }
+        return $className::fromShortcode($attrs, $content);
     }
 
     /**
@@ -909,17 +836,4 @@ class NewMail
         return [];
     }
 
-    /**
-     * Devuelve el valor neutro para un tipo PHP dado (usado cuando no hay attr ni default).
-     */
-    protected static function zeroValueForType(string $type): mixed
-    {
-        return match ($type) {
-            'float' => 0.0,
-            'int'   => 0,
-            'bool'  => false,
-            'array' => [],
-            default => '',
-        };
-    }
 }

--- a/Core/Lib/Email/SpaceBlock.php
+++ b/Core/Lib/Email/SpaceBlock.php
@@ -33,6 +33,11 @@ class SpaceBlock extends BaseBlock
         $this->height = $height;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static((float)($attrs['height'] ?? 30));
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Core/Lib/Email/TableBlock.php
+++ b/Core/Lib/Email/TableBlock.php
@@ -45,6 +45,11 @@ class TableBlock extends BaseBlock
         $this->rows = $rows;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static([], [], $attrs['css'] ?? '', $attrs['style'] ?? '');
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Core/Lib/Email/TextBlock.php
+++ b/Core/Lib/Email/TextBlock.php
@@ -41,6 +41,15 @@ class TextBlock extends BaseBlock
         $this->text = $text;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static(
+            $attrs['text'] ?? $content,
+            $attrs['css'] ?? '',
+            $attrs['style'] ?? ''
+        );
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Core/Lib/Email/TitleBlock.php
+++ b/Core/Lib/Email/TitleBlock.php
@@ -45,6 +45,16 @@ class TitleBlock extends BaseBlock
         $this->type = $type;
     }
 
+    public static function fromShortcode(array $attrs, string $content): static
+    {
+        return new static(
+            $attrs['text'] ?? $content,
+            $attrs['type'] ?? 'h2',
+            $attrs['css'] ?? '',
+            $attrs['style'] ?? ''
+        );
+    }
+
     public function render(bool $footer = false): string
     {
         $this->footer = $footer;

--- a/Test/Core/Lib/Email/NewMailTest.php
+++ b/Test/Core/Lib/Email/NewMailTest.php
@@ -85,7 +85,6 @@ final class NewMailTest extends TestCase
             . '[blockUnknown]este shortcode no existe[/blockUnknown]'
             . '[blockFake]';
         
-
         $blocks = NewMail::create()->body($text)->getMainBlocks();
 
         // solo los 5 bloques válidos deben estar presentes

--- a/Test/Core/Lib/Email/NewMailTest.php
+++ b/Test/Core/Lib/Email/NewMailTest.php
@@ -19,7 +19,13 @@
 
 namespace FacturaScripts\Test\Core\Lib\Email;
 
+use FacturaScripts\Core\Lib\Email\BaseBlock;
+use FacturaScripts\Core\Lib\Email\ButtonBlock;
+use FacturaScripts\Core\Lib\Email\HtmlBlock;
 use FacturaScripts\Core\Lib\Email\NewMail;
+use FacturaScripts\Core\Lib\Email\SpaceBlock;
+use FacturaScripts\Core\Lib\Email\TextBlock;
+use FacturaScripts\Core\Lib\Email\TitleBlock;
 use PHPUnit\Framework\TestCase;
 
 final class NewMailTest extends TestCase
@@ -66,5 +72,61 @@ final class NewMailTest extends TestCase
         $this->assertEmpty($mailer->getToAddresses());
         $this->assertEmpty($mailer->getCcAddresses());
         $this->assertCount(1, $mailer->getBccAddresses());
+    }
+
+    public function testBlocksFromShortcodes(): void
+    {
+        // 5 shortcodes válidos + 2 inválidos (deben ignorarse sin error)
+        $text = '[blockText]Texto de prueba[/blockText]'
+            . '[blockTitle type="h2"]Mi título[/blockTitle]'
+            . '[blockHtml]<b>negrita</b>[/blockHtml]'
+            . '[blockButton label="Reservar" href="https://example.com"]'
+            . '[blockSpace height="20"]'
+            . '[blockUnknown]este shortcode no existe[/blockUnknown]'
+            . '[blockFake]';
+        
+
+        $blocks = NewMail::create()->body($text)->getMainBlocks();
+
+        // solo los 5 bloques válidos deben estar presentes
+        $this->assertCount(5, $blocks, 'No se han detectado exactamente 5 bloques cuando se esperaban 5 bloques válidos');
+        $this->assertContainsOnlyInstancesOf(BaseBlock::class, $blocks, 'No todos los bloques son instancias de BaseBlock como se esperaba');
+
+        $this->assertInstanceOf(TextBlock::class, $blocks[0], 'El primer bloque no es del tipo TextBlock como se esperaba');
+        $this->assertInstanceOf(TitleBlock::class, $blocks[1], 'El segundo bloque no es del tipo TitleBlock como se esperaba');
+        $this->assertInstanceOf(HtmlBlock::class, $blocks[2], 'El tercer bloque no es del tipo HtmlBlock como se esperaba');
+        $this->assertInstanceOf(ButtonBlock::class, $blocks[3], 'El cuarto bloque no es del tipo ButtonBlock como se esperaba');
+        $this->assertInstanceOf(SpaceBlock::class, $blocks[4], 'El quinto bloque no es del tipo SpaceBlock como se esperaba');
+    }
+
+    public function testHtmlBeforeBlock(): void
+    {
+        // html antes de un bloque → HtmlBlock + bloque
+        $text = '<a href="https://example.com">mi enlace</a>'
+            . '[blockTitle type="h3"]Mi título[/blockTitle]';
+
+        $blocks = NewMail::create()->body($text)->getMainBlocks();
+
+        $this->assertCount(2, $blocks, 'No se han detectado exactamente 2 bloques cuando se esperaba un bloque HTML seguido de un bloque de título');
+        $this->assertInstanceOf(HtmlBlock::class, $blocks[0], 'El primer bloque no es del tipo HtmlBlock como se esperaba');
+        $this->assertInstanceOf(TitleBlock::class, $blocks[1], 'El segundo bloque no es del tipo TitleBlock como se esperaba');
+    }
+
+
+    public function testPlainTextBlock(): void
+    {
+        // texto plano sin bloques ni html → un único TextBlock
+        $blocks = NewMail::create()->body('Texto plano sin bloques')->getMainBlocks();
+
+        $this->assertCount(1, $blocks, 'Hay más de un bloque cuando solo debería haber uno');
+        $this->assertInstanceOf(TextBlock::class, $blocks[0], 'El bloque no es del tipo TextBlock como se esperaba');
+    }
+
+    public function testEmptyTextBlocks(): void
+    {
+        // sin texto → sin bloques
+        $blocks = NewMail::create()->getMainBlocks();
+
+        $this->assertEmpty($blocks, 'Hay bloques cuando no debería haber ninguno');
     }
 }


### PR DESCRIPTION
Ahora desde cualquier email o notificación de email podemos usar los bloques de email como el ejemplo siguiente, permitiendo así poder usar la misma lógica desde ambos lugares y mantener el html de la plantilla del email estable.

```
email de ejemplo

[blockText]Texto de prueba[/blockText]
<a href="https://danielfg.es">danielfg.es</a>
[blockTitle type="h2"]Mi título[/blockTitle]
[blockHtml]<b>negrita</b>[/blockHtml]
[blockButton label="Reservar" href="https://example.com"]
[blockSpace height="20"]
[blockUnknown]este shortcode no existe[/blockUnknown]
[blockFake]

texto final
```


## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.