### PR TITLE
Permitir banco por recibo y pago

### DIFF
--- a/Core/Controller/ApiPagarFacturaCliente.php
+++ b/Core/Controller/ApiPagarFacturaCliente.php
@@ -92,9 +92,16 @@ class ApiPagarFacturaCliente extends ApiController
     {
         // marcamos todos los recibos como pagados
         foreach ($factura->getReceipts() as $receipt) {
+            $codpago = $this->request->request->get('codpago', $receipt->codpago);
+            $paymentMethodChanged = $codpago !== $receipt->codpago;
             $receipt->pagado = true;
             $receipt->fechapago = $this->request->request->get('fechapago', $receipt->fechapago);
-            $receipt->codpago = $this->request->request->get('codpago', $receipt->codpago);
+            $receipt->codpago = $codpago;
+            if ($this->request->request->has('codcuentabanco')) {
+                $receipt->codcuentabanco = $this->request->request->get('codcuentabanco') ?: null;
+            } elseif ($paymentMethodChanged || empty($receipt->codcuentabanco)) {
+                $receipt->codcuentabanco = $receipt->getPaymentMethod()->codcuentabanco;
+            }
             if (false === $receipt->save()) {
                 $this->response
                     ->setHttpCode(Response::HTTP_INTERNAL_SERVER_ERROR)

--- a/Core/Controller/ApiPagarFacturaProveedor.php
+++ b/Core/Controller/ApiPagarFacturaProveedor.php
@@ -92,9 +92,16 @@ class ApiPagarFacturaProveedor extends ApiController
     {
         // marcamos todos los recibos como pagados
         foreach ($factura->getReceipts() as $receipt) {
+            $codpago = $this->request->request->get('codpago', $receipt->codpago);
+            $paymentMethodChanged = $codpago !== $receipt->codpago;
             $receipt->pagado = true;
             $receipt->fechapago = $this->request->request->get('fechapago', $receipt->fechapago);
-            $receipt->codpago = $this->request->request->get('codpago', $receipt->codpago);
+            $receipt->codpago = $codpago;
+            if ($this->request->request->has('codcuentabanco')) {
+                $receipt->codcuentabanco = $this->request->request->get('codcuentabanco') ?: null;
+            } elseif ($paymentMethodChanged || empty($receipt->codcuentabanco)) {
+                $receipt->codcuentabanco = $receipt->getPaymentMethod()->codcuentabanco;
+            }
             if (false === $receipt->save()) {
                 $this->response
                     ->setHttpCode(Response::HTTP_INTERNAL_SERVER_ERROR)

--- a/Core/Lib/Accounting/PaymentToAccounting.php
+++ b/Core/Lib/Accounting/PaymentToAccounting.php
@@ -20,12 +20,15 @@
 namespace FacturaScripts\Core\Lib\Accounting;
 
 use FacturaScripts\Core\Model\Asiento;
+use FacturaScripts\Core\Model\CuentaBanco;
 use FacturaScripts\Core\Model\PagoCliente;
 use FacturaScripts\Core\Model\PagoProveedor;
 use FacturaScripts\Core\Model\ReciboCliente;
 use FacturaScripts\Core\Model\ReciboProveedor;
+use FacturaScripts\Core\Model\Subcuenta;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Model\Asiento as DinAsiento;
+use FacturaScripts\Dinamic\Model\CuentaBanco as DinCuentaBanco;
 use FacturaScripts\Dinamic\Model\Ejercicio;
 
 /**
@@ -150,7 +153,7 @@ class PaymentToAccounting
 
     protected function customerPaymentBankLine(Asiento &$entry): bool
     {
-        $account = $this->payment->getPaymentMethod()->getSubcuenta($this->exercise->codejercicio, true);
+        $account = $this->getPaymentBankSubcuenta();
         if (false === $account->exists()) {
             Tools::log()->warning('payment-method-account-not-found', [
                 '%paymentMethod%' => $this->payment->getPaymentMethod()->descripcion,
@@ -173,7 +176,7 @@ class PaymentToAccounting
             return true;
         }
 
-        $account = $this->payment->getPaymentMethod()->getSubcuentaGastos($this->exercise->codejercicio, true);
+        $account = $this->getPaymentBankSubcuenta(true);
         if (false === $account->exists()) {
             Tools::log()->warning('payment-expense-account-not-found', [
                 '%paymentMethod%' => $this->payment->getPaymentMethod()->descripcion,
@@ -259,7 +262,7 @@ class PaymentToAccounting
 
     protected function supplierPaymentBankLine(Asiento &$entry): bool
     {
-        $account = $this->payment->getPaymentMethod()->getSubcuenta($this->exercise->codejercicio, true);
+        $account = $this->getPaymentBankSubcuenta();
         if (false === $account->exists()) {
             Tools::log()->warning('payment-method-account-not-found', [
                 '%paymentMethod%' => $this->payment->getPaymentMethod()->descripcion,
@@ -289,6 +292,27 @@ class PaymentToAccounting
         $newLine->debe = max($this->payment->importe, 0);
         $newLine->haber = $this->payment->importe < 0 ? abs($this->payment->importe) : 0;
         return $newLine->save();
+    }
+
+    protected function getPaymentBankAccount(): CuentaBanco
+    {
+        foreach ([$this->payment->codcuentabanco, $this->receipt->codcuentabanco] as $code) {
+            $bank = new DinCuentaBanco();
+            if ($code && $bank->load($code)) {
+                return $bank;
+            }
+        }
+
+        return $this->payment->getPaymentMethod()->getBankAccount();
+    }
+
+    protected function getPaymentBankSubcuenta(bool $expense = false): Subcuenta
+    {
+        $bank = $this->getPaymentBankAccount();
+
+        return $expense ?
+            $bank->getSubcuentaGastos($this->exercise->codejercicio, true) :
+            $bank->getSubcuenta($this->exercise->codejercicio, true);
     }
 
     protected function setCommonData(Asiento &$entry, string $concept, $invoice): void

--- a/Core/Lib/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Lib/AjaxForms/CommonSalesPurchases.php
@@ -30,6 +30,8 @@ use FacturaScripts\Core\Model\Base\PurchaseDocument;
 use FacturaScripts\Core\Model\Base\TransformerDocument;
 use FacturaScripts\Core\Session;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
+use FacturaScripts\Dinamic\Model\CuentaBanco;
 use FacturaScripts\Dinamic\Model\EstadoDocumento;
 
 /**
@@ -369,6 +371,34 @@ trait CommonSalesPurchases
         return $data;
     }
 
+    protected static function getBankAccounts(BusinessDocument $model, ?string $selectedBankAccount = null): array
+    {
+        $data = [];
+        $where = [Where::eq('idempresa', $model->idempresa)];
+        foreach (CuentaBanco::all($where, ['codcuenta' => 'ASC'], 0, 0) as $bankAccount) {
+            if ($bankAccount->codcuenta != $selectedBankAccount && !$bankAccount->activa) {
+                continue;
+            }
+
+            $data[] = $bankAccount;
+        }
+
+        return $data;
+    }
+
+    protected static function getPaymentDefaultBankAccount(BusinessDocument $model): ?string
+    {
+        if (method_exists($model, 'getReceipts')) {
+            foreach ($model->getReceipts() as $receipt) {
+                if (false == $receipt->pagado && !empty($receipt->codcuentabanco)) {
+                    return $receipt->codcuentabanco;
+                }
+            }
+        }
+
+        return FormasPago::get($model->codpago)->codcuentabanco;
+    }
+
     protected static function hora(BusinessDocument $model): string
     {
         $attributes = $model->editable ? 'name="hora" required' : 'disabled';
@@ -592,15 +622,35 @@ trait CommonSalesPurchases
             . '<div class="row g-2">'
             . '<div class="col-12 mb-2">'
             . '<a href="' . FormasPago::get($model->codpago)->url() . '">' . Tools::trans('payment-method') . '</a>'
-            . '<select id="paid-payment-modal" class="form-select" required>';
+            . '<select id="paid-payment-modal" class="form-select" required onchange="let bank=document.getElementById(\'paid-bank-account-modal\'); if (bank) { bank.value = this.options[this.selectedIndex].dataset.bankAccount || \'\'; }">';
 
         foreach (static::getPaymentMethods($model) as $row) {
-            $html .= '<option value="' . $row->codpago . '"' . ($row->codpago === $model->codpago ? ' selected' : '') . '>' . $row->descripcion . '</option>';
+            $html .= '<option value="' . $row->codpago . '" data-bank-account="' . $row->codcuentabanco . '"'
+                . ($row->codpago === $model->codpago ? ' selected' : '') . '>' . $row->descripcion . '</option>';
         }
 
         $html .= '</select>'
-            . '</div>'
-            . '<div class="col-12 mb-2">'
+            . '</div>';
+
+        $selectedBankAccount = static::getPaymentDefaultBankAccount($model);
+        $bankAccounts = static::getBankAccounts($model, $selectedBankAccount);
+        if ($bankAccounts) {
+            $html .= '<div class="col-12 mb-2">'
+                . '<a href="ListFormaPago?activetab=ListCuentaBanco">' . Tools::trans('bank-account') . '</a>'
+                . '<select id="paid-bank-account-modal" class="form-select">'
+                . '<option value="">' . Tools::trans('none') . '</option>';
+
+            foreach ($bankAccounts as $bankAccount) {
+                $html .= '<option value="' . $bankAccount->codcuenta . '"'
+                    . ($bankAccount->codcuenta === $selectedBankAccount ? ' selected' : '')
+                    . '>' . $bankAccount->descripcion . '</option>';
+            }
+
+            $html .= '</select>'
+                . '</div>';
+        }
+
+        $html .= '<div class="col-12 mb-2">'
             . Tools::trans('date')
             . '<input type="date" id="paid-date-modal" value="' . date('Y-m-d') . '" class="form-control" required/>'
             . '</div>'
@@ -613,7 +663,8 @@ trait CommonSalesPurchases
             . '<button type="button" class="btn btn-primary btn-spin-action" onclick="(function(){
     let pago = document.getElementById(\'paid-payment-modal\') ? document.getElementById(\'paid-payment-modal\').value : \'\';
     let fecha = document.getElementById(\'paid-date-modal\') ? document.getElementById(\'paid-date-modal\').value : \'\';
-    prepareForm(\'save-paid\', {\'paid-payment-modal\': pago, \'paid-date-modal\': fecha, \'paid-status\': 1});
+    let banco = document.getElementById(\'paid-bank-account-modal\') ? document.getElementById(\'paid-bank-account-modal\').value : \'\';
+    prepareForm(\'save-paid\', {\'paid-payment-modal\': pago, \'paid-bank-account-modal\': banco, \'paid-date-modal\': fecha, \'paid-status\': 1});
 })()">'
             . Tools::trans('paid')
             . '</button>'

--- a/Core/Lib/AjaxForms/PurchasesController.php
+++ b/Core/Lib/AjaxForms/PurchasesController.php
@@ -463,8 +463,15 @@ abstract class PurchasesController extends PanelController
             $receipt->nick = $this->user->nick;
             // si no está pagado, actualizamos fechapago y codpago
             if (false == $receipt->pagado) {
+                $codpago = $formData['paid-payment-modal'] ?? $model->codpago;
+                $paymentMethodChanged = $codpago !== $receipt->codpago;
                 $receipt->fechapago = $formData['paid-date-modal'] ?? Tools::date();
-                $receipt->codpago = $formData['paid-payment-modal'] ?? $model->codpago;
+                $receipt->codpago = $codpago;
+                if (array_key_exists('paid-bank-account-modal', $formData)) {
+                    $receipt->codcuentabanco = $formData['paid-bank-account-modal'] ?: null;
+                } elseif ($paymentMethodChanged || empty($receipt->codcuentabanco)) {
+                    $receipt->codcuentabanco = $receipt->getPaymentMethod()->codcuentabanco;
+                }
             }
             $receipt->pagado = (bool)$formData['paid-status'];
             if (false === $receipt->save()) {

--- a/Core/Lib/AjaxForms/SalesController.php
+++ b/Core/Lib/AjaxForms/SalesController.php
@@ -477,8 +477,15 @@ abstract class SalesController extends PanelController
             $receipt->nick = $this->user->nick;
             // si no está pagado, actualizamos fechapago y codpago
             if (false == $receipt->pagado) {
+                $codpago = $formData['paid-payment-modal'] ?? $model->codpago;
+                $paymentMethodChanged = $codpago !== $receipt->codpago;
                 $receipt->fechapago = $formData['paid-date-modal'] ?? Tools::date();
-                $receipt->codpago = $formData['paid-payment-modal'] ?? $model->codpago;
+                $receipt->codpago = $codpago;
+                if (array_key_exists('paid-bank-account-modal', $formData)) {
+                    $receipt->codcuentabanco = $formData['paid-bank-account-modal'] ?: null;
+                } elseif ($paymentMethodChanged || empty($receipt->codcuentabanco)) {
+                    $receipt->codcuentabanco = $receipt->getPaymentMethod()->codcuentabanco;
+                }
             }
             $receipt->pagado = (bool)$formData['paid-status'];
             if (false === $receipt->save()) {

--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -121,7 +121,8 @@ abstract class PDFDocument extends PDFCore
 
         // cuenta bancaria de la empresa
         $cuentaBco = new CuentaBanco();
-        if ($payMethod->codcuentabanco && $cuentaBco->load($payMethod->codcuentabanco) && $cuentaBco->iban) {
+        $codCuentaBanco = empty($receipt->codcuentabanco) ? $payMethod->codcuentabanco : $receipt->codcuentabanco;
+        if ($codCuentaBanco && $cuentaBco->load($codCuentaBanco) && $cuentaBco->iban) {
             return $payMethod->descripcion . ' : ' . $cuentaBco->getIban(true);
         }
 

--- a/Core/Model/Base/BankAccountRelationTrait.php
+++ b/Core/Model/Base/BankAccountRelationTrait.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Model\Base;
+
+use FacturaScripts\Core\Model\CuentaBanco;
+use FacturaScripts\Dinamic\Model\CuentaBanco as DinCuentaBanco;
+
+/**
+ * @author Carlos Garcia Gomez <carlos@facturascripts.com>
+ */
+trait BankAccountRelationTrait
+{
+    /** @var string|null */
+    public $codcuentabanco;
+
+    public function getBankAccount(): CuentaBanco
+    {
+        $bank = new DinCuentaBanco();
+        $bank->load($this->codcuentabanco);
+        return $bank;
+    }
+}

--- a/Core/Model/PagoCliente.php
+++ b/Core/Model/PagoCliente.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model;
 
 use FacturaScripts\Core\Model\Base\AccEntryRelationTrait;
+use FacturaScripts\Core\Model\Base\BankAccountRelationTrait;
 use FacturaScripts\Core\Model\Base\PaymentRelationTrait;
 use FacturaScripts\Core\Session;
 use FacturaScripts\Core\Template\ModelClass;
@@ -37,6 +38,7 @@ class PagoCliente extends ModelClass
 {
     use ModelTrait;
     use AccEntryRelationTrait;
+    use BankAccountRelationTrait;
     use PaymentRelationTrait;
 
     /** @var string */
@@ -125,6 +127,10 @@ class PagoCliente extends ModelClass
 
     public function test(): bool
     {
+        $this->codcuentabanco = Tools::noHtml($this->codcuentabanco);
+        if ($this->codcuentabanco === '') {
+            $this->codcuentabanco = null;
+        }
         $this->customid = Tools::noHtml($this->customid);
         $this->customstatus = Tools::noHtml($this->customstatus);
 

--- a/Core/Model/PagoProveedor.php
+++ b/Core/Model/PagoProveedor.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model;
 
 use FacturaScripts\Core\Model\Base\AccEntryRelationTrait;
+use FacturaScripts\Core\Model\Base\BankAccountRelationTrait;
 use FacturaScripts\Core\Model\Base\PaymentRelationTrait;
 use FacturaScripts\Core\Session;
 use FacturaScripts\Core\Template\ModelClass;
@@ -37,6 +38,7 @@ class PagoProveedor extends ModelClass
 {
     use ModelTrait;
     use AccEntryRelationTrait;
+    use BankAccountRelationTrait;
     use PaymentRelationTrait;
 
     /** @var bool */
@@ -111,6 +113,16 @@ class PagoProveedor extends ModelClass
     public static function tableName(): string
     {
         return 'pagosprov';
+    }
+
+    public function test(): bool
+    {
+        $this->codcuentabanco = Tools::noHtml($this->codcuentabanco);
+        if ($this->codcuentabanco === '') {
+            $this->codcuentabanco = null;
+        }
+
+        return parent::test();
     }
 
     public function url(string $type = 'auto', string $list = 'List'): string

--- a/Core/Model/ReciboCliente.php
+++ b/Core/Model/ReciboCliente.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Model\Base\BankAccountRelationTrait;
 use FacturaScripts\Core\Model\Base\CompanyRelationTrait;
 use FacturaScripts\Core\Model\Base\PaymentRelationTrait;
 use FacturaScripts\Core\Session;
@@ -41,6 +42,7 @@ use FacturaScripts\Dinamic\Model\PagoCliente as DinPagoCliente;
 class ReciboCliente extends ModelClass
 {
     use ModelTrait;
+    use BankAccountRelationTrait;
     use CompanyRelationTrait;
     use PaymentRelationTrait;
 
@@ -215,6 +217,7 @@ class ReciboCliente extends ModelClass
     {
         $formaPago = new FormaPago();
         if ($formaPago->load($codpago)) {
+            $this->codcuentabanco = $formaPago->codcuentabanco;
             $this->codpago = $codpago;
             $this->pagado = $formaPago->pagado;
             $this->setExpiration($formaPago->getExpiration($this->fecha));
@@ -231,6 +234,10 @@ class ReciboCliente extends ModelClass
 
     public function test(): bool
     {
+        $this->codcuentabanco = Tools::noHtml($this->codcuentabanco);
+        if ($this->codcuentabanco === '') {
+            $this->codcuentabanco = null;
+        }
         $this->observaciones = Tools::noHtml($this->observaciones);
 
         // asignamos el código de la factura
@@ -279,6 +286,7 @@ class ReciboCliente extends ModelClass
         }
 
         $pago = new DinPagoCliente();
+        $pago->codcuentabanco = $this->codcuentabanco;
         $pago->codpago = $this->codpago;
         $pago->fecha = $this->fechapago ?? $pago->fecha;
         $pago->gastos = $this->gastos;
@@ -296,6 +304,10 @@ class ReciboCliente extends ModelClass
         }
 
         switch ($field) {
+            case 'codpago':
+                $this->updateBankAccountFromPaymentMethod();
+                return true;
+
             case 'importe':
                 return !$this->getOriginal('pagado');
 
@@ -329,6 +341,21 @@ class ReciboCliente extends ModelClass
         $this->updateCustomerRisk();
 
         parent::onUpdate();
+    }
+
+    protected function updateBankAccountFromPaymentMethod(): void
+    {
+        if ($this->isDirty('codcuentabanco')) {
+            return;
+        }
+
+        $oldPaymentMethod = new FormaPago();
+        $oldBankAccount = $oldPaymentMethod->load($this->getOriginal('codpago')) ?
+            $oldPaymentMethod->codcuentabanco :
+            null;
+        if (empty($this->codcuentabanco) || $this->codcuentabanco === $oldBankAccount) {
+            $this->codcuentabanco = $this->getPaymentMethod()->codcuentabanco;
+        }
     }
 
     protected function saveInsert(): bool

--- a/Core/Model/ReciboProveedor.php
+++ b/Core/Model/ReciboProveedor.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model;
 
+use FacturaScripts\Core\Model\Base\BankAccountRelationTrait;
 use FacturaScripts\Core\Model\Base\CompanyRelationTrait;
 use FacturaScripts\Core\Model\Base\PaymentRelationTrait;
 use FacturaScripts\Core\Session;
@@ -40,6 +41,7 @@ use FacturaScripts\Dinamic\Model\Proveedor as DinProveedor;
 class ReciboProveedor extends ModelClass
 {
     use ModelTrait;
+    use BankAccountRelationTrait;
     use CompanyRelationTrait;
     use PaymentRelationTrait;
 
@@ -184,6 +186,7 @@ class ReciboProveedor extends ModelClass
     {
         $formaPago = new FormaPago();
         if ($formaPago->load($codpago)) {
+            $this->codcuentabanco = $formaPago->codcuentabanco;
             $this->codpago = $codpago;
             $this->pagado = $formaPago->pagado;
             $this->setExpiration($formaPago->getExpiration($this->fecha));
@@ -200,6 +203,10 @@ class ReciboProveedor extends ModelClass
 
     public function test(): bool
     {
+        $this->codcuentabanco = Tools::noHtml($this->codcuentabanco);
+        if ($this->codcuentabanco === '') {
+            $this->codcuentabanco = null;
+        }
         $this->observaciones = Tools::noHtml($this->observaciones);
 
         // asignamos el código de la factura
@@ -246,6 +253,7 @@ class ReciboProveedor extends ModelClass
         }
 
         $pago = new DinPagoProveedor();
+        $pago->codcuentabanco = $this->codcuentabanco;
         $pago->codpago = $this->codpago;
         $pago->fecha = $this->fechapago ?? $pago->fecha;
         $pago->idrecibo = $this->idrecibo;
@@ -262,6 +270,10 @@ class ReciboProveedor extends ModelClass
         }
 
         switch ($field) {
+            case 'codpago':
+                $this->updateBankAccountFromPaymentMethod();
+                return true;
+
             case 'importe':
                 return !$this->getOriginal('pagado');
 
@@ -286,6 +298,21 @@ class ReciboProveedor extends ModelClass
         $this->updateInvoice();
 
         parent::onUpdate();
+    }
+
+    protected function updateBankAccountFromPaymentMethod(): void
+    {
+        if ($this->isDirty('codcuentabanco')) {
+            return;
+        }
+
+        $oldPaymentMethod = new FormaPago();
+        $oldBankAccount = $oldPaymentMethod->load($this->getOriginal('codpago')) ?
+            $oldPaymentMethod->codcuentabanco :
+            null;
+        if (empty($this->codcuentabanco) || $this->codcuentabanco === $oldBankAccount) {
+            $this->codcuentabanco = $this->getPaymentMethod()->codcuentabanco;
+        }
     }
 
     protected function saveInsert(): bool

--- a/Core/Table/pagoscli.xml
+++ b/Core/Table/pagoscli.xml
@@ -10,6 +10,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codcuentabanco</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>customid</name>
         <type>character varying(30)</type>
     </column>
@@ -65,5 +69,9 @@
     <constraint>
         <name>ca_pagoscli_recibo</name>
         <type>FOREIGN KEY (idrecibo) REFERENCES recibospagoscli (idrecibo) ON DELETE CASCADE ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>ca_pagoscli_cuentasbanco</name>
+        <type>FOREIGN KEY (codcuentabanco) REFERENCES cuentasbanco (codcuenta) ON DELETE SET NULL ON UPDATE CASCADE</type>
     </constraint>
 </table>

--- a/Core/Table/pagosprov.xml
+++ b/Core/Table/pagosprov.xml
@@ -10,6 +10,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codcuentabanco</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>fecha</name>
         <type>date</type>
         <null>NO</null>
@@ -52,5 +56,9 @@
     <constraint>
         <name>ca_pagosprov_recibo</name>
         <type>FOREIGN KEY (idrecibo) REFERENCES recibospagosprov (idrecibo) ON DELETE CASCADE ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>ca_pagosprov_cuentasbanco</name>
+        <type>FOREIGN KEY (codcuentabanco) REFERENCES cuentasbanco (codcuenta) ON DELETE SET NULL ON UPDATE CASCADE</type>
     </constraint>
 </table>

--- a/Core/Table/recibospagoscli.xml
+++ b/Core/Table/recibospagoscli.xml
@@ -23,6 +23,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codcuentabanco</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>fecha</name>
         <type>date</type>
         <null>NO</null>
@@ -101,5 +105,9 @@
     <constraint>
         <name>ca_recibospagoscli_facturascli</name>
         <type>FOREIGN KEY (idfactura) REFERENCES facturascli (idfactura) ON DELETE CASCADE ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>ca_recibospagoscli_cuentasbanco</name>
+        <type>FOREIGN KEY (codcuentabanco) REFERENCES cuentasbanco (codcuenta) ON DELETE SET NULL ON UPDATE CASCADE</type>
     </constraint>
 </table>

--- a/Core/Table/recibospagosprov.xml
+++ b/Core/Table/recibospagosprov.xml
@@ -18,6 +18,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codcuentabanco</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>codproveedor</name>
         <type>character varying(10)</type>
         <null>NO</null>
@@ -96,5 +100,9 @@
     <constraint>
         <name>ca_recibospagosprov_facturasprov</name>
         <type>FOREIGN KEY (idfactura) REFERENCES facturasprov (idfactura) ON DELETE CASCADE ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>ca_recibospagosprov_cuentasbanco</name>
+        <type>FOREIGN KEY (codcuentabanco) REFERENCES cuentasbanco (codcuenta) ON DELETE SET NULL ON UPDATE CASCADE</type>
     </constraint>
 </table>

--- a/Core/XMLView/EditReciboCliente.xml
+++ b/Core/XMLView/EditReciboCliente.xml
@@ -72,13 +72,18 @@
                     <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion" fieldfilter="idempresa"/>
                 </widget>
             </column>
-            <column name="paid" order="140">
+            <column name="bank-account" order="140">
+                <widget type="select" fieldname="codcuentabanco" parent="idempresa" onclick="EditCuentaBanco">
+                    <values source="cuentasbanco" fieldcode="codcuenta" fieldtitle="descripcion" fieldfilter="idempresa"/>
+                </widget>
+            </column>
+            <column name="paid" order="150">
                 <widget type="checkbox" fieldname="pagado"/>
             </column>
-            <column name="payment-date" order="150">
+            <column name="payment-date" order="160">
                 <widget type="date" fieldname="fechapago" readonly="dinamic"/>
             </column>
-            <column name="observations" numcolumns="12" order="160">
+            <column name="observations" numcolumns="12" order="170">
                 <widget type="textarea" fieldname="observaciones"/>
             </column>
         </group>

--- a/Core/XMLView/EditReciboProveedor.xml
+++ b/Core/XMLView/EditReciboProveedor.xml
@@ -69,13 +69,18 @@
                     <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion" fieldfilter="idempresa"/>
                 </widget>
             </column>
-            <column name="paid" order="130">
+            <column name="bank-account" order="130">
+                <widget type="select" fieldname="codcuentabanco" parent="idempresa" onclick="EditCuentaBanco">
+                    <values source="cuentasbanco" fieldcode="codcuenta" fieldtitle="descripcion" fieldfilter="idempresa"/>
+                </widget>
+            </column>
+            <column name="paid" order="140">
                 <widget type="checkbox" fieldname="pagado"/>
             </column>
-            <column name="payment-date" order="140">
+            <column name="payment-date" order="150">
                 <widget type="date" fieldname="fechapago" readonly="dinamic"/>
             </column>
-            <column name="observations" numcolumns="12" order="150">
+            <column name="observations" numcolumns="12" order="160">
                 <widget type="textarea" fieldname="observaciones"/>
             </column>
         </group>

--- a/Core/XMLView/ListPagoCliente.xml
+++ b/Core/XMLView/ListPagoCliente.xml
@@ -48,13 +48,18 @@
                 <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion" />
             </widget>
         </column>
-        <column name="code" order="180">
+        <column name="bank-account" order="180">
+            <widget type="select" fieldname="codcuentabanco" onclick="EditCuentaBanco">
+                <values source="cuentasbanco" fieldcode="codcuenta" fieldtitle="descripcion" />
+            </widget>
+        </column>
+        <column name="code" order="190">
             <widget type="text" fieldname="customid" />
         </column>
-        <column name="status" order="190">
+        <column name="status" order="200">
             <widget type="text" fieldname="customstatus" />
         </column>
-        <column name="user" display="right" order="200">
+        <column name="user" display="right" order="210">
             <widget type="select" fieldname="nick">
                 <values source="users" fieldcode="nick" fieldtitle="nick" />
             </widget>

--- a/Core/XMLView/ListPagoProveedor.xml
+++ b/Core/XMLView/ListPagoProveedor.xml
@@ -45,7 +45,12 @@
                 <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion" />
             </widget>
         </column>
-        <column name="user" display="right" order="170">
+        <column name="bank-account" order="170">
+            <widget type="select" fieldname="codcuentabanco" onclick="EditCuentaBanco">
+                <values source="cuentasbanco" fieldcode="codcuenta" fieldtitle="descripcion" />
+            </widget>
+        </column>
+        <column name="user" display="right" order="180">
             <widget type="select" fieldname="nick">
                 <values source="users" fieldcode="nick" fieldtitle="nick" />
             </widget>

--- a/Core/XMLView/ListReciboCliente.xml
+++ b/Core/XMLView/ListReciboCliente.xml
@@ -60,7 +60,12 @@
                 <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
             </widget>
         </column>
-        <column name="payment-date" order="190">
+        <column name="bank-account" display="right" order="190">
+            <widget type="select" fieldname="codcuentabanco" onclick="EditCuentaBanco">
+                <values source="cuentasbanco" fieldcode="codcuenta" fieldtitle="descripcion"/>
+            </widget>
+        </column>
+        <column name="payment-date" order="195">
             <widget type="date" fieldname="fechapago"/>
         </column>
         <column name="expiration" display="right" order="200">

--- a/Core/XMLView/ListReciboProveedor.xml
+++ b/Core/XMLView/ListReciboProveedor.xml
@@ -55,7 +55,12 @@
                 <values source="formaspago" fieldcode="codpago" fieldtitle="descripcion"/>
             </widget>
         </column>
-        <column name="payment-date" order="180">
+        <column name="bank-account" display="right" order="180">
+            <widget type="select" fieldname="codcuentabanco" onclick="EditCuentaBanco">
+                <values source="cuentasbanco" fieldcode="codcuenta" fieldtitle="descripcion"/>
+            </widget>
+        </column>
+        <column name="payment-date" order="185">
             <widget type="date" fieldname="fechapago"/>
         </column>
         <column name="expiration" display="right" order="190">

--- a/Test/Core/Lib/PDF/PDFDocumentTest.php
+++ b/Test/Core/Lib/PDF/PDFDocumentTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Lib\PDF;
+
+use FacturaScripts\Core\Lib\PDF\PDFDocument;
+use FacturaScripts\Core\Model\CuentaBanco;
+use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Model\FormaPago;
+use FacturaScripts\Core\Model\ReciboCliente;
+use FacturaScripts\Core\Response;
+use PHPUnit\Framework\TestCase;
+
+final class PDFDocumentTest extends TestCase
+{
+    public function testInvoiceBankDataUsesPaymentMethodBankAccount(): void
+    {
+        $bank = $this->getTestBankAccount('PDF invoice bank', 'ES9121000418450200051332');
+        $payMethod = $this->getTestPaymentMethod('PDF invoice payment', $bank);
+
+        $invoice = new FacturaCliente();
+        $invoice->codcliente = '1';
+        $invoice->codpago = $payMethod->codpago;
+
+        $pdf = new TestPDFDocument();
+        $this->assertStringContainsString($bank->getIban(true), $pdf->bankData($invoice));
+
+        $this->assertTrue($payMethod->delete(), 'payment-method-cant-delete');
+        $this->assertTrue($bank->delete(), 'bank-cant-delete');
+    }
+
+    public function testReceiptBankDataPrefersReceiptBankAccount(): void
+    {
+        $defaultBank = $this->getTestBankAccount('PDF default bank', 'ES7921000813610123456789');
+        $receiptBank = $this->getTestBankAccount('PDF receipt bank', 'PT50002700000001234567833');
+        $payMethod = $this->getTestPaymentMethod('PDF receipt payment', $defaultBank);
+
+        $receipt = new ReciboCliente();
+        $receipt->codcliente = '1';
+        $receipt->codcuentabanco = $receiptBank->codcuenta;
+        $receipt->codpago = $payMethod->codpago;
+
+        $pdf = new TestPDFDocument();
+        $bankData = $pdf->bankData($receipt);
+        $this->assertStringContainsString($receiptBank->getIban(true), $bankData);
+        $this->assertStringNotContainsString($defaultBank->getIban(true), $bankData);
+
+        $this->assertTrue($payMethod->delete(), 'payment-method-cant-delete');
+        $this->assertTrue($receiptBank->delete(), 'receipt-bank-cant-delete');
+        $this->assertTrue($defaultBank->delete(), 'default-bank-cant-delete');
+    }
+
+    private function getTestBankAccount(string $description, string $iban): CuentaBanco
+    {
+        $bank = new CuentaBanco();
+        $bank->codcuenta = (string)mt_rand(100000, 999999);
+        $bank->descripcion = $description;
+        $bank->iban = $iban;
+        $this->assertTrue($bank->save(), 'bank-cant-save');
+
+        return $bank;
+    }
+
+    private function getTestPaymentMethod(string $description, CuentaBanco $bank): FormaPago
+    {
+        $payMethod = new FormaPago();
+        $payMethod->codcuentabanco = $bank->codcuenta;
+        $payMethod->descripcion = $description;
+        $payMethod->domiciliado = false;
+        $payMethod->imprimir = true;
+        $payMethod->pagado = false;
+        $payMethod->plazovencimiento = 0;
+        $payMethod->tipovencimiento = 'days';
+        $this->assertTrue($payMethod->save(), 'payment-method-cant-save');
+
+        return $payMethod;
+    }
+}
+
+final class TestPDFDocument extends PDFDocument
+{
+    public function addBusinessDocPage($model): bool
+    {
+        return true;
+    }
+
+    public function addListModelPage($model, $where, $order, $offset, $columns, $title = ''): bool
+    {
+        return true;
+    }
+
+    public function addModelPage($model, $columns, $title = ''): bool
+    {
+        return true;
+    }
+
+    public function addTablePage($headers, $rows, $options = [], $title = ''): bool
+    {
+        return true;
+    }
+
+    public function bankData($receipt): string
+    {
+        return $this->getBankData($receipt);
+    }
+
+    public function getDoc()
+    {
+        return '';
+    }
+
+    public function newDoc(string $title, int $idformat, string $langcode)
+    {
+    }
+
+    public function show(Response &$response)
+    {
+    }
+}

--- a/Test/Core/Model/ReciboClienteTest.php
+++ b/Test/Core/Model/ReciboClienteTest.php
@@ -19,12 +19,15 @@
 
 namespace FacturaScripts\Test\Core\Model;
 
+use FacturaScripts\Core\Lib\Accounting\PaymentToAccounting;
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Lib\ReceiptGenerator;
 use FacturaScripts\Core\Model\Base\ModelCore;
+use FacturaScripts\Core\Model\CuentaBanco;
 use FacturaScripts\Core\Model\FacturaCliente;
 use FacturaScripts\Core\Model\FormaPago;
 use FacturaScripts\Core\Model\ReciboCliente;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -472,8 +475,165 @@ final class ReciboClienteTest extends TestCase
         $this->assertTrue($subject->delete(), 'can-not-delete-subject');
     }
 
+    public function testChangePaymentMethodUpdatesBankAccount(): void
+    {
+        $firstBank = $this->getTestBankAccount('First customer bank', '5720001101');
+        $secondBank = $this->getTestBankAccount('Second customer bank', '5720001102');
+        $customBank = $this->getTestBankAccount('Custom customer bank', '5720001103');
+
+        $firstPayMethod = $this->getTestPaymentMethod('first-test', $firstBank);
+        $secondPayMethod = $this->getTestPaymentMethod('second-test', $secondBank);
+
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save(), 'cant-create-customer');
+
+        $invoice = new FacturaCliente();
+        $invoice->setSubject($customer);
+        $invoice->codpago = $firstPayMethod->codpago;
+        $this->assertTrue($invoice->save(), 'can-not-create-invoice');
+
+        $line = $invoice->getNewLine();
+        $line->cantidad = 1;
+        $line->descripcion = 'test';
+        $line->pvpunitario = 100;
+        $this->assertTrue($line->save(), 'cant-add-invoice-line');
+        $lines = $invoice->getLines();
+        $this->assertTrue(Calculator::calculate($invoice, $lines, true), 'cant-update-invoice');
+
+        $receipt = $invoice->getReceipts()[0];
+        $this->assertEquals($firstBank->codcuenta, $receipt->codcuentabanco, 'bad-first-receipt-bank');
+
+        $receipt->codpago = $secondPayMethod->codpago;
+        $this->assertTrue($receipt->save(), 'can-not-change-receipt-payment-method');
+        $this->assertEquals($secondBank->codcuenta, $receipt->codcuentabanco, 'bad-second-receipt-bank');
+
+        $receipt->codcuentabanco = $customBank->codcuenta;
+        $this->assertTrue($receipt->save(), 'can-not-set-custom-receipt-bank');
+
+        $receipt->codpago = $firstPayMethod->codpago;
+        $this->assertTrue($receipt->save(), 'can-not-change-receipt-payment-method-again');
+        $this->assertEquals($customBank->codcuenta, $receipt->codcuentabanco, 'custom-bank-should-be-preserved');
+
+        $this->assertTrue($invoice->delete(), 'can-not-delete-invoice');
+        $this->assertTrue($customer->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($customer->delete(), 'can-not-delete-customer');
+        $this->assertTrue($secondPayMethod->delete(), 'can-not-delete-second-forma-pago');
+        $this->assertTrue($firstPayMethod->delete(), 'can-not-delete-first-forma-pago');
+        $this->assertTrue($customBank->delete(), 'custom-bank-cant-delete');
+        $this->assertTrue($secondBank->delete(), 'second-bank-cant-delete');
+        $this->assertTrue($firstBank->delete(), 'first-bank-cant-delete');
+    }
+
+    public function testPayReceiptUsesReceiptBankAccount(): void
+    {
+        $defaultBank = $this->getTestBankAccount('Default customer bank', '5720001001');
+        $receiptBank = $this->getTestBankAccount('Receipt customer bank', '5720001002');
+
+        $payMethod = new FormaPago();
+        $payMethod->codcuentabanco = $defaultBank->codcuenta;
+        $payMethod->descripcion = 'test';
+        $payMethod->plazovencimiento = 0;
+        $payMethod->tipovencimiento = 'days';
+        $this->assertTrue($payMethod->save(), 'cant-save-forma-pago');
+
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save(), 'cant-create-customer');
+
+        $invoice = new FacturaCliente();
+        $invoice->setSubject($customer);
+        $invoice->codpago = $payMethod->codpago;
+        $this->assertTrue($invoice->save(), 'can-not-create-invoice');
+
+        $line = $invoice->getNewLine();
+        $line->cantidad = 1;
+        $line->descripcion = 'test';
+        $line->pvpunitario = 100;
+        $this->assertTrue($line->save(), 'cant-add-invoice-line');
+        $lines = $invoice->getLines();
+        $this->assertTrue(Calculator::calculate($invoice, $lines, true), 'cant-update-invoice');
+
+        $receipts = $invoice->getReceipts();
+        $this->assertCount(1, $receipts, 'bad-invoice-receipts-count');
+        $this->assertEquals($defaultBank->codcuenta, $receipts[0]->codcuentabanco, 'bad-default-receipt-bank');
+
+        $receipts[0]->codcuentabanco = $receiptBank->codcuenta;
+        $receipts[0]->pagado = true;
+        $this->assertTrue($receipts[0]->save(), 'can-not-set-paid-receipt');
+
+        $payments = $receipts[0]->getPayments();
+        $this->assertCount(1, $payments, 'should-have-one-payment');
+        $this->assertEquals($receiptBank->codcuenta, $payments[0]->codcuentabanco, 'bad-payment-bank');
+
+        $lines = $payments[0]->getAccountingEntry()->getLines();
+        $subaccounts = array_column($lines, 'codsubcuenta');
+        $this->assertContains($receiptBank->codsubcuenta, $subaccounts, 'missing-receipt-bank-accounting-line');
+        $this->assertNotContains($defaultBank->codsubcuenta, $subaccounts, 'default-bank-should-not-be-used');
+
+        $this->deleteAccountingEntry($payments[0]);
+        $payments[0]->codcuentabanco = '';
+        $this->assertTrue($payments[0]->save(), 'can-not-clear-payment-bank');
+        $this->assertNull($payments[0]->codcuentabanco, 'empty-payment-bank-should-be-null');
+        $this->assertTrue((new PaymentToAccounting())->generate($payments[0]), 'can-not-regenerate-payment-entry');
+        $this->assertAccountingEntryBank($payments[0], $receiptBank, $defaultBank);
+        $this->deleteAccountingEntry($payments[0]);
+
+        $receipts[0]->codcuentabanco = '';
+        $this->assertTrue($receipts[0]->save(), 'can-not-clear-receipt-bank');
+        $this->assertNull($receipts[0]->codcuentabanco, 'empty-receipt-bank-should-be-null');
+        $this->assertTrue((new PaymentToAccounting())->generate($payments[0]), 'can-not-regenerate-default-entry');
+        $this->assertAccountingEntryBank($payments[0], $defaultBank, $receiptBank);
+        $this->deleteAccountingEntry($payments[0]);
+
+        $this->assertTrue($invoice->delete(), 'can-not-delete-invoice');
+        $this->assertTrue($customer->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($customer->delete(), 'can-not-delete-customer');
+        $this->assertTrue($payMethod->delete(), 'can-not-delete-forma-pago');
+        $this->assertTrue($receiptBank->delete(), 'receipt-bank-cant-delete');
+        $this->assertTrue($defaultBank->delete(), 'default-bank-cant-delete');
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();
+    }
+
+    private function assertAccountingEntryBank($payment, CuentaBanco $expectedBank, CuentaBanco $unexpectedBank): void
+    {
+        $lines = $payment->getAccountingEntry()->getLines();
+        $subaccounts = array_column($lines, 'codsubcuenta');
+        $this->assertContains($expectedBank->codsubcuenta, $subaccounts, 'missing-expected-bank-accounting-line');
+        $this->assertNotContains($unexpectedBank->codsubcuenta, $subaccounts, 'unexpected-bank-accounting-line');
+    }
+
+    private function deleteAccountingEntry($payment): void
+    {
+        $entry = $payment->getAccountingEntry();
+        $entry->editable = true;
+        $this->assertTrue($entry->delete(), 'payment-entry-cant-delete');
+        $payment->idasiento = null;
+    }
+
+    private function getTestPaymentMethod(string $description, CuentaBanco $bank): FormaPago
+    {
+        $payMethod = new FormaPago();
+        $payMethod->codcuentabanco = $bank->codcuenta;
+        $payMethod->descripcion = $description;
+        $payMethod->plazovencimiento = 0;
+        $payMethod->tipovencimiento = 'days';
+        $this->assertTrue($payMethod->save(), 'cant-save-forma-pago');
+
+        return $payMethod;
+    }
+
+    private function getTestBankAccount(string $description, string $codsubcuenta): CuentaBanco
+    {
+        $bank = new CuentaBanco();
+        $bank->codcuenta = (string)mt_rand(100000, 999999);
+        $bank->codsubcuenta = $codsubcuenta;
+        $bank->descripcion = $description;
+        $bank->idempresa = Tools::settings('default', 'idempresa');
+        $this->assertTrue($bank->save(), 'bank-cant-save');
+
+        return $bank;
     }
 }

--- a/Test/Core/Model/ReciboProveedorTest.php
+++ b/Test/Core/Model/ReciboProveedorTest.php
@@ -19,12 +19,15 @@
 
 namespace FacturaScripts\Test\Core\Model;
 
+use FacturaScripts\Core\Lib\Accounting\PaymentToAccounting;
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Lib\ReceiptGenerator;
 use FacturaScripts\Core\Model\Base\ModelCore;
+use FacturaScripts\Core\Model\CuentaBanco;
 use FacturaScripts\Core\Model\FacturaProveedor;
 use FacturaScripts\Core\Model\FormaPago;
 use FacturaScripts\Core\Model\ReciboProveedor;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -415,8 +418,165 @@ class ReciboProveedorTest extends TestCase
         $this->assertTrue($subject->delete(), 'can-not-delete-subject');
     }
 
+    public function testChangePaymentMethodUpdatesBankAccount(): void
+    {
+        $firstBank = $this->getTestBankAccount('First supplier bank', '5720002101');
+        $secondBank = $this->getTestBankAccount('Second supplier bank', '5720002102');
+        $customBank = $this->getTestBankAccount('Custom supplier bank', '5720002103');
+
+        $firstPayMethod = $this->getTestPaymentMethod('first-test', $firstBank);
+        $secondPayMethod = $this->getTestPaymentMethod('second-test', $secondBank);
+
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save(), 'cant-create-supplier');
+
+        $invoice = new FacturaProveedor();
+        $invoice->setSubject($supplier);
+        $invoice->codpago = $firstPayMethod->codpago;
+        $this->assertTrue($invoice->save(), 'can-not-create-invoice');
+
+        $line = $invoice->getNewLine();
+        $line->cantidad = 1;
+        $line->descripcion = 'test';
+        $line->pvpunitario = 100;
+        $this->assertTrue($line->save(), 'cant-add-invoice-line');
+        $lines = $invoice->getLines();
+        $this->assertTrue(Calculator::calculate($invoice, $lines, true), 'cant-update-invoice');
+
+        $receipt = $invoice->getReceipts()[0];
+        $this->assertEquals($firstBank->codcuenta, $receipt->codcuentabanco, 'bad-first-receipt-bank');
+
+        $receipt->codpago = $secondPayMethod->codpago;
+        $this->assertTrue($receipt->save(), 'can-not-change-receipt-payment-method');
+        $this->assertEquals($secondBank->codcuenta, $receipt->codcuentabanco, 'bad-second-receipt-bank');
+
+        $receipt->codcuentabanco = $customBank->codcuenta;
+        $this->assertTrue($receipt->save(), 'can-not-set-custom-receipt-bank');
+
+        $receipt->codpago = $firstPayMethod->codpago;
+        $this->assertTrue($receipt->save(), 'can-not-change-receipt-payment-method-again');
+        $this->assertEquals($customBank->codcuenta, $receipt->codcuentabanco, 'custom-bank-should-be-preserved');
+
+        $this->assertTrue($invoice->delete(), 'can-not-delete-invoice');
+        $this->assertTrue($supplier->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($supplier->delete(), 'can-not-delete-supplier');
+        $this->assertTrue($secondPayMethod->delete(), 'can-not-delete-second-forma-pago');
+        $this->assertTrue($firstPayMethod->delete(), 'can-not-delete-first-forma-pago');
+        $this->assertTrue($customBank->delete(), 'custom-bank-cant-delete');
+        $this->assertTrue($secondBank->delete(), 'second-bank-cant-delete');
+        $this->assertTrue($firstBank->delete(), 'first-bank-cant-delete');
+    }
+
+    public function testPayReceiptUsesReceiptBankAccount(): void
+    {
+        $defaultBank = $this->getTestBankAccount('Default supplier bank', '5720002001');
+        $receiptBank = $this->getTestBankAccount('Receipt supplier bank', '5720002002');
+
+        $payMethod = new FormaPago();
+        $payMethod->codcuentabanco = $defaultBank->codcuenta;
+        $payMethod->descripcion = 'test';
+        $payMethod->plazovencimiento = 0;
+        $payMethod->tipovencimiento = 'days';
+        $this->assertTrue($payMethod->save(), 'cant-save-forma-pago');
+
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save(), 'cant-create-supplier');
+
+        $invoice = new FacturaProveedor();
+        $invoice->setSubject($supplier);
+        $invoice->codpago = $payMethod->codpago;
+        $this->assertTrue($invoice->save(), 'can-not-create-invoice');
+
+        $line = $invoice->getNewLine();
+        $line->cantidad = 1;
+        $line->descripcion = 'test';
+        $line->pvpunitario = 100;
+        $this->assertTrue($line->save(), 'cant-add-invoice-line');
+        $lines = $invoice->getLines();
+        $this->assertTrue(Calculator::calculate($invoice, $lines, true), 'cant-update-invoice');
+
+        $receipts = $invoice->getReceipts();
+        $this->assertCount(1, $receipts, 'bad-invoice-receipts-count');
+        $this->assertEquals($defaultBank->codcuenta, $receipts[0]->codcuentabanco, 'bad-default-receipt-bank');
+
+        $receipts[0]->codcuentabanco = $receiptBank->codcuenta;
+        $receipts[0]->pagado = true;
+        $this->assertTrue($receipts[0]->save(), 'can-not-set-paid-receipt');
+
+        $payments = $receipts[0]->getPayments();
+        $this->assertCount(1, $payments, 'should-have-one-payment');
+        $this->assertEquals($receiptBank->codcuenta, $payments[0]->codcuentabanco, 'bad-payment-bank');
+
+        $lines = $payments[0]->getAccountingEntry()->getLines();
+        $subaccounts = array_column($lines, 'codsubcuenta');
+        $this->assertContains($receiptBank->codsubcuenta, $subaccounts, 'missing-receipt-bank-accounting-line');
+        $this->assertNotContains($defaultBank->codsubcuenta, $subaccounts, 'default-bank-should-not-be-used');
+
+        $this->deleteAccountingEntry($payments[0]);
+        $payments[0]->codcuentabanco = '';
+        $this->assertTrue($payments[0]->save(), 'can-not-clear-payment-bank');
+        $this->assertNull($payments[0]->codcuentabanco, 'empty-payment-bank-should-be-null');
+        $this->assertTrue((new PaymentToAccounting())->generate($payments[0]), 'can-not-regenerate-payment-entry');
+        $this->assertAccountingEntryBank($payments[0], $receiptBank, $defaultBank);
+        $this->deleteAccountingEntry($payments[0]);
+
+        $receipts[0]->codcuentabanco = '';
+        $this->assertTrue($receipts[0]->save(), 'can-not-clear-receipt-bank');
+        $this->assertNull($receipts[0]->codcuentabanco, 'empty-receipt-bank-should-be-null');
+        $this->assertTrue((new PaymentToAccounting())->generate($payments[0]), 'can-not-regenerate-default-entry');
+        $this->assertAccountingEntryBank($payments[0], $defaultBank, $receiptBank);
+        $this->deleteAccountingEntry($payments[0]);
+
+        $this->assertTrue($invoice->delete(), 'can-not-delete-invoice');
+        $this->assertTrue($supplier->getDefaultAddress()->delete(), 'contacto-cant-delete');
+        $this->assertTrue($supplier->delete(), 'can-not-delete-supplier');
+        $this->assertTrue($payMethod->delete(), 'can-not-delete-forma-pago');
+        $this->assertTrue($receiptBank->delete(), 'receipt-bank-cant-delete');
+        $this->assertTrue($defaultBank->delete(), 'default-bank-cant-delete');
+    }
+
     protected function tearDown(): void
     {
         $this->logErrors();
+    }
+
+    private function assertAccountingEntryBank($payment, CuentaBanco $expectedBank, CuentaBanco $unexpectedBank): void
+    {
+        $lines = $payment->getAccountingEntry()->getLines();
+        $subaccounts = array_column($lines, 'codsubcuenta');
+        $this->assertContains($expectedBank->codsubcuenta, $subaccounts, 'missing-expected-bank-accounting-line');
+        $this->assertNotContains($unexpectedBank->codsubcuenta, $subaccounts, 'unexpected-bank-accounting-line');
+    }
+
+    private function deleteAccountingEntry($payment): void
+    {
+        $entry = $payment->getAccountingEntry();
+        $entry->editable = true;
+        $this->assertTrue($entry->delete(), 'payment-entry-cant-delete');
+        $payment->idasiento = null;
+    }
+
+    private function getTestPaymentMethod(string $description, CuentaBanco $bank): FormaPago
+    {
+        $payMethod = new FormaPago();
+        $payMethod->codcuentabanco = $bank->codcuenta;
+        $payMethod->descripcion = $description;
+        $payMethod->plazovencimiento = 0;
+        $payMethod->tipovencimiento = 'days';
+        $this->assertTrue($payMethod->save(), 'cant-save-forma-pago');
+
+        return $payMethod;
+    }
+
+    private function getTestBankAccount(string $description, string $codsubcuenta): CuentaBanco
+    {
+        $bank = new CuentaBanco();
+        $bank->codcuenta = (string)mt_rand(100000, 999999);
+        $bank->codsubcuenta = $codsubcuenta;
+        $bank->descripcion = $description;
+        $bank->idempresa = Tools::settings('default', 'idempresa');
+        $this->assertTrue($bank->save(), 'bank-cant-save');
+
+        return $bank;
     }
 }


### PR DESCRIPTION
## Qué cambia

- Añade `codcuentabanco` opcional a recibos y pagos de cliente/proveedor.
- Mantiene `FormaPago.codcuentabanco` como banco por defecto y lo copia al generar recibos/pagos.
- Permite cambiar el banco en el modal de marcar factura como pagada, APIs de pago y vistas de recibos/pagos.
- La contabilización de pagos prioriza banco del pago, después banco del recibo y finalmente banco de la forma de pago.
- El PDF usa el banco del recibo cuando existe, manteniendo el fallback anterior.

## Compatibilidad

- Campos nuevos nullable con `ON DELETE SET NULL`; los datos existentes siguen usando el banco de la forma de pago.
- Si no se informa banco nuevo, el comportamiento contable anterior se mantiene.

## Validación

- TDD red: los tests nuevos aplicados sobre `origin/master` fallan en `ReciboClienteTest::testChangePaymentMethodUpdatesBankAccount` porque el recibo no guarda banco propio.
- `php -l` sobre todos los PHP modificados.
- `phpunit -c phpunit.xml --testdox Test/Core/Model/ReciboClienteTest.php` -> OK (12 tests, 162 assertions).
- `phpunit -c phpunit.xml --testdox Test/Core/Model/ReciboProveedorTest.php` -> OK (11 tests, 150 assertions).
- `phpunit -c phpunit.xml --testdox Test/Core/Lib/PDF/PDFDocumentTest.php` -> OK (2 tests, 13 assertions).
- Suite core completa en PostgreSQL aislado: OK, but incomplete/skipped expected; 996 tests, 9432 assertions, 16 skipped.
