### PR TITLE
Tarea #2719 - contador de descargas en adjuntos

### DIFF
--- a/Core/Controller/Myfiles.php
+++ b/Core/Controller/Myfiles.php
@@ -19,9 +19,11 @@
 
 namespace FacturaScripts\Core\Controller;
 
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Contract\ControllerInterface;
 use FacturaScripts\Core\KernelException;
 use FacturaScripts\Core\Lib\MyFilesToken;
+use FacturaScripts\Core\Model\AttachedFile;
 use FacturaScripts\Core\Tools;
 
 /**
@@ -70,10 +72,12 @@ class Myfiles implements ControllerInterface
 
         // obtenemos el parámetro myft
         $fixedFilePath = substr($decodedUrl, 1);
-        $token = filter_input(INPUT_GET, 'myft');
+        $token = $this->getQueryString('myft');
         if (empty($token) || false === MyFilesToken::validate($fixedFilePath, $token)) {
             throw new KernelException('MyfilesTokenError', $fixedFilePath);
         }
+
+        $this->increaseDownloadCount($fixedFilePath);
     }
 
     public function getPageData(): array
@@ -133,6 +137,40 @@ class Myfiles implements ControllerInterface
         }
 
         return mime_content_type($filePath);
+    }
+
+    private function getQueryBool(string $key): ?bool
+    {
+        if (array_key_exists($key, $_GET)) {
+            return filter_var($_GET[$key], FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+        }
+
+        return filter_input(INPUT_GET, $key, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+    }
+
+    private function getQueryString(string $key): ?string
+    {
+        if (array_key_exists($key, $_GET)) {
+            return is_scalar($_GET[$key]) ? (string)$_GET[$key] : null;
+        }
+
+        $value = filter_input(INPUT_GET, $key);
+        return is_string($value) ? $value : null;
+    }
+
+    private function increaseDownloadCount(string $path): void
+    {
+        if ($this->getQueryBool('embed') === true) {
+            return;
+        }
+
+        $attachedFile = new AttachedFile();
+        if (false === $attachedFile->loadFromCode('', [new DataBaseWhere('path', $path)])) {
+            return;
+        }
+
+        $attachedFile->downloads++;
+        $attachedFile->save();
     }
 
     private function shouldForceDownload(string $filePath): bool

--- a/Core/Model/AttachedFile.php
+++ b/Core/Model/AttachedFile.php
@@ -59,12 +59,16 @@ class AttachedFile extends ModelClass
     public $path;
 
     /** @var int */
+    public $downloads;
+
+    /** @var int */
     public $size;
 
     public function clear(): void
     {
         parent::clear();
         $this->date = Tools::date();
+        $this->downloads = 0;
         $this->hour = Tools::hour();
         $this->size = 0;
     }

--- a/Core/Table/attached_files.xml
+++ b/Core/Table/attached_files.xml
@@ -35,6 +35,11 @@
         <null>NO</null>
     </column>
     <column>
+        <name>downloads</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
         <name>size</name>
         <type>integer</type>
         <null>NO</null>

--- a/Core/View/Tab/AttachedFilePreview.html.twig
+++ b/Core/View/Tab/AttachedFilePreview.html.twig
@@ -22,20 +22,20 @@
     {% elseif file.isVideo() %}
         <div class="ratio ratio-16x9">
             <video controls aria-label="{{ trans('video-player') }}: {{ file.filename }}">
-                <source src="{{ asset(file.url('download-permanent')) }}" type="video/{{ file.getExtension() }}" />
+                <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/{{ file.getExtension() }}" />
                 {% if file.getExtension() == 'mp4' %}
-                    <source src="{{ asset(file.url('download-permanent')) }}" type="video/mp4" />
+                    <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/mp4" />
                 {% elseif file.getExtension() == 'webm' %}
-                    <source src="{{ asset(file.url('download-permanent')) }}" type="video/webm" />
+                    <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/webm" />
                 {% elseif file.getExtension() == 'ogg' or file.getExtension() == 'ogv' %}
-                    <source src="{{ asset(file.url('download-permanent')) }}" type="video/ogg" />
+                    <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/ogg" />
                 {% endif %}
                 {{ trans('video-not-supported') }}
             </video>
         </div>
     {% elseif file.getExtension() == 'pdf' %}
         <div class="ratio ratio-4x3">
-            <embed src="{{ asset(file.url('download-permanent')) }}" type="application/pdf" aria-label="{{ trans('pdf-viewer') }}: {{ file.filename }}" />
+            <embed src="{{ asset(file.url('download-permanent')) }}&embed=true" type="application/pdf" aria-label="{{ trans('pdf-viewer') }}: {{ file.filename }}" />
         </div>
     {% elseif file.getExtension() in ['txt', 'log', 'md', 'csv'] %}
         <div class="card-body">

--- a/Core/XMLView/EditAttachedFile.xml
+++ b/Core/XMLView/EditAttachedFile.xml
@@ -34,10 +34,13 @@
             <column name="size" numcolumns="3" order="140">
                 <widget type="number" fieldname="size" readonly="true" />
             </column>
-            <column name="date" numcolumns="3" order="150">
+            <column name="downloads" numcolumns="3" order="150">
+                <widget type="number" fieldname="downloads" readonly="true" />
+            </column>
+            <column name="date" numcolumns="3" order="160">
                 <widget type="date" fieldname="date" readonly="true" />
             </column>
-            <column name="hour" numcolumns="3" order="160">
+            <column name="hour" numcolumns="3" order="170">
                 <widget type="text" fieldname="hour" readonly="true" />
             </column>
         </group>

--- a/Core/XMLView/ListAttachedFile.xml
+++ b/Core/XMLView/ListAttachedFile.xml
@@ -36,10 +36,13 @@
         <column name="size" display="right" order="140">
             <widget type="bytes" fieldname="size" decimal="0"/>
         </column>
-        <column name="date" display="right" order="150">
+        <column name="downloads" display="right" order="150">
+            <widget type="number" fieldname="downloads" decimal="0"/>
+        </column>
+        <column name="date" display="right" order="160">
             <widget type="date" fieldname="date"/>
         </column>
-        <column name="hour" display="right" order="160">
+        <column name="hour" display="right" order="170">
             <widget type="text" fieldname="hour"/>
         </column>
     </columns>

--- a/Test/Core/Controller/StaticFilesTest.php
+++ b/Test/Core/Controller/StaticFilesTest.php
@@ -22,6 +22,7 @@ namespace FacturaScripts\Test\Core\Controller;
 use FacturaScripts\Core\Controller\Files;
 use FacturaScripts\Core\Controller\Myfiles;
 use FacturaScripts\Core\KernelException;
+use FacturaScripts\Core\Model\AttachedFile;
 use FacturaScripts\Core\Tools;
 use PHPUnit\Framework\TestCase;
 
@@ -79,10 +80,60 @@ final class StaticFilesTest extends TestCase
         new Myfiles('Myfiles', '/MyFiles/Public/' . self::$testFolder . '/public.pdf');
     }
 
+    public function testMyfilesControllerCountsRealDownloads(): void
+    {
+        $file = $this->createAttachedFile('download.pdf');
+        $_GET['myft'] = $this->getTokenFromUrl($file->url('download-permanent'));
+
+        try {
+            new Myfiles('Myfiles', '/' . $file->path);
+            $reloaded = new AttachedFile();
+            $this->assertTrue($reloaded->loadFromCode($file->idfile), 'attached-file-not-found');
+            $this->assertEquals(1, $reloaded->downloads, 'download-counter-not-incremented');
+        } finally {
+            unset($_GET['myft'], $_GET['embed']);
+            $this->assertTrue($file->delete(), 'can-not-delete-attached-file');
+        }
+    }
+
+    public function testMyfilesControllerIgnoresEmbeddedPreviewDownloads(): void
+    {
+        $file = $this->createAttachedFile('preview.pdf');
+        $_GET['myft'] = $this->getTokenFromUrl($file->url('download-permanent'));
+        $_GET['embed'] = 'true';
+
+        try {
+            new Myfiles('Myfiles', '/' . $file->path);
+            $reloaded = new AttachedFile();
+            $this->assertTrue($reloaded->loadFromCode($file->idfile), 'attached-file-not-found');
+            $this->assertEquals(0, $reloaded->downloads, 'embed-preview-counted-as-download');
+        } finally {
+            unset($_GET['myft'], $_GET['embed']);
+            $this->assertTrue($file->delete(), 'can-not-delete-attached-file');
+        }
+    }
+
     private function createFile(string ...$path): void
     {
         $filePath = Tools::folder(...$path);
         Tools::folderCheckOrCreate(dirname($filePath));
         file_put_contents($filePath, 'test');
+    }
+
+    private function createAttachedFile(string $name): AttachedFile
+    {
+        $name = uniqid('', true) . '_' . $name;
+        $this->createFile('MyFiles', $name);
+
+        $file = new AttachedFile();
+        $file->path = $name;
+        $this->assertTrue($file->save(), 'can-not-save-attached-file');
+        return $file;
+    }
+
+    private function getTokenFromUrl(string $url): string
+    {
+        parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $query);
+        return $query['myft'] ?? '';
     }
 }


### PR DESCRIPTION
## Descripcion
- añade un contador de descargas a los archivos adjuntos.
- incrementa el contador en `Myfiles` cuando la descarga corresponde a un adjunto real.
- excluye las previsualizaciones embebidas (`embed=true`) de video y PDF para no contarlas como descarga.
- muestra el contador en las vistas de editar y listar adjuntos.
- añade tests del controlador para descarga real y preview embebida.

## Pruebas
- [x] He revisado mi codigo antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [x] He probado que funciona correctamente con una base de datos vacia.
- [x] He ejecutado los tests unitarios.

### Tests ejecutados
- `vendor\bin\phpunit.bat -c phpunit.xml --filter testMyfilesControllerCountsRealDownloads`
- `vendor\bin\phpunit.bat -c phpunit.xml --filter testMyfilesControllerIgnoresEmbeddedPreviewDownloads`

### Nota
- `StaticFilesTest` ya tenia un fallo previo no relacionado en `testFilesControllerAcceptsSafePluginFile`, por eso las comprobaciones se ejecutaron filtrando solo los tests nuevos.