### PR TITLE
Mandar subtotal manual

### DIFF
--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -237,7 +237,11 @@
     }
 
     function salesLineTotalWithTaxes(id) {
-        const total = parseFloat(prompt('{{ trans('total-with-taxes') }}').replace(',', '.')) || 0;
+        const totalInput = prompt('{{ trans('total-with-taxes') }}');
+        if (totalInput === null) {
+            return false;
+        }
+        const total = parseFloat(totalInput.replace(',', '.')) || 0;
         const dtopor = parseFloat(document.forms['salesForm']['dtopor_' + id].value) || 0;
         const dtopor2 = parseFloat(document.forms['salesForm']['dtopor2_' + id].value) || 0;
         const iva = parseFloat(document.forms['salesForm']['iva_' + id].value) || 0;
@@ -249,6 +253,7 @@
         } else if (cantidad <= 0) {
             alert('cantidad > 0');
         } else {
+            document.forms['salesForm']['linetotal_' + id].value = total;
             let pvpSinDto = (100 * total / cantidad) / (100 + iva + recargo - irpf);
             let pvp = 10000 * pvpSinDto / ((100 - dtopor) * (100 - dtopor2));
             document.forms['salesForm']['pvpunitario_' + id].value = Math.round(pvp * 100000) / 100000;
@@ -257,7 +262,11 @@
     }
 
     function salesLineTotalWithoutTaxes(id) {
-        const total = parseFloat(prompt('{{ trans('net') }}').replace(',', '.')) || 0;
+        const totalInput = prompt('{{ trans('net') }}');
+        if (totalInput === null) {
+            return false;
+        }
+        const total = parseFloat(totalInput.replace(',', '.')) || 0;
         const dtopor = parseFloat(document.forms['salesForm']['dtopor_' + id].value) || 0;
         const dtopor2 = parseFloat(document.forms['salesForm']['dtopor2_' + id].value) || 0;
         const cantidad = parseFloat(document.forms['salesForm']['cantidad_' + id].value) || 0;
@@ -266,6 +275,7 @@
         } else if (cantidad <= 0) {
             alert('cantidad > 0');
         } else {
+            document.forms['salesForm']['lineneto_' + id].value = total;
             let pvpSinDto = (100 * total / cantidad) / 100;
             let pvp = 10000 * pvpSinDto / ((100 - dtopor) * (100 - dtopor2));
             document.forms['salesForm']['pvpunitario_' + id].value = Math.round(pvp * 100000) / 100000;


### PR DESCRIPTION
https://facturascripts.com/roadmap/4523

Cuando un usuario introducía manualmente un subtotal (con o sin impuestos), el sistema calculaba el precio unitario a partir de ese valor y solo enviaba el precio unitario al servidor. El subtotal original que había escrito el usuario se perdía. Ahora el subtotal que introduce el usuario también se envía al servidor junto con el precio unitario. Los plugins ya pueden leer ese valor y usarlo para hacer sus propios cálculos. 
Modificado Core/View/Tab/SalesDocument.html.twig en las funciones de total manual por línea (salesLineTotalWithTaxes y salesLineTotalWithoutTaxes) para mantener el comportamiento existente y además enviar el total manual para plugins.

También Cuando el usuario pulsaba 'Cancelar' en el diálogo para introducir un subtotal manualmente, el sistema daba un error silencioso en JavaScript. Se ha corregido: ahora si el usuario cancela, el diálogo se cierra limpiamente sin hacer nada.

