### PR TITLE
tarea 3399

### DIFF
--- a/Core/Model/Base/PurchaseDocument.php
+++ b/Core/Model/Base/PurchaseDocument.php
@@ -190,6 +190,11 @@ abstract class PurchaseDocument extends TransformerDocument
         return 'codproveedor';
     }
 
+    public static function dontCopyFields(): array
+    {
+        return array_merge(parent::dontCopyFields(), ['numproveedor']);
+    }
+
     /**
      * Devuelve True si no hay errores en los valores de las propiedades.
      *


### PR DESCRIPTION
# Descripción
- Se ha añadido en los documentos de compra al array de `dontCopyFields` el campo `numproveedor` para que no se copie tal y como indica la tarea. Se ha comprobado aprobando un albarán y viendo que no se copia el campo.

https://facturascripts.com/roadmap/3399

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
