### PR TITLE
Mejorar la agrupación de widgets select en EditProducto, EditCliente y WidgetSelect

### DIFF
--- a/Core/Controller/EditProducto.php
+++ b/Core/Controller/EditProducto.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,7 +19,6 @@
 
 namespace FacturaScripts\Core\Controller;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Almacenes;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\DocFilesTrait;
@@ -28,6 +27,7 @@ use FacturaScripts\Core\Lib\ExtendedController\ProductImagesTrait;
 use FacturaScripts\Core\Lib\ProductType;
 use FacturaScripts\Core\Model\ProductoImagen;
 use FacturaScripts\Core\Lib\TaxExceptions;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\Atributo;
 use FacturaScripts\Dinamic\Model\CodeModel;
 
@@ -209,41 +209,29 @@ class EditProducto extends EditController
         $columnsName = ['attribute-value-1', 'attribute-value-2', 'attribute-value-3', 'attribute-value-4'];
         foreach ($columnsName as $key => $colName) {
             $column = $this->views[$viewName]->columnForName($colName);
-            if ($column && $column->widget->getType() === 'select') {
-                // Obtenemos los atributos con número de selector ($key + 1)
-                $atributos = Atributo::all([
-                    new DataBaseWhere('num_selector', ($key + 1)),
-                ]);
-
-                // si no hay ninguno, obtenemos los que tienen número de selector 0
-                if (count($atributos) === 0) {
-                    $atributos = Atributo::all([
-                        new DataBaseWhere('num_selector', 0),
-                    ]);
-                }
-
-                $valoresAtributos = [];
-
-                foreach ($atributos as $atributo) {
-                    // si ya tenemos valore, añadimos un separador
-                    if (count($valoresAtributos) > 0) {
-                        $valoresAtributos[] = [
-                            'value' => '',
-                            'title' => '------',
-                        ];
-                    }
-
-                    // agregamos al array con los campos que se usaran en el select.
-                    foreach ($atributo->getValores() as $valor) {
-                        $valoresAtributos[] = [
-                            'value' => $valor->id,
-                            'title' => $valor->descripcion,
-                        ];
-                    }
-                }
-
-                $column->widget->setValuesFromArray($valoresAtributos, false, true);
+            if (empty($column) || $column->widget->getType() !== 'select') {
+                continue;
             }
+
+            // Cargamos los atributos del selector concreto (num_selector = posición)
+            // y también los genéricos (num_selector = 0), que aparecen en todos los selectores
+            $atributos = Atributo::all([
+                Where::eq('num_selector', $key + 1),
+                Where::orEq('num_selector', 0),
+            ], ['nombre' => 'ASC']);
+
+            $valoresAtributos = [];
+            foreach ($atributos as $atributo) {
+                foreach ($atributo->getValues() as $valor) {
+                    $valoresAtributos[] = [
+                        'value' => $valor->id,
+                        'title' => $valor->valor,
+                        'group' => $atributo->nombre,
+                    ];
+                }
+            }
+
+            $column->widget->setValuesFromArray($valoresAtributos, false, true, 'value', 'title', 'group');
         }
     }
 
@@ -251,7 +239,7 @@ class EditProducto extends EditController
     {
         $references = [];
         $id = $this->getViewModelValue('EditProducto', 'idproducto');
-        $where = [new DataBaseWhere('idproducto', $id)];
+        $where = [Where::eq('idproducto', $id)];
         $values = $this->codeModel->all('variantes', 'referencia', 'referencia', false, $where);
         foreach ($values as $code) {
             $references[] = ['value' => $code->code, 'title' => $code->description];
@@ -272,7 +260,7 @@ class EditProducto extends EditController
     protected function loadData($viewName, $view)
     {
         $id = $this->getViewModelValue('EditProducto', 'idproducto');
-        $where = [new DataBaseWhere('idproducto', $id)];
+        $where = [Where::eq('idproducto', $id)];
 
         switch ($viewName) {
             case 'docfiles':
@@ -320,13 +308,13 @@ class EditProducto extends EditController
                 break;
 
             case 'ListLineaPedidoCliente':
-                $where[] = new DataBaseWhere('actualizastock', -2);
+                $where[] = Where::eq('actualizastock', -2);
                 $view->loadData('', $where);
                 $this->setSettings($viewName, 'active', $view->model->count($where) > 0);
                 break;
 
             case 'ListLineaPedidoProveedor':
-                $where[] = new DataBaseWhere('actualizastock', 2);
+                $where[] = Where::eq('actualizastock', 2);
                 $view->loadData('', $where);
                 $this->setSettings($viewName, 'active', $view->model->count($where) > 0);
                 break;

--- a/Core/Lib/Widget/WidgetSelect.php
+++ b/Core/Lib/Widget/WidgetSelect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -60,6 +60,15 @@ class WidgetSelect extends BaseWidget
     /** @var bool */
     protected $translate;
 
+    /** @var string */
+    protected $groupSource = '';
+
+    /** @var string */
+    protected $groupFieldcode = '';
+
+    /** @var string */
+    protected $groupTitle = '';
+
     /** @var array */
     public $values = [];
 
@@ -104,7 +113,10 @@ class WidgetSelect extends BaseWidget
             'fieldcode' => $this->fieldcode,
             'fieldfilter' => $this->fieldfilter,
             'fieldtitle' => $this->fieldtitle,
-            'limit' => $this->limit
+            'limit' => $this->limit,
+            'group_source' => $this->groupSource,
+            'group_fieldcode' => $this->groupFieldcode,
+            'group_title' => $this->groupTitle,
         ];
     }
 
@@ -137,7 +149,7 @@ class WidgetSelect extends BaseWidget
      * @param string $col1
      * @param string $col2
      */
-    public function setValuesFromArray(array $items, bool $translate = false, bool $addEmpty = false, string $col1 = 'value', string $col2 = 'title')
+    public function setValuesFromArray(array $items, bool $translate = false, bool $addEmpty = false, string $col1 = 'value', string $col2 = 'title', string $col3 = '')
     {
         $this->values = [];
 
@@ -154,10 +166,14 @@ class WidgetSelect extends BaseWidget
             }
 
             if (isset($item[$col1])) {
-                $this->values[] = [
+                $entry = [
                     'value' => $item[$col1],
-                    'title' => $item[$col2] ?? $item[$col1]
+                    'title' => $item[$col2] ?? $item[$col1],
                 ];
+                if ($col3 !== '' && isset($item[$col3])) {
+                    $entry['group'] = $item[$col3];
+                }
+                $this->values[] = $entry;
             }
         }
 
@@ -166,7 +182,7 @@ class WidgetSelect extends BaseWidget
         }
     }
 
-    public function setValuesFromArrayKeys(array $values, bool $translate = false, bool $addEmpty = false)
+    public function setValuesFromArrayKeys(array $values, bool $translate = false, bool $addEmpty = false, array $groups = [])
     {
         $this->values = [];
 
@@ -175,10 +191,11 @@ class WidgetSelect extends BaseWidget
         }
 
         foreach ($values as $key => $value) {
-            $this->values[] = [
-                'value' => $key,
-                'title' => $value
-            ];
+            $entry = ['value' => $key, 'title' => $value];
+            if (isset($groups[$key])) {
+                $entry['group'] = $groups[$key];
+            }
+            $this->values[] = $entry;
         }
 
         if ($translate) {
@@ -187,19 +204,22 @@ class WidgetSelect extends BaseWidget
     }
 
     /**
-     * Loads the value list from an array with value and title (description)
-     *
      * @param array $rows
      * @param bool $translate
+     * @param array $groups array indexado por code => etiqueta del grupo
      */
-    public function setValuesFromCodeModel(array $rows, bool $translate = false)
+    public function setValuesFromCodeModel(array $rows, bool $translate = false, array $groups = [])
     {
         $this->values = [];
         foreach ($rows as $codeModel) {
-            $this->values[] = [
+            $entry = [
                 'value' => $codeModel->code,
-                'title' => $codeModel->description
+                'title' => $codeModel->description,
             ];
+            if (isset($groups[$codeModel->code])) {
+                $entry['group'] = $groups[$codeModel->code];
+            }
+            $this->values[] = $entry;
         }
 
         if ($translate) {
@@ -211,11 +231,25 @@ class WidgetSelect extends BaseWidget
      * @param int $start
      * @param int $end
      * @param int $step
+     * @param array $groups array indexado por valor numérico => etiqueta del grupo
      */
-    public function setValuesFromRange(int $start, int $end, int $step)
+    public function setValuesFromRange(int $start, int $end, int $step, array $groups = [])
     {
         $values = range($start, $end, $step);
-        $this->setValuesFromArray($values);
+
+        if (empty($groups)) {
+            $this->setValuesFromArray($values);
+            return;
+        }
+
+        $this->values = [];
+        foreach ($values as $val) {
+            $entry = ['value' => $val, 'title' => $val];
+            if (isset($groups[$val])) {
+                $entry['group'] = $groups[$val];
+            }
+            $this->values[] = $entry;
+        }
     }
 
     /**
@@ -296,16 +330,63 @@ class WidgetSelect extends BaseWidget
             . '>';
 
         $found = false;
+        $hasGroups = false;
         foreach ($this->values as $option) {
-            $title = empty($option['title']) ? $option['value'] : $option['title'];
+            if (!empty($option['group'])) {
+                $hasGroups = true;
+                break;
+            }
+        }
 
-            if ($this->valuesMatch($option['value'], $this->value) && (!$found || $this->multiple)) {
-                $found = true;
-                $html .= '<option value="' . $option['value'] . '" selected>' . $title . '</option>';
-                continue;
+        if ($hasGroups) {
+            // Separar opciones sin grupo (ej. la opción vacía) de las agrupadas
+            $ungrouped = [];
+            $grouped = [];
+            foreach ($this->values as $option) {
+                if (empty($option['group'])) {
+                    $ungrouped[] = $option;
+                } else {
+                    $grouped[$option['group']][] = $option;
+                }
             }
 
-            $html .= '<option value="' . $option['value'] . '">' . $title . '</option>';
+            // Opciones sin grupo primero
+            foreach ($ungrouped as $option) {
+                $title = empty($option['title']) ? $option['value'] : $option['title'];
+                if ($this->valuesMatch($option['value'], $this->value) && (!$found || $this->multiple)) {
+                    $found = true;
+                    $html .= '<option value="' . $option['value'] . '" selected>' . $title . '</option>';
+                    continue;
+                }
+                $html .= '<option value="' . $option['value'] . '">' . $title . '</option>';
+            }
+
+            // Opciones agrupadas dentro de <optgroup>
+            foreach ($grouped as $groupLabel => $options) {
+                $html .= '<optgroup label="' . Tools::noHtml($groupLabel) . '">';
+                foreach ($options as $option) {
+                    $title = empty($option['title']) ? $option['value'] : $option['title'];
+                    if ($this->valuesMatch($option['value'], $this->value) && (!$found || $this->multiple)) {
+                        $found = true;
+                        $html .= '<option value="' . $option['value'] . '" selected>' . $title . '</option>';
+                        continue;
+                    }
+                    $html .= '<option value="' . $option['value'] . '">' . $title . '</option>';
+                }
+                $html .= '</optgroup>';
+            }
+        } else {
+            foreach ($this->values as $option) {
+                $title = empty($option['title']) ? $option['value'] : $option['title'];
+
+                if ($this->valuesMatch($option['value'], $this->value) && (!$found || $this->multiple)) {
+                    $found = true;
+                    $html .= '<option value="' . $option['value'] . '" selected>' . $title . '</option>';
+                    continue;
+                }
+
+                $html .= '<option value="' . $option['value'] . '">' . $title . '</option>';
+            }
         }
 
         // value not found?
@@ -344,10 +425,41 @@ class WidgetSelect extends BaseWidget
         $this->fieldfilter = $child['fieldfilter'] ?? $this->fieldfilter;
         $this->fieldtitle = $child['fieldtitle'] ?? $this->fieldcode;
         $this->limit = $child['limit'] ?? CodeModel::getlimit();
+        $this->groupSource = $child['group_source'] ?? '';
+        $this->groupFieldcode = $child['group_fieldcode'] ?? '';
+        $this->groupTitle = $child['group_title'] ?? '';
+
         if ($loadData && $this->source) {
             static::$codeModel::setLimit($this->limit);
             $values = static::$codeModel->all($this->source, $this->fieldcode, $this->fieldtitle, !$this->required);
-            $this->setValuesFromCodeModel($values, $this->translate);
+
+            if (!empty($this->groupSource) && !empty($this->groupFieldcode) && !empty($this->groupTitle)) {
+                // Mapa de group_fieldcode => group_title
+                $groupLabelRows = static::$codeModel->all($this->groupSource, $this->groupFieldcode, $this->groupTitle, false);
+                $groupLabelMap = [];
+                foreach ($groupLabelRows as $row) {
+                    $groupLabelMap[$row->code] = $row->description;
+                }
+
+                // Mapa de fieldcode => group_fieldcode (valor del campo de agrupación en cada registro)
+                static::$codeModel::setLimit($this->limit);
+                $groupFieldRows = static::$codeModel->all($this->source, $this->fieldcode, $this->groupFieldcode, false);
+                $groupFieldMap = [];
+                foreach ($groupFieldRows as $row) {
+                    $groupFieldMap[$row->code] = $row->description;
+                }
+
+                // Construir mapa fieldcode => etiqueta del grupo
+                $groups = [];
+                foreach ($values as $row) {
+                    $groupFieldValue = $groupFieldMap[$row->code] ?? null;
+                    $groups[$row->code] = $groupLabelMap[$groupFieldValue] ?? '';
+                }
+
+                $this->setValuesFromCodeModel($values, $this->translate, $groups);
+            } else {
+                $this->setValuesFromCodeModel($values, $this->translate);
+            }
         }
     }
 

--- a/Core/XMLView/EditCliente.xml
+++ b/Core/XMLView/EditCliente.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -104,7 +104,8 @@
             </column>
             <column name="payment-method" titleurl="ListFormaPago" numcolumns="2" order="140">
                 <widget type="select" fieldname="codpago" onclick="EditFormaPago">
-                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
+                    <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"
+                            group_source="empresas" group_fieldcode="idempresa" group_title="nombrecorto"/>
                 </widget>
             </column>
             <column name="payment-days" description="desc-payment-days" numcolumns="2" order="150">


### PR DESCRIPTION
Actualmente el WidgetSelect no permite agrupar dentro los valores, pero select2 que es la librería que se usa para WidgetSelect si lo permite. Con esta mejora se da la opción para poder agrupar valores, mostrando por ejemplo las formas de pago que van por empresa a que empresa pertenecen, o los valores de atributos, etc.

 Select de atributos en las variantes del producto
<img width="722" height="480" alt="Captura de pantalla 2026-04-09 a las 10 40 02" src="https://github.com/user-attachments/assets/b7e61bbd-7bc5-4bdd-be55-125139d3453b" />

Select de formas de pago en la ficha del cliente
<img width="684" height="472" alt="Captura de pantalla 2026-04-09 a las 10 40 21" src="https://github.com/user-attachments/assets/31f26e7e-a29d-432c-a5ea-c013e216ac22" />

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.