### PR TITLE
Corregir cuando una productos con coste 0

### DIFF
--- a/Core/Lib/CostPriceTools.php
+++ b/Core/Lib/CostPriceTools.php
@@ -77,7 +77,8 @@ class CostPriceTools
         $rows = [];
         $where = [
             new DataBaseWhere('referencia', $variant->referencia),
-            new DataBaseWhere('actualizastock', '1')
+            new DataBaseWhere('actualizastock', '1'),
+            new DataBaseWhere('pvptotal', 0, '>')
         ];
         $order = ['idlinea' => 'DESC'];
 
@@ -135,7 +136,10 @@ class CostPriceTools
     {
         $prices = [];
         $supplierProduct = new ProductoProveedor();
-        $where = [new DataBaseWhere('referencia', $variant->referencia)];
+        $where = [
+            new DataBaseWhere('referencia', $variant->referencia),
+            new DataBaseWhere('neto', 0, '>')
+        ];
         foreach ($supplierProduct->all($where, ['actualizado' => 'DESC'], 0, 0) as $prod) {
             $prices[] = $prod->neto;
         }
@@ -153,7 +157,10 @@ class CostPriceTools
     protected static function updateLastPrice(Variante $variant): void
     {
         $supplierProduct = new ProductoProveedor();
-        $where = [new DataBaseWhere('referencia', $variant->referencia)];
+        $where = [
+            new DataBaseWhere('referencia', $variant->referencia),
+            new DataBaseWhere('neto', 0, '>')
+        ];
         foreach ($supplierProduct->all($where, ['actualizado' => 'DESC'], 0, 1) as $prod) {
             $variant->coste = round($prod->neto, Producto::ROUND_DECIMALS);
             $variant->save();
@@ -169,7 +176,10 @@ class CostPriceTools
     protected static function updateHighPrice(Variante $variant): void
     {
         $supplierProduct = new ProductoProveedor();
-        $where = [new DataBaseWhere('referencia', $variant->referencia)];
+        $where = [
+            new DataBaseWhere('referencia', $variant->referencia),
+            new DataBaseWhere('neto', 0, '>')
+        ];
         foreach ($supplierProduct->all($where, ['precio' => 'DESC'], 0, 1) as $prod) {
             $variant->coste = round($prod->neto, Producto::ROUND_DECIMALS);
             $variant->save();


### PR DESCRIPTION
# Descripción
-Es un cambio simple para que el where excluya aquellos cuyo neto es igual a 0. La intención es no tener en cuenta aquellas lineas que son devoluciones y pueden aparecer como negativos, o muestras, regalos, promociones que tendrian coste 0. Estas no deberían alterar el precio, principalmente en el caso de updateLastPrice.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.


