### PR TITLE
añade soporte para archivos .webp en las validaciones de imagen.

### DIFF
--- a/Core/Controller/Files.php
+++ b/Core/Controller/Files.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -69,7 +69,7 @@ class Files implements ControllerInterface
         $safe = [
             'accdb', 'avi', 'cdr', 'css', 'csv', 'doc', 'docx', 'eot', 'gif', 'gz', 'html', 'ico', 'ics', 'jpeg',
             'jpg', 'js', 'json', 'map', 'md', 'mdb', 'mkv', 'mp3', 'mp4', 'ndg', 'ods', 'odt', 'ogg', 'pdf', 'png',
-            'pptx', 'sql', 'svg', 'ttf', 'txt', 'webm', 'woff', 'woff2', 'xls', 'xlsx', 'xml', 'xsig', 'zip'
+            'pptx', 'sql', 'svg', 'ttf', 'txt', 'webm', 'webp', 'woff', 'woff2', 'xls', 'xlsx', 'xml', 'xsig', 'zip'
         ];
         return empty($parts) || count($parts) === 1 || in_array(end($parts), $safe, true);
     }

--- a/Core/Model/ProductoImagen.php
+++ b/Core/Model/ProductoImagen.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2012-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2012-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -123,7 +123,7 @@ class ProductoImagen extends ModelClass
 
         // si la extensión no está entre las permitidas terminamos
         $ext = pathinfo($file->getFullPath(), PATHINFO_EXTENSION);
-        if (false === in_array($ext, ['jpg', 'jpeg', 'png', 'gif'])) {
+        if (false === in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp'])) {
             return '';
         }
 

--- a/Core/View/Tab/ProductoImagen.html.twig
+++ b/Core/View/Tab/ProductoImagen.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2022-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2022-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -49,7 +49,7 @@
                             <div class="col">
                                 {{ trans('images') }}
                                 <input type="file" name="newfiles[]" class="form-control" multiple=""
-                                       accept="image/png, image/jpeg, image/gif" required/>
+                                       accept="image/png, image/jpeg, image/gif, image/webp" required/>
                                 <p class="text-muted mb-2">
                                     {{ trans('help-server-accepts-filesize', {'%size%': currentView.model.getMaxFileUpload()}) }}
                                 </p>

--- a/Core/XMLView/ConfigEmail.xml
+++ b/Core/XMLView/ConfigEmail.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -32,7 +32,7 @@
                 <widget type="password" fieldname="password" icon="fa-solid fa-key"/>
             </column>
             <column name="logo" order="120">
-                <widget type="library" fieldname="idlogo" icon="fa-solid fa-image" onclick="EditAttachedFile" accept=".jpg,.jpeg,.png"/>
+                <widget type="library" fieldname="idlogo" icon="fa-solid fa-image" onclick="EditAttachedFile" accept=".jpg,.jpeg,.png,.webp"/>
             </column>
             <column name="email-signature" numcolumns="12" order="130">
                 <widget type="textarea" fieldname="signature"/>

--- a/Core/XMLView/SettingsDefault.xml
+++ b/Core/XMLView/SettingsDefault.xml
@@ -159,7 +159,7 @@
                 </widget>
             </column>
             <column name="login-image" numcolumns="3" order="120">
-                <widget type="library" fieldname="idloginimage" icon="fa-solid fa-image" onclick="EditAttachedFile" accept=".gif,.jpg,.png"/>
+                <widget type="library" fieldname="idloginimage" icon="fa-solid fa-image" onclick="EditAttachedFile" accept=".gif,.jpg,.jpeg,.png,.webp"/>
             </column>
             <column name="table-size" numcolumns="3" order="130">
                 <widget type="select" fieldname="tablesize" icon="fa-solid fa-table" required="true" translate="true">


### PR DESCRIPTION
La biblioteca dejaba subir imágenes web pero luego se podía usar a nivel de email, logo de login, al comprobar con el controlador Files, y tampoco a nivel de la fichad e productos. Con este cambio se permite está nueva opción.

A nivel de pdf no es posible porque Cezpdf solo acepta gif, upe o png. Y mpdf de PantillasPDF si acepta web pero hay que convertirlo a png sin canal alpha. Por esto no damos la opción de webp para el logo en los pdf.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.