### PR TITLE
Add download counter for attached files

### DIFF
--- a/Core/Controller/Myfiles.php
+++ b/Core/Controller/Myfiles.php
@@ -22,7 +22,10 @@ namespace FacturaScripts\Core\Controller;
 use FacturaScripts\Core\Contract\ControllerInterface;
 use FacturaScripts\Core\KernelException;
 use FacturaScripts\Core\Lib\MyFilesToken;
+use FacturaScripts\Core\Model\AttachedFile;
+use FacturaScripts\Core\Request;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
 
 /**
  * Controlador para servir archivos de MyFiles, aplicando tokens salvo en la carpeta pública.
@@ -70,10 +73,12 @@ class Myfiles implements ControllerInterface
 
         // obtenemos el parámetro myft
         $fixedFilePath = substr($decodedUrl, 1);
-        $token = filter_input(INPUT_GET, 'myft');
+        $token = Request::createFromGlobals()->query->get('myft');
         if (empty($token) || false === MyFilesToken::validate($fixedFilePath, $token)) {
             throw new KernelException('MyfilesTokenError', $fixedFilePath);
         }
+
+        $this->increaseDownloadCount($fixedFilePath);
     }
 
     public function getPageData(): array
@@ -133,6 +138,25 @@ class Myfiles implements ControllerInterface
         }
 
         return mime_content_type($filePath);
+    }
+
+    // Este método solo suma descargas reales.
+    // Las previsualizaciones embebidas usan la misma ruta con embed=true
+    // para evitar que el contador sume solo al mostrar el archivo.
+    private function increaseDownloadCount(string $path): void
+    {
+        $request = Request::createFromGlobals();
+        if ($request->query->getBool('embed') === true) {
+            return;
+        }
+
+        $attachedFile = new AttachedFile();
+        if (false === $attachedFile->loadWhere([Where::eq('path', $path)])) {
+            return;
+        }
+
+        $attachedFile->downloads++;
+        $attachedFile->save();
     }
 
     private function shouldForceDownload(string $filePath): bool

--- a/Core/Controller/Myfiles.php
+++ b/Core/Controller/Myfiles.php
@@ -41,6 +41,8 @@ class Myfiles implements ControllerInterface
             return;
         }
 
+        $request = Request::createFromGlobals();
+
         // ¿La url empieza por /MyFiles/?
         if (strpos($url, '/MyFiles/') !== 0) {
             return;
@@ -73,12 +75,12 @@ class Myfiles implements ControllerInterface
 
         // obtenemos el parámetro myft
         $fixedFilePath = substr($decodedUrl, 1);
-        $token = filter_input(INPUT_GET, 'myft');
+        $token = $request->query->get('myft');
         if (empty($token) || false === MyFilesToken::validate($fixedFilePath, $token)) {
             throw new KernelException('MyfilesTokenError', $fixedFilePath);
         }
 
-        $this->increaseDownloadCount($fixedFilePath);
+        $this->increaseDownloadCount($request, $fixedFilePath);
     }
 
     public function getPageData(): array
@@ -143,9 +145,8 @@ class Myfiles implements ControllerInterface
     // Este método solo suma descargas reales.
     // Las previsualizaciones embebidas usan la misma ruta con embed=true
     // para evitar que el contador sume solo al mostrar el archivo.
-    private function increaseDownloadCount(string $path): void
+    private function increaseDownloadCount(Request $request, string $path): void
     {
-        $request = Request::createFromGlobals();
         if ($request->query->getBool('embed') === true) {
             return;
         }

--- a/Core/Controller/Myfiles.php
+++ b/Core/Controller/Myfiles.php
@@ -73,7 +73,7 @@ class Myfiles implements ControllerInterface
 
         // obtenemos el parámetro myft
         $fixedFilePath = substr($decodedUrl, 1);
-        $token = Request::createFromGlobals()->query->get('myft');
+        $token = filter_input(INPUT_GET, 'myft');
         if (empty($token) || false === MyFilesToken::validate($fixedFilePath, $token)) {
             throw new KernelException('MyfilesTokenError', $fixedFilePath);
         }

--- a/Core/Model/AttachedFile.php
+++ b/Core/Model/AttachedFile.php
@@ -19,12 +19,12 @@
 
 namespace FacturaScripts\Core\Model;
 
-use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Cache;
 use FacturaScripts\Core\Lib\MyFilesToken;
 use FacturaScripts\Core\Template\ModelClass;
 use FacturaScripts\Core\Template\ModelTrait;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
 use finfo;
 
 /**
@@ -59,12 +59,16 @@ class AttachedFile extends ModelClass
     public $path;
 
     /** @var int */
+    public $downloads;
+
+    /** @var int */
     public $size;
 
     public function clear(): void
     {
         parent::clear();
         $this->date = Tools::date();
+        $this->downloads = 0;
         $this->hour = Tools::hour();
         $this->size = 0;
     }
@@ -79,7 +83,7 @@ class AttachedFile extends ModelClass
         }
 
         // eliminamos las relaciones con los productos
-        $where = [new DataBaseWhere('idfile', $this->idfile)];
+        $where = [Where::eq('idfile', $this->idfile)];
         foreach (ProductoImagen::all($where, [], 0, 0) as $productoImage) {
             $productoImage->delete();
         }

--- a/Core/Table/attached_files.xml
+++ b/Core/Table/attached_files.xml
@@ -35,6 +35,11 @@
         <null>NO</null>
     </column>
     <column>
+        <name>downloads</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
         <name>size</name>
         <type>integer</type>
         <null>NO</null>

--- a/Core/View/Tab/AttachedFilePreview.html.twig
+++ b/Core/View/Tab/AttachedFilePreview.html.twig
@@ -22,20 +22,20 @@
     {% elseif file.isVideo() %}
         <div class="ratio ratio-16x9">
             <video controls aria-label="{{ trans('video-player') }}: {{ file.filename }}">
-                <source src="{{ asset(file.url('download-permanent')) }}" type="video/{{ file.getExtension() }}" />
+                <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/{{ file.getExtension() }}" />
                 {% if file.getExtension() == 'mp4' %}
-                    <source src="{{ asset(file.url('download-permanent')) }}" type="video/mp4" />
+                    <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/mp4" />
                 {% elseif file.getExtension() == 'webm' %}
-                    <source src="{{ asset(file.url('download-permanent')) }}" type="video/webm" />
+                    <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/webm" />
                 {% elseif file.getExtension() == 'ogg' or file.getExtension() == 'ogv' %}
-                    <source src="{{ asset(file.url('download-permanent')) }}" type="video/ogg" />
+                    <source src="{{ asset(file.url('download-permanent')) }}&embed=true" type="video/ogg" />
                 {% endif %}
                 {{ trans('video-not-supported') }}
             </video>
         </div>
     {% elseif file.getExtension() == 'pdf' %}
         <div class="ratio ratio-4x3">
-            <embed src="{{ asset(file.url('download-permanent')) }}" type="application/pdf" aria-label="{{ trans('pdf-viewer') }}: {{ file.filename }}" />
+            <embed src="{{ asset(file.url('download-permanent')) }}&embed=true" type="application/pdf" aria-label="{{ trans('pdf-viewer') }}: {{ file.filename }}" />
         </div>
     {% elseif file.getExtension() in ['txt', 'log', 'md', 'csv'] %}
         <div class="card-body">

--- a/Core/XMLView/EditAttachedFile.xml
+++ b/Core/XMLView/EditAttachedFile.xml
@@ -34,10 +34,13 @@
             <column name="size" numcolumns="3" order="140">
                 <widget type="number" fieldname="size" readonly="true" />
             </column>
-            <column name="date" numcolumns="3" order="150">
+            <column name="downloads" numcolumns="3" order="150">
+                <widget type="number" fieldname="downloads" readonly="true" />
+            </column>
+            <column name="date" numcolumns="3" order="160">
                 <widget type="date" fieldname="date" readonly="true" />
             </column>
-            <column name="hour" numcolumns="3" order="160">
+            <column name="hour" numcolumns="3" order="170">
                 <widget type="text" fieldname="hour" readonly="true" />
             </column>
         </group>

--- a/Core/XMLView/ListAttachedFile.xml
+++ b/Core/XMLView/ListAttachedFile.xml
@@ -36,10 +36,13 @@
         <column name="size" display="right" order="140">
             <widget type="bytes" fieldname="size" decimal="0"/>
         </column>
-        <column name="date" display="right" order="150">
+        <column name="downloads" display="right" order="150">
+            <widget type="number" fieldname="downloads" decimal="0"/>
+        </column>
+        <column name="date" display="right" order="160">
             <widget type="date" fieldname="date"/>
         </column>
-        <column name="hour" display="right" order="160">
+        <column name="hour" display="right" order="170">
             <widget type="text" fieldname="hour"/>
         </column>
     </columns>

--- a/Test/Core/Controller/StaticFilesTest.php
+++ b/Test/Core/Controller/StaticFilesTest.php
@@ -22,7 +22,9 @@ namespace FacturaScripts\Test\Core\Controller;
 use FacturaScripts\Core\Controller\Files;
 use FacturaScripts\Core\Controller\Myfiles;
 use FacturaScripts\Core\KernelException;
+use FacturaScripts\Core\Model\AttachedFile;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
 use PHPUnit\Framework\TestCase;
 
 final class StaticFilesTest extends TestCase
@@ -79,10 +81,60 @@ final class StaticFilesTest extends TestCase
         new Myfiles('Myfiles', '/MyFiles/Public/' . self::$testFolder . '/public.pdf');
     }
 
+    public function testMyfilesControllerCountsRealDownloads(): void
+    {
+        $file = $this->createAttachedFile('download.pdf');
+        $_GET['myft'] = $this->getTokenFromUrl($file->url('download-permanent'));
+
+        try {
+            new Myfiles('Myfiles', '/' . $file->path);
+            $storedFile = new AttachedFile();
+            $this->assertTrue($storedFile->load($file->idfile), 'attached-file-not-found');
+            $this->assertEquals(1, $storedFile->downloads, 'download-counter-not-incremented');
+        } finally {
+            unset($_GET['myft'], $_GET['embed']);
+            $this->assertTrue($file->delete(), 'can-not-delete-attached-file');
+        }
+    }
+
+    public function testMyfilesControllerIgnoresEmbeddedPreviewDownloads(): void
+    {
+        $file = $this->createAttachedFile('preview.pdf');
+        $_GET['myft'] = $this->getTokenFromUrl($file->url('download-permanent'));
+        $_GET['embed'] = 'true';
+
+        try {
+            new Myfiles('Myfiles', '/' . $file->path);
+            $storedFile = new AttachedFile();
+            $this->assertTrue($storedFile->loadWhere([Where::eq('idfile', $file->idfile)]), 'attached-file-not-found');
+            $this->assertEquals(0, $storedFile->downloads, 'embed-preview-counted-as-download');
+        } finally {
+            unset($_GET['myft'], $_GET['embed']);
+            $this->assertTrue($file->delete(), 'can-not-delete-attached-file');
+        }
+    }
+
     private function createFile(string ...$path): void
     {
         $filePath = Tools::folder(...$path);
         Tools::folderCheckOrCreate(dirname($filePath));
         file_put_contents($filePath, 'test');
+    }
+
+    private function createAttachedFile(string $name): AttachedFile
+    {
+        $name = uniqid('', true) . '_' . $name;
+        $this->createFile('MyFiles', $name);
+
+        $file = new AttachedFile();
+        $file->path = $name;
+        $this->assertTrue($file->save(), 'can-not-save-attached-file');
+        return $file;
+    }
+
+    private function getTokenFromUrl(string $url): string
+    {
+        parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $query);
+        return $query['myft'] ?? '';
     }
 }


### PR DESCRIPTION
## Summary
- add a downloads counter to attached files and show it in edit/list views
- increment the counter only for real downloads from MyFiles and ignore embedded preview requests
- cover the new Myfiles behavior with controller tests

esto lo cambio para que me pasen los tests porque en cli no funciona filter_input(INPUT_GET, 'myft')
$token = filter_input(INPUT_GET, 'myft');
$token = $request->query->get('myft');
