### PR TITLE
mantiene formato cuando existe mas de un impuesto

### DIFF
--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -397,11 +397,25 @@ abstract class PDFDocument extends PDFCore
             'shadeHeadingCol' => [0.95, 0.95, 0.95],
             'width' => $this->tableWidth
         ];
+        // Mantiene impuestos y totales anclados en la parte inferior cuando no hay texto final largo.
+        $compactFooter = strlen($this->format->texto ?? '') < 400;
         if (count($taxRows) > 1) {
             $this->removeEmptyCols($taxRows, $taxHeaders, Tools::number(0));
+            if ($compactFooter) {
+                // Reserva altura para la tabla de impuestos y el espacio previo a la tabla de totales.
+                $taxRowsHeight = (count($taxRows) + 1) * (self::FONT_SIZE + 7) + self::FONT_SIZE;
+                if ($this->pdf->y > static::INVOICE_TOTALS_Y + $taxRowsHeight) {
+                    $this->pdf->y = static::INVOICE_TOTALS_Y + $taxRowsHeight;
+                }
+            }
             $this->pdf->ezTable($taxRows, $taxHeaders, '', $taxTableOptions);
-            $this->pdf->ezText("\n");
-        } elseif ($this->pdf->ezPageCount < 2 && strlen($this->format->texto ?? '') < 400 && $this->pdf->y > static::INVOICE_TOTALS_Y) {
+            if ($compactFooter) {
+                // Separación visual entre la tabla de impuestos y la de totales.
+                $this->pdf->y -= self::FONT_SIZE;
+            } else {
+                $this->pdf->ezText("\n");
+            }
+        } elseif ($compactFooter && $this->pdf->y > static::INVOICE_TOTALS_Y) {
             $this->pdf->y = static::INVOICE_TOTALS_Y;
         }
 


### PR DESCRIPTION
# Descripción
- Cuando se añade retenciones IRPF u otros IMPUESTOS la tabla de impuestos y totales pierden su localización pegandose a las lineas del documento en lugar de mantenerse en la zona inferior.
- Estos cambios corrigen esta circunstancia manteniendo siempre la tabla de impuestos y totales en la zona inferior tanto cuando existe una sola página o multiples páginas.

ANTES:
<img width="689" height="598" alt="imagen" src="https://github.com/user-attachments/assets/08f8d4fc-72f8-4297-8608-d4f399f8264b" />


DESPUÉS:
<img width="674" height="789" alt="imagen" src="https://github.com/user-attachments/assets/bd2dc9a9-ba4c-4bea-af99-812a2bc7a7f2" />

