### PR TITLE
Añadido minlength al widget text

### DIFF
--- a/Core/Lib/Widget/WidgetText.php
+++ b/Core/Lib/Widget/WidgetText.php
@@ -35,6 +35,14 @@ class WidgetText extends BaseWidget
     protected $maxlength;
 
     /**
+     * Indicates the minim length of characters.
+     * 0 -> indeterminate
+     *
+     * @var int
+     */
+    protected $minlength;
+
+    /**
      * Class constructor
      *
      * @param array $data
@@ -42,17 +50,27 @@ class WidgetText extends BaseWidget
     public function __construct($data)
     {
         parent::__construct($data);
-        $this->maxlength = $data['maxlength'] ?? 0;
+        $this->maxlength = $data['maxlength'] ?? $data['max'] ?? 0;
+        $this->minlength = $data['minlength'] ?? $data['min'] ?? 0;
     }
 
     /**
-     * Add extra attributes to html input field
+     * Add extra attributes to HTML input field
      *
      * @return string
      */
-    protected function inputHtmlExtraParams()
+    protected function inputHtmlExtraParams(): string
     {
-        $params = $this->maxlength > 0 ? ' maxlength="' . $this->maxlength . '"' : '';
+        $params = '';
+
+        if ($this->maxlength > 0) {
+            $params .= ' maxlength="' . $this->maxlength . '"';
+        }
+
+        if ($this->minlength > 0) {
+            $params .= ' minlength="' . $this->minlength . '"';
+        }
+
         return $params . parent::inputHtmlExtraParams();
     }
 }


### PR DESCRIPTION
# Descripción
- Se ha añadido la posibilidad de poder indicar en la vista xml una longitud mínima al widget text de manera similar que estaba el poder indicar un máximo.
- Se ha añadido la posibilidad de usar los atributos min y max al declarar el widget en la vista xml para hacer lo mismo, siendo más memo técnico y sencillo de recordar.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.