### PR TITLE
Mejora la gestión de pestañas e historial al clicar en ellas

### DIFF
--- a/Core/View/Master/ListController.html.twig
+++ b/Core/View/Master/ListController.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -217,11 +217,25 @@
             if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) == false) {
                 $("input[name='query']:visible").focus();
             }
+            var pageBaseTitle = document.title;
             $('.nav-tabs a').click(function (e) {
+                e.preventDefault();
                 $(this).tab('show');
-                var scrollmem = $('body').scrollTop();
-                window.location.hash = this.hash;
-                $('html,body').scrollTop(scrollmem);
+                if (history.pushState) {
+                    var tabTitle = $(this).attr('title') || $(this).text().trim();
+                    var newTitle = pageBaseTitle + ' - ' + tabTitle;
+                    document.title = newTitle;
+                    history.pushState({ title: newTitle }, '', this.hash);
+                }
+            });
+            $(window).on('popstate', function (e) {
+                var title = e.originalEvent.state && e.originalEvent.state.title
+                    ? e.originalEvent.state.title
+                    : pageBaseTitle;
+                document.title = title;
+                if (document.location.hash) {
+                    $(".nav-tabs a[href=\"" + document.location.hash + "\"]").tab('show');
+                }
             });
             $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
                 // Desplazar la pestaña activa cuando se cambia de pestaña

--- a/Core/View/Master/PanelController.html.twig
+++ b/Core/View/Master/PanelController.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -152,6 +152,29 @@
             if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) == false) {
                 $("input:visible,textarea:visible").filter(":not([readonly='readonly']):not([disabled='disabled']):not([type='hidden']):not([type='checkbox']):not([type='radio'])").first().focus();
             }
+            var pageBaseTitle = document.title;
+            if (document.location.hash) {
+                $('a[data-bs-toggle="pill"][href="' + document.location.hash + '"]').tab('show');
+            }
+            $('a[data-bs-toggle="pill"]').click(function (e) {
+                e.preventDefault();
+                $(this).tab('show');
+                if (history.pushState) {
+                    var tabTitle = $(this).find('span').first().text().trim();
+                    var newTitle = pageBaseTitle + ' - ' + tabTitle;
+                    document.title = newTitle;
+                    history.pushState({ title: newTitle }, '', this.hash);
+                }
+            });
+            $(window).on('popstate', function (e) {
+                var title = e.originalEvent.state && e.originalEvent.state.title
+                    ? e.originalEvent.state.title
+                    : pageBaseTitle;
+                document.title = title;
+                if (document.location.hash) {
+                    $('a[data-bs-toggle="pill"][href="' + document.location.hash + '"]').tab('show');
+                }
+            });
         });
     </script>
 {% endblock %}

--- a/Core/View/Master/PanelControllerBottom.html.twig
+++ b/Core/View/Master/PanelControllerBottom.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -171,6 +171,30 @@
 
             // Desplazar la pestaña activa al cargar la página
             scrollActivePillIntoView();
+
+            var pageBaseTitle = document.title;
+            if (document.location.hash) {
+                $('a[data-bs-toggle="tab"][href="' + document.location.hash + '"]').tab('show');
+            }
+            $('a[data-bs-toggle="tab"]').click(function (e) {
+                e.preventDefault();
+                $(this).tab('show');
+                if (history.pushState) {
+                    var tabTitle = $(this).find('span').first().text().trim();
+                    var newTitle = pageBaseTitle + ' - ' + tabTitle;
+                    document.title = newTitle;
+                    history.pushState({ title: newTitle }, '', this.hash);
+                }
+            });
+            $(window).on('popstate', function (e) {
+                var title = e.originalEvent.state && e.originalEvent.state.title
+                    ? e.originalEvent.state.title
+                    : pageBaseTitle;
+                document.title = title;
+                if (document.location.hash) {
+                    $('a[data-bs-toggle="tab"][href="' + document.location.hash + '"]').tab('show');
+                }
+            });
 
             // Desplazar cuando se cambia de pestaña
             $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {

--- a/Core/View/Master/PanelControllerTop.html.twig
+++ b/Core/View/Master/PanelControllerTop.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -219,6 +219,30 @@
             if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) == false) {
                 $("input:visible,textarea:visible").filter(":not([readonly='readonly']):not([disabled='disabled']):not([type='hidden'])").first().focus();
             }
+
+            var pageBaseTitle = document.title;
+            if (document.location.hash) {
+                $('a[data-bs-toggle="tab"][href="' + document.location.hash + '"]').tab('show');
+            }
+            $('a[data-bs-toggle="tab"]').click(function (e) {
+                e.preventDefault();
+                $(this).tab('show');
+                if (history.pushState) {
+                    var tabTitle = $(this).find('span').first().text().trim();
+                    var newTitle = pageBaseTitle + ' - ' + tabTitle;
+                    document.title = newTitle;
+                    history.pushState({ title: newTitle }, '', this.hash);
+                }
+            });
+            $(window).on('popstate', function (e) {
+                var title = e.originalEvent.state && e.originalEvent.state.title
+                    ? e.originalEvent.state.title
+                    : pageBaseTitle;
+                document.title = title;
+                if (document.location.hash) {
+                    $('a[data-bs-toggle="tab"][href="' + document.location.hash + '"]').tab('show');
+                }
+            });
 
             // Desplazar cuando se cambia de pestaña
             $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {


### PR DESCRIPTION
Este PR corrige el problema en Safari (es compatible con todos los navegadores) que a clicar en una pestaña en Safari se mueve el scroll hacia arriba perdiendo el foco en la parte superior, es muy molesto. Este cambio no afecta en nada a otros navegadores.

Además, ahora se guarda en el historial del navegador la página de forma correcta y la pestaña, pudiendo volver desde el historial a una página y pestaña solicitada.

<img width="416" height="623" alt="Captura de pantalla 2026-05-13 a las 10 16 18" src="https://github.com/user-attachments/assets/ac944d2c-57e8-45b7-88f0-fa87d4ffe409" />

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.