### PR TITLE
Añadida funcionalidad para desvincular clientes y proveedores al desa…

### DIFF
--- a/Core/Model/FormaPago.php
+++ b/Core/Model/FormaPago.php
@@ -1,7 +1,8 @@
 <?php
+
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -23,7 +24,10 @@ use FacturaScripts\Core\DataSrc\FormasPago;
 use FacturaScripts\Core\Template\ModelClass;
 use FacturaScripts\Core\Template\ModelTrait;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
+use FacturaScripts\Dinamic\Model\Cliente;
 use FacturaScripts\Dinamic\Model\CuentaBanco as DinCuentaBanco;
+use FacturaScripts\Dinamic\Model\Proveedor;
 
 /**
  * Payment method of an invoice, delivery note, order or estimation.
@@ -175,6 +179,23 @@ class FormaPago extends ModelClass
         return parent::test();
     }
 
+    protected function deactivate(): void
+    {
+        $where = [Where::eq('codpago', $this->codpago)];
+
+        // desvincular de clientes
+        foreach (Cliente::all($where) as $cliente) {
+            $cliente->codpago = null;
+            $cliente->save();
+        }
+
+        // desvincular de proveedores
+        foreach (Proveedor::all($where) as $proveedor) {
+            $proveedor->codpago = null;
+            $proveedor->save();
+        }
+    }
+
     protected function saveInsert(): bool
     {
         if (empty($this->codpago)) {
@@ -182,6 +203,22 @@ class FormaPago extends ModelClass
         }
 
         return parent::saveInsert();
+    }
+
+    protected function saveUpdate(): bool
+    {
+        $result = parent::saveUpdate();
+        if ($result === false) {
+            return false;
+        }
+
+        // si antes la forma de apgo estaba activa y ahora no,
+        // hay que desvincularla de clientes y proveedores que la tengan asignada
+        if ($this->getOriginal('activa') && !$this->activa) {
+            $this->deactivate();
+        }
+
+        return true;
     }
 
     private function newLetterCode(): string

--- a/Test/Core/Model/ClienteTest.php
+++ b/Test/Core/Model/ClienteTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2022-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2022-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -21,6 +21,7 @@ namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Lib\Vies;
 use FacturaScripts\Core\Model\Cliente;
+use FacturaScripts\Core\Model\FormaPago;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use PHPUnit\Framework\TestCase;
@@ -238,6 +239,34 @@ final class ClienteTest extends TestCase
         $this->assertFalse($cliente->hasColumn('columna_inexistente'), 'cliente-should-not-have-columna_inexistente');
         $this->assertFalse($cliente->hasColumn('total'), 'cliente-should-not-have-total-column');
         $this->assertFalse($cliente->hasColumn(''), 'cliente-should-not-have-empty-column');
+    }
+
+    public function testCustomerPaymentMethodClear(): void
+    {
+        // creamos una forma de pago
+        $payment = new FormaPago();
+        $payment->codpago = 'TEST';
+        $payment->descripcion = 'Test Payment Method';
+        $this->assertTrue($payment->save(), 'payment-method-cant-save');
+
+        // creamos un cliente con esa forma de pago
+        $cliente = new Cliente();
+        $cliente->nombre = 'Test';
+        $cliente->cifnif = '12345678A';
+        $cliente->codpago = 'TEST';
+        $this->assertTrue($cliente->save(), 'cliente-cant-save');
+
+        // desactivamos la forma de pago
+        $payment->activa = false;
+        $this->assertTrue($payment->save(), 'payment-method-cant-deactivate');
+
+        // recargamos el cliente y comprobamos que se ha eliminado la forma de pago
+        $cliente->reload();
+        $this->assertNull($cliente->codpago, 'cliente-payment-method-not-cleared');
+
+        // eliminamos
+        $this->assertTrue($cliente->delete(), 'cliente-cant-delete');
+        $this->assertTrue($payment->delete(), 'payment-method-cant-delete');
     }
 
     protected function tearDown(): void

--- a/Test/Core/Model/ProveedorTest.php
+++ b/Test/Core/Model/ProveedorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2022-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2022-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Test\Core\Model;
 
 use FacturaScripts\Core\Lib\Vies;
+use FacturaScripts\Core\Model\FormaPago;
 use FacturaScripts\Core\Model\Proveedor;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
@@ -129,15 +130,15 @@ final class ProveedorTest extends TestCase
         $proveedor->nombre = 'Test';
         $proveedor->cifnif = '12345678A';
         $proveedor->web = 'javascript:alert(origin)';
-        $this->assertFalse($proveedor->save(), 'cliente-can-save-bad-web');
+        $this->assertFalse($proveedor->save(), 'proveedor-can-save-bad-web');
 
         // javascript con forma de url
         $proveedor->web = 'javascript://example.com//%0aalert(document.domain);//';
-        $this->assertFalse($proveedor->save(), 'cliente-can-save-bad-web-2');
+        $this->assertFalse($proveedor->save(), 'proveedor-can-save-bad-web-2');
 
         // javascript con mayúsculas
         $proveedor->web = 'jAvAsCriPt://sadas.com/%0aalert(15);//';
-        $this->assertFalse($proveedor->save(), 'cliente-can-save-bad-web-3');
+        $this->assertFalse($proveedor->save(), 'proveedor-can-save-bad-web-3');
     }
 
     public function testGoodWeb(): void
@@ -146,7 +147,7 @@ final class ProveedorTest extends TestCase
         $proveedor->nombre = 'Test';
         $proveedor->cifnif = '12345678A';
         $proveedor->web = 'https://www.example.com';
-        $this->assertTrue($proveedor->save(), 'cliente-can-save-good-web');
+        $this->assertTrue($proveedor->save(), 'proveedor-can-save-good-web');
 
         // eliminamos
         $this->assertTrue($proveedor->getDefaultAddress()->delete(), 'contacto-cant-delete');
@@ -196,6 +197,34 @@ final class ProveedorTest extends TestCase
         // eliminamos
         $this->assertTrue($address->delete());
         $this->assertTrue($proveedor->delete());
+    }
+
+    public function testSupplierPaymentMethodClear(): void
+    {
+        // creamos una forma de pago
+        $payment = new FormaPago();
+        $payment->codpago = 'TEST';
+        $payment->descripcion = 'Test Payment Method';
+        $this->assertTrue($payment->save(), 'payment-method-cant-save');
+
+        // creamos un proveedor con esa forma de pago
+        $supplier = new Proveedor();
+        $supplier->nombre = 'Test';
+        $supplier->cifnif = '12345678A';
+        $supplier->codpago = 'TEST';
+        $this->assertTrue($supplier->save(), 'proveedor-cant-save');
+
+        // desactivamos la forma de pago
+        $payment->activa = false;
+        $this->assertTrue($payment->save(), 'payment-method-cant-deactivate');
+
+        // recargamos el proveedor y comprobamos que se ha eliminado la forma de pago
+        $supplier->reload();
+        $this->assertNull($supplier->codpago, 'proveedor-payment-method-not-cleared');
+
+        // eliminamos
+        $this->assertTrue($supplier->delete(), 'proveedor-cant-delete');
+        $this->assertTrue($payment->delete(), 'payment-method-cant-delete');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
…ctivar una forma de pago. Implementadas pruebas para verificar el comportamiento.

Cuando un cliente o proveedor tiene una forma de pago vinculada y ahora esa forma de pago se desactiva para no usarla más, seguía quedando vinculada en el cliente y en el proveedor, eso era un problema, con este cambio se actualiza el cliente y proveedor para desvincular esa forma de pago.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.