### PR TITLE
ajustar texto de ayuda en los checkboxs

### DIFF
--- a/Core/Lib/Widget/WidgetCheckbox.php
+++ b/Core/Lib/Widget/WidgetCheckbox.php
@@ -50,7 +50,7 @@ class WidgetCheckbox extends BaseWidget
             . '" class="' . $class . '"' . $checked . $readonly . $tabindex . '/>';
         $labelHtml = '<label for="' . $id . '">' . Tools::trans($title) . '</label>';
         $descriptionHtml = empty($description) ? '' :
-            '<small class="form-text text-muted">' . Tools::trans($description) . '</small>';
+            '<div class="form-text text-muted">' . Tools::trans($description) . '</div>';
 
         return '<div class="form-check pe-3 mb-3">'
             . $inputHtml


### PR DESCRIPTION
usando div ya no se pega al checkbox y se muestra el texto en la siguiente linea.

<img width="851" height="745" alt="imagen" src="https://github.com/user-attachments/assets/ff9e199c-7223-4629-9791-642fd5c4e6b4" />


extraido de la documentación de bootstrap:
<img width="1081" height="424" alt="imagen" src="https://github.com/user-attachments/assets/b41ac444-d1aa-421f-9e2d-709747b88de7" />
