### PR TITLE
bugfix: devolver resources sin repetir al solicitar la api

### DIFF
--- a/Core/Controller/ApiRoot.php
+++ b/Core/Controller/ApiRoot.php
@@ -40,6 +40,11 @@ class ApiRoot extends ApiController
         self::$custom_resources[] = $name;
     }
 
+    public static function getCustomResources(): array
+    {
+        return self::$custom_resources;
+    }
+
     protected function exposeResources(array &$map): void
     {
         $json = ['resources' => self::$custom_resources];
@@ -47,15 +52,11 @@ class ApiRoot extends ApiController
             $json['resources'][] = $key;
         }
 
-        // ordenamos
+        // eliminamos duplicados y ordenamos
+        $json['resources'] = array_unique($json['resources']);
         sort($json['resources']);
 
         $this->response->json($json);
-    }
-
-    public static function getCustomResources(): array
-    {
-        return self::$custom_resources;
     }
 
     protected function getResourcesMap(): array


### PR DESCRIPTION
Algunos resources de la api se estaban repitiendo, porque no se tenía en cuenta que fuese un array de valores únicos.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.