### PR TITLE
Añadido webp a thumbail de productos

### DIFF
--- a/Core/Model/ProductoImagen.php
+++ b/Core/Model/ProductoImagen.php
@@ -125,7 +125,7 @@ class ProductoImagen extends ModelClass
         // solo se generan miniaturas para gif, jpg, jpeg y png
         // (webp se ha excluido porque da problemas al embeberse en PDFs)
         $ext = pathinfo($file->getFullPath(), PATHINFO_EXTENSION);
-        if (false === in_array($ext, ['gif', 'jpg', 'jpeg', 'png'])) {
+        if (false === in_array($ext, ['gif', 'jpg', 'jpeg', 'png', 'webp'])) {
             return '';
         }
 
@@ -161,6 +161,10 @@ class ProductoImagen extends ModelClass
                 case 'jpg':
                 case 'jpeg':
                     imagejpeg($thumb, FS_FOLDER . $thumbFile, 90);
+                    break;
+
+                case 'webp':
+                    imagewebp($thumb, FS_FOLDER . $thumbFile, 90);
                     break;
 
                 case 'png':


### PR DESCRIPTION
# Descripción
Dado que los problemas de impresión son los mismos que los png con canal alpha transparente, pido añadir la generación de thumbails para mejorar el rendimiento en la impresión de pedidos con muchas lineas donde se imprimen los productos con su imagen.