### PR TITLE
Añadir descripción en el modal del GroupItem

### DIFF
--- a/Core/Lib/Widget/GroupItem.php
+++ b/Core/Lib/Widget/GroupItem.php
@@ -136,7 +136,10 @@ class GroupItem extends VisualItem
             . '<div class="modal-dialog ' . $this->class . '" role="document">'
             . '<div class="modal-content">'
             . '<div class="modal-header">'
+            . '<div>'
             . '<h5 class="modal-title">' . $icon . Tools::trans($this->title) . '</h5>'
+            . (empty($this->description) ? '' : '<small class="form-text text-muted">' . Tools::trans($this->description) . '</small>')
+            . '</div>'
             . '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">'
             . '</button>'
             . '</div>'


### PR DESCRIPTION
Existe el campo description para los grupos en los xmlView pero en los grupos de los modales no funciona, con este cambio si.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.