### PR TITLE
Tarea4526 bug nombre plugin

### DIFF
--- a/Core/Plugins.php
+++ b/Core/Plugins.php
@@ -360,6 +360,9 @@ final class Plugins
 
             $plugin = new Plugin($item);
             if ($plugin->exists()) {
+                if ($plugin->folder !== $plugin->name) {
+                    $plugin->folder = $plugin->name;
+                }
                 self::$plugins[] = $plugin;
             }
         }

--- a/Dinamic/Model/Contacto.php
+++ b/Dinamic/Model/Contacto.php
@@ -1,9 +1,0 @@
-<?php namespace FacturaScripts\Dinamic\Model;
-
-/**
- * Class created by Core/Internal/PluginsDeploy
- * @author FacturaScripts <carlos@facturascripts.com>
- */
-class Contacto extends \FacturaScripts\Plugins\CRM\Model\Contacto
-{
-}

--- a/Dinamic/Model/Contacto.php
+++ b/Dinamic/Model/Contacto.php
@@ -4,6 +4,6 @@
  * Class created by Core/Internal/PluginsDeploy
  * @author FacturaScripts <carlos@facturascripts.com>
  */
-class Contacto extends \FacturaScripts\Core\Model\Contacto
+class Contacto extends \FacturaScripts\Plugins\CRM\Model\Contacto
 {
 }

--- a/Test/Core/PluginsTest.php
+++ b/Test/Core/PluginsTest.php
@@ -411,6 +411,43 @@ final class PluginsTest extends TestCase
         $this->assertNull(Plugins::get('RenameFolder'));
     }
 
+    public function testStaleFolderInPluginsJson(): void
+    {
+        // instalamos TestPlugin2 de forma normal
+        $this->assertTrue(Plugins::add(__DIR__ . '/../__files/TestPlugin2.zip'));
+
+        // verificamos que el folder instalado es correcto
+        $this->assertEquals('TestPlugin2', Plugins::get('TestPlugin2')->folder);
+
+        // corrompemos plugins.json con un folder obsoleto (simula el escenario del bug:
+        // el usuario tenía la carpeta con otro nombre y la renombró manualmente)
+        $jsonPath = Tools::folder('MyFiles', Plugins::FILE_NAME);
+        $data = json_decode(file_get_contents($jsonPath), true);
+        foreach ($data as &$item) {
+            if ($item['name'] === 'TestPlugin2') {
+                $item['folder'] = 'TestPlugin2-old-folder';
+                break;
+            }
+        }
+        file_put_contents($jsonPath, json_encode($data, JSON_PRETTY_PRINT));
+
+        // reseteamos el caché estático para forzar recarga desde disco
+        $ref = new \ReflectionClass(Plugins::class);
+        $prop = $ref->getProperty('plugins');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+
+        // con el bug: enable() falla porque folder='TestPlugin2-old-folder' !== name='TestPlugin2'
+        // con el fix: enable() funciona porque loadFromFile() corrige el folder obsoleto
+        $this->assertTrue(Plugins::enable('TestPlugin2'));
+
+        // limpieza
+        $this->assertTrue(Plugins::disable('TestPlugin2'));
+        $this->assertTrue(Plugins::remove('TestPlugin2'));
+        $this->assertNull(Plugins::get('TestPlugin2'));
+    }
+
+
     public function testPluginsOrder(): void
     {
         // añadimos los plugins TestPlugin3, TestPlugin2 y TestPlugin4


### PR DESCRIPTION
https://facturascripts.com/roadmap/4526
En Core/Plugins.php, método loadFromFile(), se añade una comprobacion, si el plugin existe en disco (exists() = true) pero folder !== name, se corrige folder = name en memoria antes de añadirlo. El siguiente save() guarda el valor correcto en plugins.json.

Test añadido: testStaleFolderInPluginsJson en Test/Core/PluginsTest.php  instala un plugin, rompe plugins.json metiendo una carpeta que ya no existe, limpia el caché estático con Reflection y comprueba que enable() sigue funcionando.
