### PR TITLE
Tarea #605 - Validar cantidad pendiente al agrupar o partir

### DIFF
--- a/Core/Controller/DocumentStitcher.php
+++ b/Core/Controller/DocumentStitcher.php
@@ -112,6 +112,11 @@ class DocumentStitcher extends Controller
                 return;
             }
 
+            // Evita aprobar más cantidad de la que realmente queda pendiente en cada línea.
+            if (false === $this->validateSelectedQuantities()) {
+                return;
+            }
+
             // si el $statusCode empieza por close:, cerramos
             if (0 === strpos($statusCode, 'close:')) {
                 $status = substr($statusCode, 6);
@@ -449,5 +454,28 @@ class DocumentStitcher extends Controller
                 $this->moreDocuments[] = $doc;
             }
         }
+    }
+
+    protected function validateSelectedQuantities(): bool
+    {
+        foreach ($this->documents as $document) {
+            foreach ($document->getLines() as $line) {
+                $quantity = (float)$this->request->input('approve_quant_' . $line->id(), '0');
+
+                $pending = max(0, $line->cantidad - $line->servido);
+                if ($quantity <= $pending) {
+                    continue;
+                }
+
+                Tools::log()->error('error-more-quant-than-pending', [
+                    '%description%' => $line->descripcion,
+                    '%pending%' => $pending,
+                    '%selected_quantity%' => $quantity,
+                ]);
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Core/Translation/en_EN.json
+++ b/Core/Translation/en_EN.json
@@ -634,6 +634,7 @@
     "error-connecting-memcache": "Error connecting to Memcache server.",
     "error-creating-zip-file": "Error creating ZIP file",
     "error-deleting-lines": "Error deleting lines",
+    "error-more-quant-than-pending": "You cannot select a quantity greater than the pending quantity on the line. Check the line: '%description%', pending: '%pending%', selected qty: '%selected_quantity%'.",
     "error-generating-qr-code": "Could not generate QR: %message%, %url%",
     "error-generating-qr-code-url": "Error generating the QR code URL",
     "error-generating-secret-key": "Error generating secret key",

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -634,6 +634,7 @@
     "error-connecting-memcache": "Error al conectar con el servidor Memcache.",
     "error-creating-zip-file": "Error al crear el archivo ZIP",
     "error-deleting-lines": "Error al eliminar líneas",
+    "error-more-quant-than-pending": "No se puede seleccionar una cantidad superior a la pendiente de la linea. Revise la linea: '%description%', pendiente: '%pending%', cant. seleccionada: '%selected_quantity%'.",
     "error-generating-qr-code": "No se pudo generar el QR: %message%, %url%",
     "error-generating-qr-code-url": "Error al generar la URL del código QR",
     "error-generating-secret-key": "Error al generar la clave secreta",

--- a/Core/View/DocumentStitcher.html.twig
+++ b/Core/View/DocumentStitcher.html.twig
@@ -333,11 +333,11 @@
                             <input type="number" value="{{ line.servido }}" class="form-control text-end"
                                    readonly="true" tabindex="-1"/>
                         </td>
-                        {% set newQuantity = line.cantidad - line.servido %}
+                        {% set newQuantity = line.cantidad - line.servido > 0 ? line.cantidad - line.servido : 0 %}
                         <td class="{{ newQuantity == 0 ? 'table-warning' : 'table-success' }}">
                             <input type="hidden" class="to_serve" value="{{ newQuantity }}"/>
                             <input type="number" name="approve_quant_{{ line.primaryColumnValue() }}"
-                                   value="{{ newQuantity }}" step="any" min="0" max="{{ line.cantidad }}"
+                                   value="{{ newQuantity }}" step="any" min="0" max="{{ newQuantity }}"
                                    class="form-control text-end to_be_served" autocomplete="off"/>
                         </td>
                     </tr>

--- a/Test/Core/Controller/DocumentStitcherTest.php
+++ b/Test/Core/Controller/DocumentStitcherTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Controller;
+
+use FacturaScripts\Core\Base\ControllerPermissions;
+use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Controller\DocumentStitcher;
+use FacturaScripts\Core\Request;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+
+final class DocumentStitcherTest extends TestCase
+{
+    use DefaultSettingsTrait;
+    use LogErrorsTrait;
+    use RandomDataTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::setDefaultSettings();
+    }
+
+    public function testPrivateCoreRejectsQuantityGreaterThanPending(): void
+    {
+        $customer = $this->getRandomCustomer();
+        $this->assertTrue($customer->save(), 'can-not-save-customer');
+
+        $doc = new \FacturaScripts\Dinamic\Model\PedidoCliente();
+        $doc->setSubject($customer);
+        $this->assertTrue($doc->save(), 'can-not-save-document');
+
+        $line = $doc->getNewLine();
+        $line->cantidad = 10;
+        $line->servido = 8;
+        $line->pvpunitario = 100;
+        $this->assertTrue($line->save(), 'can-not-save-line');
+
+        $statusId = 0;
+        foreach ($doc->getAvailableStatus() as $status) {
+            if (empty($status->generadoc)) {
+                continue;
+            }
+
+            $statusId = (int)$status->idestado;
+            break;
+        }
+        $this->assertGreaterThan(0, $statusId, 'missing-generating-status');
+
+        $user = $this->getRandomUser();
+        $user->admin = true;
+        $this->assertTrue($user->save(), 'can-not-save-user');
+
+        $controller = new DocumentStitcher('DocumentStitcher', '/DocumentStitcher');
+        $controller->multiRequestProtection->clearSeed();
+        $controller->multiRequestProtection->addSeed($user->nick);
+        $token = $controller->multiRequestProtection->newToken();
+        $controller->multiRequestProtection->clearSeed();
+        $controller->request = new Request([
+            'request' => [
+                'codes' => [$doc->id()],
+                'model' => 'PedidoCliente',
+                'multireqtoken' => $token,
+                'status' => (string)$statusId,
+                'approve_quant_' . $line->id() => '5',
+            ],
+        ]);
+
+        try {
+            $response = new Response();
+            $permissions = new ControllerPermissions($user, 'DocumentStitcher');
+            $controller->privateCore($response, $user, $permissions);
+
+            $this->assertEquals(8.0, (float)$doc->getLines()[0]->servido, 'line-served-quantity-changed');
+            $this->assertEmpty($doc->childrenDocuments(), 'generated-document-with-invalid-quantity');
+        } finally {
+            // eliminamos
+            foreach ($doc->childrenDocuments() as $child) {
+                $this->assertTrue($child->delete(), 'can-not-delete-child-document');
+            }
+
+            $this->assertTrue($doc->delete(), 'can-not-delete-document');
+            $this->assertTrue($user->delete(), 'can-not-delete-user');
+            $this->assertTrue($customer->getDefaultAddress()->delete(), 'can-not-delete-address');
+            $this->assertTrue($customer->delete(), 'can-not-delete-customer');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        MiniLog::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}


### PR DESCRIPTION
## Descripcion
- evita aprobar una cantidad superior a la pendiente en el asistente de agrupar o partir documentos.
- valida en servidor usando la cantidad pendiente de cada linea (`cantidad - servido`).
- ajusta el maximo del input en la vista para limitar la seleccion en cliente.
- añade un test de integracion para el caso de una linea parcialmente servida.

## Pruebas
- [x] He revisado mi codigo antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacia.
- [x] He ejecutado los tests unitarios.