### PR TITLE
bloquear pantalla log procesando

### DIFF
--- a/Core/Base/MiniLog.php
+++ b/Core/Base/MiniLog.php
@@ -135,9 +135,10 @@ final class MiniLog
      * @param string $message
      * @param array $context
      */
-    public function info(string $message, array $context = []): void
+    public function info(string $message, array $context = []): self
     {
         $this->log('info', $message, $context);
+        return $this;
     }
 
     /**
@@ -146,9 +147,10 @@ final class MiniLog
      * @param string $message
      * @param array $context
      */
-    public function notice(string $message, array $context = []): void
+    public function notice(string $message, array $context = []): self
     {
         $this->log('notice', $message, $context);
+        return $this;
     }
 
     /**
@@ -282,5 +284,21 @@ final class MiniLog
         if (count(self::$data) > self::LIMIT) {
             self::save($this->channel);
         }
+    }
+
+    public function bloquearInteraccion(): self
+    {
+        // Marca el último mensaje del canal actual para que la vista active
+        // un overlay bloqueante de interacción cuando ese mensaje se renderiza.
+        // Solo afecta al mensaje más reciente del canal para evitar bloquear
+        // otros avisos no relacionados.
+        for ($i = count(self::$data) - 1; $i >= 0; --$i) {
+            if (self::$data[$i]['channel'] === $this->channel) {
+                self::$data[$i]['block_interaction'] = true;
+                break;
+            }
+        }
+
+        return $this;
     }
 }

--- a/Core/Controller/AdminPlugins.php
+++ b/Core/Controller/AdminPlugins.php
@@ -193,7 +193,7 @@ class AdminPlugins extends Controller
         }
 
         if ($ok) {
-            Tools::log()->notice('reloading');
+            Tools::log()->notice('reloading')->bloquearInteraccion();
             $this->redirect($this->url(), 3);
         }
     }
@@ -277,7 +277,7 @@ class AdminPlugins extends Controller
         Cache::clear();
 
         if ($ok) {
-            Tools::log()->notice('reloading');
+            Tools::log()->notice('reloading')->bloquearInteraccion();
             $this->redirect($this->url(), 3);
         }
     }

--- a/Core/View/Macro/Toasts.html.twig
+++ b/Core/View/Macro/Toasts.html.twig
@@ -1,6 +1,20 @@
 <div id="messages-toasts" style="z-index: 9999; position: fixed; bottom: 2%; left: 50%; transform: translateX(-50%);"></div>
+<div id="messages-block-overlay" class="position-fixed top-0 start-0 w-100 h-100 d-none d-flex justify-content-center align-items-center" style="z-index: 9998; backdrop-filter: blur(2px); background: rgba(255,255,255,.55); pointer-events: all;">
+    <div class="alert alert-info border border-info shadow fw-semibold text-center mb-0 mx-3"></div>
+</div>
 
 <script>
+    function blockUserInteraction(message = '') {
+        const overlay = document.getElementById('messages-block-overlay');
+        if (!overlay) {
+            return;
+        }
+
+        overlay.querySelector('div').textContent = message !== '' ? message + ' - {{ trans('processing') }}...' : '{{ trans('processing') }}...';
+        overlay.classList.remove('d-none');
+        document.body.style.overflow = 'hidden';
+    }
+
     function setToast(message, style = 'info', title = '', time = 10000) {
         let icon = '';
         let styleBorder = '';

--- a/Core/View/Macro/Utils.html.twig
+++ b/Core/View/Macro/Utils.html.twig
@@ -21,6 +21,12 @@
 {# Muestra todos los mensajes con alguno de los niveles dados #}
 {% macro message(log, levels, style) %}
     {% set messages = log.read('master', levels) | merge(log.read('database', levels)) %}
+    {% set blockInteraction = false %}
+    {% for item in messages %}
+        {% if item.block_interaction is defined and item.block_interaction %}
+            {% set blockInteraction = true %}
+        {% endif %}
+    {% endfor %}
     {% if messages | length > 0 %}
         <div class="alert alert-dismissible alert-{{ style }}" role="alert">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
@@ -28,6 +34,9 @@
                 <div>{{ item.message }}</div>
             {% endfor %}
         </div>
+        {% if blockInteraction %}
+            <script>blockUserInteraction({{ messages[0].message|json_encode|raw }});</script>
+        {% endif %}
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
# Descripción
• Se añadió bloqueo de interacción de UI activable desde el log.

  - MiniLog:
      - Nuevo bloquearInteraccion() marca el último mensaje del canal con block_interaction.
  - AdminPlugins:
      - En uploadPluginAction() y extracción ZIP: Tools::log()->notice('reloading')->bloquearInteraccion();
  - Vistas:
      - Overlay con blur en Macro/Toasts.html.twig (estilo Bootstrap).
      - El bloqueo se dispara al renderizar el mensaje en Macro/Utils.html.twig.

  Resultado: cuando aparece el aviso de recarga, la pantalla queda bloqueada con mensaje centrado.



https://github.com/user-attachments/assets/1aa978e7-0ff0-4fc5-b081-a93140909ff5


