### PR TITLE
Tarea #851 agregar pagada y forma pago devoluciones

### DIFF
--- a/Core/Controller/EditFacturaCliente.php
+++ b/Core/Controller/EditFacturaCliente.php
@@ -6,6 +6,7 @@
 namespace FacturaScripts\Core\Controller;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\DataSrc\FormasPago;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Lib\Accounting\InvoiceToAccounting;
@@ -28,6 +29,13 @@ class EditFacturaCliente extends SalesController
     public function getModelClassName(): string
     {
         return 'FacturaCliente';
+    }
+
+    public function paymentMethods(): array
+    {
+        return array_filter(FormasPago::all(), function ($method) {
+            return $method->activa;
+        });
     }
 
     public function getPageData(): array
@@ -361,17 +369,26 @@ class EditFacturaCliente extends SalesController
             return true;
         }
 
-        // si la factura estaba pagada, marcamos los recibos de la nueva como pagados
-        if ($invoice->pagada) {
-            foreach ($newRefund->getReceipts() as $receipt) {
-                $receipt->pagado = true;
-                $receipt->save();
-            }
+        if (false === $this->updateRefundInvoicePayment(
+            $invoice,
+            $this->request->input('codpago_original', $invoice->codpago),
+            $this->request->input('pagada_original', false)
+        )) {
+            Tools::log()->error('record-save-error');
+            $this->dataBase->rollback();
+            return true;
         }
 
-        // asignamos el estado de la factura
+        $codpagoRectificativa = $this->request->input('codpago_rectificativa', $newRefund->codpago);
         $newRefund->idestado = $this->request->input('idestado');
+
         if (false === $newRefund->save()) {
+            Tools::log()->error('record-save-error');
+            $this->dataBase->rollback();
+            return true;
+        }
+
+        if (false === $this->updateRefundInvoicePayment($newRefund, $codpagoRectificativa, $this->request->input('pagada_rectificativa', false))) {
             Tools::log()->error('record-save-error');
             $this->dataBase->rollback();
             return true;
@@ -381,6 +398,24 @@ class EditFacturaCliente extends SalesController
         Tools::log()->notice('record-updated-correctly');
         $this->redirect($newRefund->url() . '&action=save-ok');
         return false;
+    }
+
+    private function updateRefundInvoicePayment(FacturaCliente $invoice, string $codpago, bool $paid): bool
+    {
+        if (false === $invoice->savePaymentMethod($codpago)) {
+            return false;
+        }
+
+        foreach ($invoice->getReceipts() as $receipt) {
+            $receipt->setPaymentMethod($codpago);
+            $receipt->pagado = $paid;
+            if (false === $receipt->save()) {
+                return false;
+            }
+        }
+
+        $invoice->reload();
+        return true;
     }
 
     /**

--- a/Core/Controller/EditFacturaProveedor.php
+++ b/Core/Controller/EditFacturaProveedor.php
@@ -6,6 +6,7 @@
 namespace FacturaScripts\Core\Controller;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\DataSrc\FormasPago;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Lib\Accounting\InvoiceToAccounting;
@@ -29,6 +30,13 @@ class EditFacturaProveedor extends PurchasesController
     public function getModelClassName(): string
     {
         return 'FacturaProveedor';
+    }
+
+    public function paymentMethods(): array
+    {
+        return array_filter(FormasPago::all(), function ($method) {
+            return $method->activa;
+        });
     }
 
     public function getPageData(): array
@@ -364,17 +372,26 @@ class EditFacturaProveedor extends PurchasesController
             return true;
         }
 
-        // si la factura estaba pagada, marcamos los recibos de la nueva como pagados
-        if ($invoice->pagada) {
-            foreach ($newRefund->getReceipts() as $receipt) {
-                $receipt->pagado = true;
-                $receipt->save();
-            }
+        if (false === $this->updateRefundInvoicePayment(
+            $invoice,
+            $this->request->input('codpago_original', $invoice->codpago),
+            $this->request->input('pagada_original', false)
+        )) {
+            Tools::log()->error('record-save-error');
+            $this->dataBase->rollback();
+            return true;
         }
 
-        // asignamos el estado de la factura
+        $codpagoRectificativa = $this->request->input('codpago_rectificativa', $newRefund->codpago);
         $newRefund->idestado = $this->request->input('idestado');
+
         if (false === $newRefund->save()) {
+            Tools::log()->error('record-save-error');
+            $this->dataBase->rollback();
+            return true;
+        }
+
+        if (false === $this->updateRefundInvoicePayment($newRefund, $codpagoRectificativa, $this->request->input('pagada_rectificativa', false))) {
             Tools::log()->error('record-save-error');
             $this->dataBase->rollback();
             return true;
@@ -384,6 +401,24 @@ class EditFacturaProveedor extends PurchasesController
         Tools::log()->notice('record-updated-correctly');
         $this->redirect($newRefund->url() . '&action=save-ok');
         return false;
+    }
+
+    private function updateRefundInvoicePayment(FacturaProveedor $invoice, string $codpago, bool $paid): bool
+    {
+        if (false === $invoice->savePaymentMethod($codpago)) {
+            return false;
+        }
+
+        foreach ($invoice->getReceipts() as $receipt) {
+            $receipt->setPaymentMethod($codpago);
+            $receipt->pagado = $paid;
+            if (false === $receipt->save()) {
+                return false;
+            }
+        }
+
+        $invoice->reload();
+        return true;
     }
 
     /**

--- a/Core/Model/FacturaCliente.php
+++ b/Core/Model/FacturaCliente.php
@@ -139,6 +139,20 @@ class FacturaCliente extends SalesDocument
         return 'facturascli';
     }
 
+    public function savePaymentMethod(string $codpago): bool
+    {
+        $formaPago = new FormaPago();
+        if (false === $formaPago->load($codpago)) {
+            return false;
+        }
+
+        if (false === $this->update(['codpago' => $codpago])) {
+            return false;
+        }
+
+        return $this->reload();
+    }
+
     protected function saveInsert(): bool
     {
         return $this->testDate() && parent::saveInsert();

--- a/Core/Model/FacturaProveedor.php
+++ b/Core/Model/FacturaProveedor.php
@@ -133,6 +133,20 @@ class FacturaProveedor extends PurchaseDocument
         return 'facturasprov';
     }
 
+    public function savePaymentMethod(string $codpago): bool
+    {
+        $formaPago = new FormaPago();
+        if (false === $formaPago->load($codpago)) {
+            return false;
+        }
+
+        if (false === $this->update(['codpago' => $codpago])) {
+            return false;
+        }
+
+        return $this->reload();
+    }
+
     protected function testDate(): bool
     {
         return true;

--- a/Core/Translation/es_ES.json
+++ b/Core/Translation/es_ES.json
@@ -1095,6 +1095,8 @@
     "mailer": "Controlador de correo",
     "main-address": "Dirección principal",
     "make-invoice": "Hacer factura",
+    "mark-original-invoice-as-paid": "Marcar la original como pagada",
+    "mark-rectifying-invoice-as-paid": "Marcar la rectificativa como pagada",
     "manage": "Administrar",
     "manage-installation": "Administrar",
     "manual": "Manual",

--- a/Core/View/Tab/RefundFacturaCliente.html.twig
+++ b/Core/View/Tab/RefundFacturaCliente.html.twig
@@ -81,6 +81,34 @@
                     <div class="card-body">
                         <p>{{ trans('rectified-invoice-p') }}</p>
                         <div class="row g-2 align-items-end">
+                            <div class="col bg-light border rounded">
+                                <div class="form-check mb-2">
+                                    <input type="checkbox" name="pagada_original" id="pagada_original" value="true" class="form-check-input">
+                                    <label class="form-check-label" for="pagada_original">{{ trans('mark-original-invoice-as-paid') }}</label>
+                                </div>
+                                <div class="mb-3">
+                                    {{ trans('payment-method') }}
+                                    <select name="codpago_original" class="form-select">
+                                        {% for paymethod in fsc.paymentMethods() %}
+                                            <option value="{{ paymethod.codpago }}"{{ paymethod.codpago == firstView.model.codpago ? ' selected' : '' }}>{{ paymethod.descripcion }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col bg-light border rounded">
+                                <div class="form-check mb-2">
+                                    <input type="checkbox" name="pagada_rectificativa" id="pagada_rectificativa" value="true" class="form-check-input">
+                                    <label class="form-check-label" for="pagada_rectificativa">{{ trans('mark-rectifying-invoice-as-paid') }}</label>
+                                </div>
+                                <div class="mb-3">
+                                    {{ trans('payment-method') }}
+                                    <select name="codpago_rectificativa" class="form-select">
+                                        {% for paymethod in fsc.paymentMethods() %}
+                                            <option value="{{ paymethod.codpago }}"{{ paymethod.codpago == firstView.model.codpago ? ' selected' : '' }}>{{ paymethod.descripcion }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
                             <div class="col-sm-6 col-md-4 col-lg">
                                 <div class="mb-3">
                                     {{ trans('serie') }}

--- a/Core/View/Tab/RefundFacturaCliente.html.twig
+++ b/Core/View/Tab/RefundFacturaCliente.html.twig
@@ -83,7 +83,7 @@
                         <div class="row g-2 align-items-end">
                             <div class="col bg-light border rounded">
                                 <div class="form-check mb-2">
-                                    <input type="checkbox" name="pagada_original" id="pagada_original" value="true" class="form-check-input">
+                                    <input type="checkbox" name="pagada_original" id="pagada_original" value="true" class="form-check-input"{{ firstView.model.pagada ? ' checked' : '' }}>
                                     <label class="form-check-label" for="pagada_original">{{ trans('mark-original-invoice-as-paid') }}</label>
                                 </div>
                                 <div class="mb-3">

--- a/Core/View/Tab/RefundFacturaProveedor.html.twig
+++ b/Core/View/Tab/RefundFacturaProveedor.html.twig
@@ -83,7 +83,7 @@
                         <div class="row g-2 align-items-end">
                             <div class="col bg-light border rounded">
                                 <div class="form-check mb-2">
-                                    <input type="checkbox" name="pagada_original" id="pagada_original" value="true" class="form-check-input">
+                                    <input type="checkbox" name="pagada_original" id="pagada_original" value="true" class="form-check-input"{{ firstView.model.pagada ? ' checked' : '' }}>
                                     <label class="form-check-label" for="pagada_original">{{ trans('mark-original-invoice-as-paid') }}</label>
                                 </div>
                                 <div class="mb-3">

--- a/Core/View/Tab/RefundFacturaProveedor.html.twig
+++ b/Core/View/Tab/RefundFacturaProveedor.html.twig
@@ -81,6 +81,34 @@
                     <div class="card-body">
                         <p>{{ trans('rectified-invoice-p') }}</p>
                         <div class="row g-2 align-items-end">
+                            <div class="col bg-light border rounded">
+                                <div class="form-check mb-2">
+                                    <input type="checkbox" name="pagada_original" id="pagada_original" value="true" class="form-check-input">
+                                    <label class="form-check-label" for="pagada_original">{{ trans('mark-original-invoice-as-paid') }}</label>
+                                </div>
+                                <div class="mb-3">
+                                    {{ trans('payment-method') }}
+                                    <select name="codpago_original" class="form-select">
+                                        {% for paymethod in fsc.paymentMethods() %}
+                                            <option value="{{ paymethod.codpago }}"{{ paymethod.codpago == firstView.model.codpago ? ' selected' : '' }}>{{ paymethod.descripcion }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col bg-light border rounded">
+                                <div class="form-check mb-2">
+                                    <input type="checkbox" name="pagada_rectificativa" id="pagada_rectificativa" value="true" class="form-check-input">
+                                    <label class="form-check-label" for="pagada_rectificativa">{{ trans('mark-rectifying-invoice-as-paid') }}</label>
+                                </div>
+                                <div class="mb-3">
+                                    {{ trans('payment-method') }}
+                                    <select name="codpago_rectificativa" class="form-select">
+                                        {% for paymethod in fsc.paymentMethods() %}
+                                            <option value="{{ paymethod.codpago }}"{{ paymethod.codpago == firstView.model.codpago ? ' selected' : '' }}>{{ paymethod.descripcion }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
                             <div class="col-sm-6 col-md-3 col-lg">
                                 <div class="mb-3">
                                     {{ trans('serie') }}

--- a/Test/Core/Model/RectificativaTest.php
+++ b/Test/Core/Model/RectificativaTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Model;
+
+use FacturaScripts\Core\Lib\Calculator;
+use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Model\FormaPago;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+
+final class RectificativaTest extends TestCase
+{
+    use DefaultSettingsTrait;
+    use LogErrorsTrait;
+    use RandomDataTrait;
+
+    private static $contado;
+    private static $paypal;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::setDefaultSettings();
+        self::installAccountingPlan();
+
+        self::$contado = self::cargarFormaPago('CONT');
+        self::$paypal = self::cargarFormaPago('PAYPAL');
+    }
+
+    public function testRectificativaSinMarcarPagadas(): void
+    {
+        [$original, $rectificativa] = $this->escenario(false, false);
+
+        $this->comprobarFactura($original, false, self::$paypal->codpago, 'original');
+        $this->comprobarFactura($rectificativa, false, self::$paypal->codpago, 'rectificativa');
+        $this->eliminar($original, $rectificativa);
+    }
+
+    public function testRectificativaMarcandoOriginalPagada(): void
+    {
+        [$original, $rectificativa] = $this->escenario(true, false);
+
+        $this->comprobarFactura($original, true, self::$paypal->codpago, 'original');
+        $this->comprobarFactura($rectificativa, false, self::$paypal->codpago, 'rectificativa');
+        $this->eliminar($original, $rectificativa);
+    }
+
+    public function testRectificativaMarcandoRectificativaPagada(): void
+    {
+        [$original, $rectificativa] = $this->escenario(false, true);
+
+        $this->comprobarFactura($original, false, self::$paypal->codpago, 'original');
+        $this->comprobarFactura($rectificativa, true, self::$paypal->codpago, 'rectificativa');
+        $this->eliminar($original, $rectificativa);
+    }
+
+    public function testRectificativaMarcandoAmbasPagadas(): void
+    {
+        [$original, $rectificativa] = $this->escenario(true, true);
+
+        $this->comprobarFactura($original, true, self::$paypal->codpago, 'original');
+        $this->comprobarFactura($rectificativa, true, self::$paypal->codpago, 'rectificativa');
+        $this->eliminar($original, $rectificativa);
+    }
+
+    private static function cargarFormaPago(string $codpago): FormaPago
+    {
+        $formaPago = new FormaPago();
+        self::assertTrue($formaPago->load($codpago), 'forma-pago-no-encontrada-' . $codpago);
+        return $formaPago;
+    }
+
+    private function cambiarFormaPago(FacturaCliente $factura, string $codpago, bool $pagada): void
+    {
+        $this->assertTrue($factura->savePaymentMethod($codpago), 'no-se-puede-guardar-forma-pago-' . $factura->codigo);
+
+        foreach ($factura->getReceipts() as $recibo) {
+            $recibo->setPaymentMethod($codpago);
+            $recibo->pagado = $pagada;
+            $this->assertTrue($recibo->save(), 'no-se-puede-guardar-recibo-' . $factura->codigo);
+        }
+
+        $factura->reload();
+    }
+
+    private function comprobarFactura(FacturaCliente $factura, bool $pagada, string $codpago, string $tipo): void
+    {
+        $factura->loadFromCode($factura->idfactura);
+        $this->assertSame($pagada, $factura->pagada, $tipo . '-pagada-incorrecta');
+        $this->assertEquals($codpago, $factura->codpago, $tipo . '-forma-pago-incorrecta');
+
+        foreach ($factura->getReceipts() as $recibo) {
+            $this->assertSame($pagada, $recibo->pagado, $tipo . '-recibo-pagado-incorrecto');
+            $this->assertEquals($codpago, $recibo->codpago, $tipo . '-recibo-forma-pago-incorrecta');
+        }
+    }
+
+    private function crearRectificativa(FacturaCliente $original): FacturaCliente
+    {
+        if ($original->editable) {
+            foreach ($original->getAvailableStatus() as $status) {
+                if ($status->editable || !$status->activo) {
+                    continue;
+                }
+                $original->idestado = $status->idestado;
+                $this->assertTrue($original->save(), 'no-se-puede-bloquear-original');
+                break;
+            }
+        }
+
+        $rectificativa = new FacturaCliente();
+        $rectificativa->loadFromData($original->toArray(), $original::dontCopyFields());
+        $rectificativa->codigorect = $original->codigo;
+        $rectificativa->idfacturarect = $original->idfactura;
+        $this->assertTrue($rectificativa->save(), 'no-se-puede-crear-rectificativa');
+
+        foreach ($original->getLines() as $linea) {
+            $nuevaLinea = $rectificativa->getNewLine($linea->toArray());
+            $nuevaLinea->cantidad = 0 - $linea->cantidad;
+            $nuevaLinea->idlinearect = $linea->idlinea;
+            $this->assertTrue($nuevaLinea->save(), 'no-se-puede-crear-linea-rectificativa');
+        }
+
+        $lineas = $rectificativa->getLines();
+        $this->assertTrue(Calculator::calculate($rectificativa, $lineas, true));
+        return $rectificativa;
+    }
+
+    private function eliminar(FacturaCliente $original, FacturaCliente $rectificativa): void
+    {
+        $this->assertTrue($rectificativa->delete(), 'no-se-puede-eliminar-rectificativa');
+        $original->editable = true;
+        $this->assertTrue($original->delete(), 'no-se-puede-eliminar-original');
+        $this->assertTrue($original->getSubject()->getDefaultAddress()->delete());
+        $this->assertTrue($original->getSubject()->delete());
+    }
+
+    private function escenario(bool $originalPagada, bool $rectificativaPagada): array
+    {
+        $original = $this->getRandomCustomerInvoice();
+        $this->assertTrue($original->exists(), 'no-se-puede-crear-original');
+        $original->codpago = self::$contado->codpago;
+        $this->assertTrue($original->save(), 'no-se-puede-asignar-contado');
+        $original->reload();
+        $this->assertFalse($original->pagada, 'original-debe-estar-sin-pagar');
+        $this->assertEquals(self::$contado->codpago, $original->codpago, 'original-debe-estar-contado');
+
+        $rectificativa = $this->crearRectificativa($original);
+        $this->cambiarFormaPago($original, self::$paypal->codpago, $originalPagada);
+        $this->cambiarFormaPago($rectificativa, self::$paypal->codpago, $rectificativaPagada);
+
+        return [$original, $rectificativa];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}


### PR DESCRIPTION
# Descripción
Modificar el formulario de devoluciones para poder indicar al crear si las 2 facturas (la rectificada y la nueva) se van a marcar como pagadas y con qué forma de pago.

Motivación

Cuando te devuelven una factura entera que no te han pagado, además de la rectificativa tienes que marcar como pagada la anterior. La idea es reducir las posibilidades de error del usuario aquí.

<img width="1933" height="909" alt="imagen" src="https://github.com/user-attachments/assets/615d70ab-1bba-42b5-93dc-0978bb1c666f" />
