### PR TITLE
Actualizar precio coste

### DIFF
--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -126,6 +126,9 @@ final class Kernel
         WorkQueue::addWorker('CuentaWorker', 'Model.Subcuenta.Update');
         WorkQueue::addWorker('PartidaWorker', 'Model.Partida.Delete');
         WorkQueue::addWorker('PartidaWorker', 'Model.Partida.Save');
+        WorkQueue::addWorker('ProductoProveedorWorker', 'Model.ProductoProveedor.Delete');
+        WorkQueue::addWorker('ProductoProveedorWorker', 'Model.ProductoProveedor.Insert');
+        WorkQueue::addWorker('ProductoProveedorWorker', 'Model.ProductoProveedor.Update');
         WorkQueue::addWorker('PurchaseDocumentWorker', 'Model.AlbaranProveedor.Update');
         WorkQueue::addWorker('PurchaseDocumentWorker', 'Model.FacturaProveedor.Update');
         WorkQueue::addWorker('PurchaseDocumentWorker', 'Model.PedidoProveedor.Update');

--- a/Core/Model/Base/PurchaseDocument.php
+++ b/Core/Model/Base/PurchaseDocument.php
@@ -24,7 +24,6 @@ use FacturaScripts\Core\Model\Proveedor as CoreProveedor;
 use FacturaScripts\Core\Model\User;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Where;
-use FacturaScripts\Dinamic\Model\ProductoProveedor;
 use FacturaScripts\Dinamic\Model\Proveedor;
 use FacturaScripts\Dinamic\Model\Variante;
 
@@ -96,8 +95,6 @@ abstract class PurchaseDocument extends TransformerDocument
             $newLine->pvpunitario = $variant->coste;
             $newLine->recargo = $product->getTax()->recargo;
             $newLine->referencia = $variant->referencia;
-
-            $this->setLastSupplierPrice($newLine);
 
             Calculator::calculateLine($this, $newLine);
 
@@ -214,26 +211,4 @@ abstract class PurchaseDocument extends TransformerDocument
         return $this->codproveedor && $proveedor->load($this->codproveedor) && $this->setSubject($proveedor);
     }
 
-    /**
-     * Establece el último precio y descuentos de este proveedor.
-     *
-     * @param BusinessDocumentLine $newLine
-     */
-    protected function setLastSupplierPrice(&$newLine): void
-    {
-        $where = [
-            Where::eq('codproveedor', $this->codproveedor),
-            Where::eq('referencia', $newLine->referencia),
-            Where::gt('precio', 0)
-        ];
-        $orderBy = ['coddivisa' => 'DESC'];
-        foreach (ProductoProveedor::all($where, $orderBy) as $prod) {
-            if ($prod->coddivisa === $this->coddivisa || $prod->coddivisa === null) {
-                $newLine->dtopor = $prod->dtopor;
-                $newLine->dtopor2 = $prod->dtopor2;
-                $newLine->pvpunitario = $prod->precio;
-                return;
-            }
-        }
-    }
 }

--- a/Core/Model/Base/PurchaseDocument.php
+++ b/Core/Model/Base/PurchaseDocument.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2013-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2013-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/Core/Model/ProductoProveedor.php
+++ b/Core/Model/ProductoProveedor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2020-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2020-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/Core/Model/ProductoProveedor.php
+++ b/Core/Model/ProductoProveedor.php
@@ -25,7 +25,6 @@ use FacturaScripts\Core\Model\Base\ProductRelationTrait;
 use FacturaScripts\Core\Template\ModelClass;
 use FacturaScripts\Core\Template\ModelTrait;
 use FacturaScripts\Core\Tools;
-use FacturaScripts\Dinamic\Lib\CostPriceTools;
 use FacturaScripts\Dinamic\Model\Divisa as DinDivisa;
 use FacturaScripts\Dinamic\Model\Producto as DinProducto;
 use FacturaScripts\Dinamic\Model\Proveedor as DinProveedor;
@@ -192,35 +191,5 @@ class ProductoProveedor extends ModelClass
         return $this->getVariant()->url($type);
     }
 
-    /**
-     * This method is called after a record is deleted on the database (delete).
-     */
-    protected function onDelete(): void
-    {
-        CostPriceTools::update($this->getVariant());
 
-        parent::onDelete();
-    }
-
-    /**
-     * This method is called after a new record is saved on the database (saveInsert).
-     */
-    protected function onInsert(): void
-    {
-        CostPriceTools::update($this->getVariant());
-
-        parent::onInsert();
-    }
-
-    /**
-     * This method is called after a record is updated on the database (saveUpdate).
-     */
-    protected function onUpdate(): void
-    {
-        if ($this->isDirty('neto')) {
-            CostPriceTools::update($this->getVariant());
-        }
-
-        parent::onUpdate();
-    }
 }

--- a/Core/Worker/ProductoProveedorWorker.php
+++ b/Core/Worker/ProductoProveedorWorker.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -24,6 +24,10 @@ use FacturaScripts\Core\Model\WorkEvent;
 use FacturaScripts\Core\Template\WorkerClass;
 use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\Variante;
+
+/**
+ * @author Esteban Sánchez Martínez <esteban@factura.city>
+ */
 
 class ProductoProveedorWorker extends WorkerClass
 {

--- a/Core/Worker/ProductoProveedorWorker.php
+++ b/Core/Worker/ProductoProveedorWorker.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Core\Worker;
+
+use FacturaScripts\Core\Lib\CostPriceTools;
+use FacturaScripts\Core\Model\WorkEvent;
+use FacturaScripts\Core\Template\WorkerClass;
+use FacturaScripts\Core\Where;
+use FacturaScripts\Dinamic\Model\Variante;
+
+class ProductoProveedorWorker extends WorkerClass
+{
+    public function run(WorkEvent $event): bool
+    {
+        $referencia = $event->param('referencia');
+        if (empty($referencia)) {
+            return $this->done();
+        }
+
+        $variant = new Variante();
+        if (false === $variant->loadWhere([Where::eq('referencia', $referencia)])) {
+            return $this->done();
+        }
+
+        CostPriceTools::update($variant);
+
+        return $this->done();
+    }
+}

--- a/Dinamic/Model/Contacto.php
+++ b/Dinamic/Model/Contacto.php
@@ -4,6 +4,6 @@
  * Class created by Core/Internal/PluginsDeploy
  * @author FacturaScripts <carlos@facturascripts.com>
  */
-class Contacto extends \FacturaScripts\Plugins\CRM\Model\Contacto
+class Contacto extends \FacturaScripts\Core\Model\Contacto
 {
 }

--- a/Dinamic/Model/Contacto.php
+++ b/Dinamic/Model/Contacto.php
@@ -4,6 +4,6 @@
  * Class created by Core/Internal/PluginsDeploy
  * @author FacturaScripts <carlos@facturascripts.com>
  */
-class Contacto extends \FacturaScripts\Core\Model\Contacto
+class Contacto extends \FacturaScripts\Plugins\CRM\Model\Contacto
 {
 }

--- a/Test/Core/Model/ProductoProveedorTest.php
+++ b/Test/Core/Model/ProductoProveedorTest.php
@@ -182,40 +182,6 @@ final class ProductoProveedorTest extends TestCase
     /**
      * Comprobamos que al crear una línea de Albarán
      * con un Producto previamente incluido en otro Albarán
-     * mantiene el precio del ProductoProveedor creado en el Albarán previo
-     * y no el precio del Producto.
-     */
-    public function testItCanAssignProductoProveedorPrice(): void
-    {
-        [$subject, $product, $doc, $pvpUnitario, $dtopor, $dtopor2] = $this->getAlbaranConLineaProducto();
-
-        // Creamos otro albarán
-        $doc2 = new AlbaranProveedor();
-        $doc2->setSubject($subject);
-        $this->assertTrue($doc2->save());
-
-        // Añadimos el producto
-        $line = $doc2->getNewProductLine($product->referencia);
-        $this->assertTrue($line->save());
-
-        // comprobamos que el precio del producto es el del albarán previo
-        $this->assertEquals($pvpUnitario, $line->pvpunitario);
-        $this->assertEquals($dtopor, $line->dtopor);
-        $this->assertEquals($dtopor2, $line->dtopor2);
-        $this->assertNotEquals($product->precio, $line->pvpunitario);
-
-        // eliminamos
-        $this->assertTrue($doc->delete());
-        $this->assertTrue($doc2->delete());
-        $this->assertTrue($subject->getDefaultAddress()->delete());
-        $this->assertTrue($subject->delete());
-        $this->assertTrue($product->delete());
-        $this->assertTrue(ProductoProveedor::deleteWhere([]));
-    }
-
-    /**
-     * Comprobamos que al crear una línea de Albarán
-     * con un Producto previamente incluido en otro Albarán
      * y creamos otro Albarán con distinta Divisa incluyendo el mismo Producto,
      * se crea un ProductoProveedor nuevo con la Divisa del Albarán
      */
@@ -269,6 +235,151 @@ final class ProductoProveedorTest extends TestCase
         $this->assertTrue($subject->delete());
         $this->assertTrue($product->delete());
         $this->assertTrue($divisa->delete());
+    }
+
+    public function testWorkerUpdatesCosteOnInsert(): void
+    {
+        Tools::settingsSet('default', 'costpricepolicy', 'last-price');
+
+        $product = $this->getRandomProduct();
+        $this->assertTrue($product->save());
+        $variant = $product->getVariants()[0];
+
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save());
+
+        $pp = new ProductoProveedor();
+        $pp->referencia = $product->referencia;
+        $pp->idproducto = $product->idproducto;
+        $pp->codproveedor = $supplier->codproveedor;
+        $pp->precio = 50.0;
+        $this->assertTrue($pp->save());
+
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+
+        $variant->load($variant->idvariante);
+        $this->assertEquals(50.0, (float)$variant->coste);
+
+        $pp->delete();
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+        $supplier->getDefaultAddress()->delete();
+        $supplier->delete();
+        $product->delete();
+    }
+
+    public function testWorkerUpdatesCosteOnUpdate(): void
+    {
+        Tools::settingsSet('default', 'costpricepolicy', 'last-price');
+
+        $product = $this->getRandomProduct();
+        $this->assertTrue($product->save());
+        $variant = $product->getVariants()[0];
+
+        $supplier = $this->getRandomSupplier();
+        $this->assertTrue($supplier->save());
+
+        $pp = new ProductoProveedor();
+        $pp->referencia = $product->referencia;
+        $pp->idproducto = $product->idproducto;
+        $pp->codproveedor = $supplier->codproveedor;
+        $pp->precio = 50.0;
+        $this->assertTrue($pp->save());
+
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+
+        $pp->precio = 80.0;
+        $this->assertTrue($pp->save());
+
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+
+        $variant->load($variant->idvariante);
+        $this->assertEquals(80.0, (float)$variant->coste);
+
+        $pp->delete();
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+        $supplier->getDefaultAddress()->delete();
+        $supplier->delete();
+        $product->delete();
+    }
+
+    public function testWorkerUpdatesCosteOnDelete(): void
+    {
+        Tools::settingsSet('default', 'costpricepolicy', 'average-price');
+
+        $product = $this->getRandomProduct();
+        $this->assertTrue($product->save());
+        $variant = $product->getVariants()[0];
+
+        $supplier1 = $this->getRandomSupplier();
+        $this->assertTrue($supplier1->save());
+
+        $supplier2 = $this->getRandomSupplier();
+        $this->assertTrue($supplier2->save());
+
+        $pp1 = new ProductoProveedor();
+        $pp1->referencia = $product->referencia;
+        $pp1->idproducto = $product->idproducto;
+        $pp1->codproveedor = $supplier1->codproveedor;
+        $pp1->precio = 40.0;
+        $this->assertTrue($pp1->save());
+
+        $pp2 = new ProductoProveedor();
+        $pp2->referencia = $product->referencia;
+        $pp2->idproducto = $product->idproducto;
+        $pp2->codproveedor = $supplier2->codproveedor;
+        $pp2->precio = 60.0;
+        $this->assertTrue($pp2->save());
+
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+
+        $variant->load($variant->idvariante);
+        $this->assertEquals(50.0, (float)$variant->coste);
+
+        $pp2->delete();
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+
+        $variant->load($variant->idvariante);
+        $this->assertEquals(40.0, (float)$variant->coste);
+
+        $pp1->delete();
+        while (true) {
+            if (false === WorkQueue::run()) {
+                break;
+            }
+        }
+        $supplier1->getDefaultAddress()->delete();
+        $supplier1->delete();
+        $supplier2->getDefaultAddress()->delete();
+        $supplier2->delete();
+        $product->delete();
     }
 
     public function testPrimaryColumn(): void

--- a/Test/Core/Model/ProductoProveedorTest.php
+++ b/Test/Core/Model/ProductoProveedorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2023-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2023-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as


### PR DESCRIPTION
https://facturascripts.com/roadmap/4012
-Eliminado código duplicado en PurchaseDocument.php método setLastSupplierPrice() y su llamada en getNewProductLine().
-Creado ProductoProveedorWorker.php con la actualización de los precios. 
-En Kernel.php se han añadido workers a la cola de trabajo para manejar las operaciones de inserción, actualización y eliminación de ProductoProveedor.
- Se eliminaron métodos obsoletos en ProductoProveedor relacionados con la actualización de precios.
- Se implementaron y probaron pruebas para verificar que el coste del producto se actualiza correctamente al insertar, actualizar y eliminar registros de ProductoProveedor.


Archivos modificados/creados:
- Kernel.php
- ProductoProveedor.php
- ProductoProveedorTest.php
- PurchaseDocument.php
- ProductoProveedorWorker.php