### PR TITLE
Permite autocomplete con source desde un JoinModel

### DIFF
--- a/Core/Model/CodeModel.php
+++ b/Core/Model/CodeModel.php
@@ -327,7 +327,7 @@ class CodeModel
      */
     protected static function isValidTableName(string $tableName): bool
     {
-        return preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName) === 1;
+        return preg_match('/^(?:Join\\\\)?[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName) === 1;
     }
 
     protected static function db(): DataBase


### PR DESCRIPTION
# Descripción
- Permite indicar un source de un widget autocomplete con origen en "Join\ModelXXXX". Esto permite tener autocompletes que recogen datos de varias tablas.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.