### PR TITLE
Tarea1426 rellenar huecos sin cambiar fecha

### DIFF
--- a/Core/Lib/BusinessDocumentCode.php
+++ b/Core/Lib/BusinessDocumentCode.php
@@ -150,8 +150,10 @@ class BusinessDocumentCode
                     $document->codejercicio == $preCodejercicio
                 ) {
                     // hole found
-                    $document->fecha = $preDate;
-                    $document->hora = $preHour;
+                    if (false === $sequence->mantenerfecha) {
+                        $document->fecha = $preDate;
+                        $document->hora = $preHour;
+                    }
                     $sequence->disablePatternTest(true);
                     $sequence->save();
                     $sequence->disablePatternTest(false);
@@ -174,8 +176,10 @@ class BusinessDocumentCode
                 $document->codejercicio == $preCodejercicio
             ) {
                 // the gap is in the first positions of the range
-                $document->fecha = $preDate;
-                $document->hora = $preHour;
+                if (false === $sequence->mantenerfecha) {
+                    $document->fecha = $preDate;
+                    $document->hora = $preHour;
+                }
                 $sequence->disablePatternTest(true);
                 $sequence->save();
                 $sequence->disablePatternTest(false);

--- a/Core/Model/SecuenciaDocumento.php
+++ b/Core/Model/SecuenciaDocumento.php
@@ -51,6 +51,9 @@ class SecuenciaDocumento extends ModelClass
     /** @var int */
     public $longnumero;
 
+    /** @var bool */
+    public $mantenerfecha;
+
     /** @var int */
     public $numero;
 
@@ -72,6 +75,7 @@ class SecuenciaDocumento extends ModelClass
         $this->idempresa = Tools::settings('default', 'idempresa');
         $this->inicio = 1;
         $this->longnumero = 6;
+        $this->mantenerfecha = false;
         $this->numero = 1;
         $this->patron = '{EJE}{SERIE}{0NUM}';
         $this->usarhuecos = false;

--- a/Core/Table/secuencias_documentos.xml
+++ b/Core/Table/secuencias_documentos.xml
@@ -36,6 +36,12 @@
         <null>NO</null>
     </column>
     <column>
+        <name>mantenerfecha</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>false</default>
+    </column>
+    <column>
         <name>numero</name>
         <type>integer</type>
         <null>NO</null>

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -1814,6 +1814,7 @@
     "upload-file": "Upload file",
     "uploaded-at": "Uploaded at",
     "url": "Web site",
+    "keep-date": "Keep date",
     "use-gaps": "Use gaps",
     "use-holes-invoices-esp": "If you uncheck the use of gaps in invoices and delete some, the gap will remain in the billing and you will have problems with the treasury",
     "user": "User",

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -1814,6 +1814,7 @@
     "upload-file": "Subir archivo",
     "uploaded-at": "Cargado en",
     "url": "Dirección web",
+    "keep-date": "Mantener fecha",
     "use-gaps": "Usar huecos",
     "use-holes-invoices-esp": "Si desmarcas el uso de huecos en facturas y eliminas alguna se quedará el hueco en la facturación y tendrás problemas con hacienda",
     "user": "Usuario",

--- a/Core/XMLView/EditSecuenciaDocumento.xml
+++ b/Core/XMLView/EditSecuenciaDocumento.xml
@@ -66,6 +66,9 @@
             <column name="use-gaps" numcolumns="2" order="130">
                 <widget type="checkbox" fieldname="usarhuecos"/>
             </column>
+            <column name="keep-date" numcolumns="2" order="135">
+                <widget type="checkbox" fieldname="mantenerfecha"/>
+            </column>
             <column name="pattern" order="140">
                 <widget type="text" fieldname="patron" maxlength="50" required="true"/>
             </column>

--- a/Test/Core/Model/SecuenciaDocumentoTest.php
+++ b/Test/Core/Model/SecuenciaDocumentoTest.php
@@ -505,6 +505,157 @@ final class SecuenciaDocumentoTest extends TestCase
         $this->assertTrue($customer->delete(), 'customer-cant-delete');
     }
 
+    public function testFillGapsChangesDateWhenMantenerfechaIsFalse(): void
+    {
+        // usamos una serie aleatoria para que no haya documentos previos que interfieran
+        $serie = $this->getRandomSerie();
+        $this->assertTrue($serie->save(), 'serie-cant-save');
+
+        // objeto fresco para la secuencia (sin estado de llamadas anteriores)
+        $sequence = new SecuenciaDocumento();
+        $sequence->codserie = $serie->codserie;
+        $sequence->idempresa = 1;
+        $sequence->inicio = 1;
+        $sequence->longnumero = 6;
+        $sequence->numero = 1;
+        $sequence->patron = 'PRE{EJE}{SERIE}{0NUM}';
+        $sequence->tipodoc = 'PresupuestoCliente';
+        $sequence->usarhuecos = true;
+        $sequence->mantenerfecha = false;
+        $this->assertTrue($sequence->save(), 'document-sequence-cant-save');
+
+        // creamos un cliente
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save(), 'customer-cant-save');
+
+        // usamos el año actual para que todos los documentos queden en el mismo ejercicio
+        $year = date('Y');
+
+        // creamos el primer presupuesto con fecha al inicio del año
+        $doc1 = new PresupuestoCliente();
+        $doc1->setSubject($customer);
+        $doc1->codserie = $serie->codserie;
+        $doc1->setDate('01-01-' . $year, '00:00:00');
+        $this->assertTrue($doc1->save(), 'document-cant-save');
+        $this->assertEquals(1, $doc1->numero, 'document-not-one');
+
+        // creamos el segundo presupuesto (lo borraremos para crear el hueco)
+        $doc2 = new PresupuestoCliente();
+        $doc2->setSubject($customer);
+        $doc2->codserie = $serie->codserie;
+        $doc2->setDate('15-01-' . $year, '00:00:00');
+        $this->assertTrue($doc2->save(), 'document-cant-save');
+        $this->assertEquals(2, $doc2->numero, 'document-not-two');
+
+        // creamos el tercer presupuesto para que el hueco quede en el medio
+        $doc3 = new PresupuestoCliente();
+        $doc3->setSubject($customer);
+        $doc3->codserie = $serie->codserie;
+        $doc3->setDate('20-01-' . $year, '00:00:00');
+        $this->assertTrue($doc3->save(), 'document-cant-save');
+        $this->assertEquals(3, $doc3->numero, 'document-not-three');
+
+        // eliminamos el segundo presupuesto: ahora hay un hueco en el número 2
+        $this->assertTrue($doc2->delete(), 'document-cant-delete');
+
+        // creamos un cuarto presupuesto con la fecha de hoy
+        $doc4 = new PresupuestoCliente();
+        $doc4->setSubject($customer);
+        $doc4->codserie = $serie->codserie;
+        $this->assertTrue($doc4->save(), 'document-cant-save');
+
+        // comprobamos que se le asigna el número 2 (rellena el hueco)
+        $this->assertEquals(2, $doc4->numero, 'document-not-two');
+
+        // con mantenerfecha=false la fecha SÍ se modifica: pasa a ser la del documento siguiente al hueco
+        // (el algoritmo recorre en orden descendente, así que $preDate es la fecha del doc con número mayor)
+        $this->assertEquals($doc3->fecha, $doc4->fecha, 'date-should-have-changed-to-next-doc-date');
+
+        // eliminamos
+        $this->assertTrue($doc4->delete(), 'document-cant-delete');
+        $this->assertTrue($doc3->delete(), 'document-cant-delete');
+        $this->assertTrue($doc1->delete(), 'document-cant-delete');
+        $this->assertTrue($sequence->delete(), 'document-sequence-cant-delete');
+        $this->assertTrue($customer->getDefaultAddress()->delete(), 'address-cant-delete');
+        $this->assertTrue($customer->delete(), 'customer-cant-delete');
+        $this->assertTrue($serie->delete(), 'serie-cant-delete');
+    }
+
+    public function testFillGapsKeepsDateWhenMantenerfechaIsTrue(): void
+    {
+        // usamos una serie aleatoria para que no haya documentos previos que interfieran
+        $serie = $this->getRandomSerie();
+        $this->assertTrue($serie->save(), 'serie-cant-save');
+
+        // objeto fresco para la secuencia (sin estado de llamadas anteriores)
+        $sequence = new SecuenciaDocumento();
+        $sequence->codserie = $serie->codserie;
+        $sequence->idempresa = 1;
+        $sequence->inicio = 1;
+        $sequence->longnumero = 6;
+        $sequence->numero = 1;
+        $sequence->patron = 'PRE{EJE}{SERIE}{0NUM}';
+        $sequence->tipodoc = 'PresupuestoCliente';
+        $sequence->usarhuecos = true;
+        $sequence->mantenerfecha = true;
+        $this->assertTrue($sequence->save(), 'document-sequence-cant-save');
+
+        // creamos un cliente
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save(), 'customer-cant-save');
+
+        // usamos el año actual para que todos los documentos queden en el mismo ejercicio
+        $year = date('Y');
+
+        // creamos el primer presupuesto con fecha al inicio del año
+        $doc1 = new PresupuestoCliente();
+        $doc1->setSubject($customer);
+        $doc1->codserie = $serie->codserie;
+        $doc1->setDate('01-01-' . $year, '00:00:00');
+        $this->assertTrue($doc1->save(), 'document-cant-save');
+        $this->assertEquals(1, $doc1->numero, 'document-not-one');
+
+        // creamos el segundo presupuesto (lo borraremos para crear el hueco)
+        $doc2 = new PresupuestoCliente();
+        $doc2->setSubject($customer);
+        $doc2->codserie = $serie->codserie;
+        $doc2->setDate('15-01-' . $year, '00:00:00');
+        $this->assertTrue($doc2->save(), 'document-cant-save');
+        $this->assertEquals(2, $doc2->numero, 'document-not-two');
+
+        // creamos el tercer presupuesto para que el hueco quede en el medio
+        $doc3 = new PresupuestoCliente();
+        $doc3->setSubject($customer);
+        $doc3->codserie = $serie->codserie;
+        $doc3->setDate('20-01-' . $year, '00:00:00');
+        $this->assertTrue($doc3->save(), 'document-cant-save');
+        $this->assertEquals(3, $doc3->numero, 'document-not-three');
+
+        // eliminamos el segundo presupuesto: ahora hay un hueco en el número 2
+        $this->assertTrue($doc2->delete(), 'document-cant-delete');
+
+        // creamos un cuarto presupuesto con la fecha de hoy
+        $doc4 = new PresupuestoCliente();
+        $doc4->setSubject($customer);
+        $doc4->codserie = $serie->codserie;
+        $this->assertTrue($doc4->save(), 'document-cant-save');
+
+        // comprobamos que se le asigna el número 2 (rellena el hueco)
+        $this->assertEquals(2, $doc4->numero, 'document-not-two');
+
+        // con mantenerfecha=true la fecha NO se modifica: sigue siendo la de hoy
+        $this->assertEquals(Tools::date(), $doc4->fecha, 'date-should-be-preserved');
+
+        // eliminamos
+        $this->assertTrue($doc4->delete(), 'document-cant-delete');
+        $this->assertTrue($doc3->delete(), 'document-cant-delete');
+        $this->assertTrue($doc1->delete(), 'document-cant-delete');
+        $this->assertTrue($sequence->delete(), 'document-sequence-cant-delete');
+        $this->assertTrue($customer->getDefaultAddress()->delete(), 'address-cant-delete');
+        $this->assertTrue($customer->delete(), 'customer-cant-delete');
+        $this->assertTrue($serie->delete(), 'serie-cant-delete');
+    }
+
     public function testWithExercisesAndWithout(): void
     {
         // eliminamos todas las secuencias de PresupuestoCliente


### PR DESCRIPTION
https://facturascripts.com/roadmap/1426
feat: añadir pruebas para el manejo de huecos en la secuencia de documentos

Abderra ya añadio el manejo de los huecos en el commit anterior
- Se implementaron dos pruebas en SecuenciaDocumentoTest.php:
  - testFillGapsChangesDateWhenMantenerfechaIsFalse: Verifica que al rellenar un hueco, la fecha se modifica si mantenerfecha es false.
  - testFillGapsKeepsDateWhenMantenerfechaIsTrue: Verifica que al rellenar un hueco, la fecha se conserva si mantenerfecha es true.