### PR TITLE
forzar IVA 0% cuando el cliente tiene excepcioniva

### DIFF
--- a/Core/Lib/Calculator.php
+++ b/Core/Lib/Calculator.php
@@ -373,7 +373,7 @@ class Calculator
         // recorremos las líneas del documento
         foreach ($lines as $line) {
             // ¿La serie es sin impuestos o el régimen exento?
-            if ($noTax || $regimen === RegimenIVA::TAX_SYSTEM_EXEMPT) {
+            if ($noTax || $regimen === RegimenIVA::TAX_SYSTEM_EXEMPT || !empty($taxException)) {
                 $line->codimpuesto = Impuestos::get('IVA0')->codimpuesto;
                 $line->excepcioniva = $taxException;
                 $line->iva = $line->recargo = 0.0;


### PR DESCRIPTION
 Si el cliente tenía excepcioniva informada pero regimeniva General,                                                                                                                                                         
las líneas se calculaban con el IVA del producto en lugar de 0%.                                                                                                                                                            
 TicketBAI rechaza líneas con excepción de IVA y porcentaje mayor que 0.                                                                                                                                                     

Se añade !empty($taxException) como tercera condición en el bloque     
 que fuerza codimpuesto=IVA0, iva=0 y recargo=0 en todas las líneas."