### PR TITLE
fix: bug allow same codproveedor and refproveedor in 2 different prod…

### DIFF
--- a/Core/Model/ProductoProveedor.php
+++ b/Core/Model/ProductoProveedor.php
@@ -20,6 +20,7 @@
 namespace FacturaScripts\Core\Model;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Core\DataSrc\Divisas;
 use FacturaScripts\Core\Model\Base\ProductRelationTrait;
 use FacturaScripts\Core\Template\ModelClass;
@@ -183,6 +184,23 @@ class ProductoProveedor extends ModelClass
 
         $tasaConv = Divisas::get($this->coddivisa)->tasaconvcompra;
         $this->netoeuros = empty($tasaConv) ? 0 : round($this->neto / $tasaConv, 5);
+
+        // no puede existir otra referencia de proveedor con el mismo codproveedor + refproveedor apuntando a un producto distinto
+        $where = [
+            Where::eq('codproveedor', $this->codproveedor),
+            Where::eq('refproveedor', $this->refproveedor),
+            Where::notEq('referencia', $this->referencia),
+        ];
+        if (!empty($this->id)) {
+            $where[] = Where::notEq('id', $this->id);
+        }
+        if ($this->count($where) > 0) {
+            Tools::log()->warning('duplicated-supplier-reference', [
+                '%refproveedor%' => $this->refproveedor,
+                '%codproveedor%' => $this->codproveedor,
+            ]);
+            return false;
+        }
 
         return parent::test();
     }

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -578,6 +578,7 @@
     "duplicate-customer-name-or-cif": "A customer with the same name or VAT number exists",
     "duplicate-record": "Duplicated record",
     "duplicated-reference": "Reference '%reference%' duplicated",
+    "duplicated-supplier-reference": "Supplier reference '%refproveedor%' of supplier '%codproveedor%' is already linked to another product",
     "duplicated-request": "Duplicated request",
     "duration": "Duration",
     "edit": "Edit",

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -578,6 +578,7 @@
     "duplicate-customer-name-or-cif": "Existe un cliente con el mismo nombre o CIF\/NIF",
     "duplicate-record": "Registro duplicado",
     "duplicated-reference": "Referencia '%reference%' duplicada",
+    "duplicated-supplier-reference": "La referencia de proveedor '%refproveedor%' del proveedor '%codproveedor%' ya está vinculada a otro producto",
     "duplicated-request": "Petición duplicada",
     "duration": "Duración",
     "edit": "Editar",

--- a/Test/Core/Model/ProductoProveedorTest.php
+++ b/Test/Core/Model/ProductoProveedorTest.php
@@ -73,6 +73,48 @@ final class ProductoProveedorTest extends TestCase
         $this->assertTrue($proveedor->delete());
     }
 
+    /**
+     * No se debe permitir que la misma referencia de proveedor (refproveedor + codproveedor)
+     * esté vinculada a más de un producto distinto.
+     */
+    public function testCanNotCreateDuplicateRefproveedor(): void
+    {
+        // creamos un proveedor
+        $proveedor = $this->getRandomSupplier();
+        $this->assertTrue($proveedor->save());
+
+        // creamos dos productos distintos
+        $producto1 = $this->getRandomProduct();
+        $this->assertTrue($producto1->save());
+
+        $producto2 = $this->getRandomProduct();
+        $this->assertTrue($producto2->save());
+
+        // creamos un producto del proveedor para el producto1 con una refproveedor concreta
+        $productoProveedor1 = new ProductoProveedor();
+        $productoProveedor1->referencia = $producto1->referencia;
+        $productoProveedor1->codproveedor = $proveedor->codproveedor;
+        $productoProveedor1->refproveedor = 'ref-ext-duplicada';
+        $this->assertTrue($productoProveedor1->save());
+
+        // intentamos crear otro registro con el mismo codproveedor + refproveedor pero apuntando a otro producto
+        $productoProveedor2 = new ProductoProveedor();
+        $productoProveedor2->referencia = $producto2->referencia;
+        $productoProveedor2->codproveedor = $proveedor->codproveedor;
+        $productoProveedor2->refproveedor = 'ref-ext-duplicada';
+        $this->assertFalse(
+            $productoProveedor2->save(),
+            'No debe permitirse la misma refproveedor del mismo proveedor vinculada a dos productos distintos'
+        );
+
+        // eliminamos
+        $this->assertTrue($productoProveedor1->delete());
+        $this->assertTrue($producto1->delete());
+        $this->assertTrue($producto2->delete());
+        $this->assertTrue($proveedor->getDefaultAddress()->delete());
+        $this->assertTrue($proveedor->delete());
+    }
+
     public function testCantCreateWithoutReference(): void
     {
         // creamos un proveedor


### PR DESCRIPTION
# Descripción
- Modificado para que si intentar añadir a un producto el mismo codproveedor y mismo refproveedor entonces no te permita y suelte una warning.
- Añadido también un test que lo respalda.
https://facturascripts.com/roadmap/3494

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.