### PR TITLE
Añadir validación de estado del documento en PurchasesController y SalesController

### DIFF
--- a/Core/Lib/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Lib/AjaxForms/CommonSalesPurchases.php
@@ -433,6 +433,7 @@ trait CommonSalesPurchases
             . '<div class="dropdown-menu dropdown-menu-right">' . implode('', $options) . '</div>'
             . '</div>'
             . '</div>'
+            . '<input type="hidden" name="idestado" value="' . $model->idestado . '">'
             . '</div>';
     }
 

--- a/Core/Lib/AjaxForms/PurchasesController.php
+++ b/Core/Lib/AjaxForms/PurchasesController.php
@@ -375,6 +375,14 @@ abstract class PurchasesController extends PanelController
 
         $model = $this->getModel();
         $formData = json_decode($this->request->input('data'), true);
+
+        if (isset($formData['idestado']) && (int)$formData['idestado'] !== $model->idestado) {
+            $this->db()->rollback();
+            Tools::log()->warning('document-state-changed');
+            $this->sendJsonWithLogs(['ok' => false]);
+            return false;
+        }
+
         PurchasesHeaderHTML::apply($model, $formData);
         PurchasesFooterHTML::apply($model, $formData);
 

--- a/Core/Lib/AjaxForms/PurchasesController.php
+++ b/Core/Lib/AjaxForms/PurchasesController.php
@@ -496,7 +496,11 @@ abstract class PurchasesController extends PanelController
             return false;
         }
 
-        if ($this->getModel()->editable && false === $this->saveDocAction(false)) {
+        $formData = json_decode($this->request->input('data'), true);
+        $currentModel = $this->getModel();
+        $formIdestado = isset($formData['idestado']) ? (int)$formData['idestado'] : $currentModel->idestado;
+
+        if ($currentModel->editable && $formIdestado === $currentModel->idestado && false === $this->saveDocAction(false)) {
             return false;
         }
 

--- a/Core/Lib/AjaxForms/SalesController.php
+++ b/Core/Lib/AjaxForms/SalesController.php
@@ -390,6 +390,14 @@ abstract class SalesController extends PanelController
 
         $model = $this->getModel();
         $formData = json_decode($this->request->input('data'), true);
+
+        if (isset($formData['idestado']) && (int)$formData['idestado'] !== $model->idestado) {
+            $this->db()->rollback();
+            Tools::log()->warning('document-state-changed');
+            $this->sendJsonWithLogs(['ok' => false]);
+            return false;
+        }
+
         SalesHeaderHTML::apply($model, $formData);
         SalesFooterHTML::apply($model, $formData);
 

--- a/Core/Lib/AjaxForms/SalesController.php
+++ b/Core/Lib/AjaxForms/SalesController.php
@@ -510,7 +510,11 @@ abstract class SalesController extends PanelController
             return false;
         }
 
-        if ($this->getModel()->editable && false === $this->saveDocAction(false)) {
+        $formData = json_decode($this->request->input('data'), true);
+        $currentModel = $this->getModel();
+        $formIdestado = isset($formData['idestado']) ? (int)$formData['idestado'] : $currentModel->idestado;
+
+        if ($currentModel->editable && $formIdestado === $currentModel->idestado && false === $this->saveDocAction(false)) {
             return false;
         }
 

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -480,6 +480,7 @@
     "default-retention": "Retención predeterminada",
     "default-role": "Grupo de usuario pred.",
     "default-status-non-editable": "El estado predeterminado no es editable",
+    "document-state-changed": "El estado del documento ha cambiado. Recarga la página antes de guardar.",
     "default-tax": "Impuesto predeterminado",
     "default-to-company-email": "Por defecto al email de la empresa",
     "default-to-config-email": "Por defecto al email de la configuración",


### PR DESCRIPTION
https://facturascripts.com/roadmap/4673
Se ha modificado la lógica de validación en los métodos de guardado de documentos en
PurchasesController y SalesController tanto para facturas emitidas, como recibidas. Ahora se verifica el estado del documento
antes de permitir la acción de guardado, asegurando que solo se guarden documentos editables con el estado correcto.
- Se agregó un campo oculto para el estado del documento en CommonSalesPurchases.php.
- Se implementó la validación del estado del documento en PurchasesController.php y SalesController.php.
- Se añadió un mensaje de advertencia en caso de que el estado del documento cambie.

Esto ayuda a prevenir la pérdida de datos al intentar guardar cambios en un documento cuyo estado ha cambiado.

- Modificado PurchasesController.php
- Modificado SalesController.php