### PR TITLE
Rediseñar pestañas de devoluciones

### DIFF
--- a/Core/View/Tab/RefundFacturaCliente.html.twig
+++ b/Core/View/Tab/RefundFacturaCliente.html.twig
@@ -1,212 +1,164 @@
-{#
-/**
- * This file is part of FacturaScripts
- * Copyright (C) 2018-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
- */
-#}
 {% set currentView = fsc.getCurrentView() %}
 {% set firstView = fsc.views | first %}
+{% set lines = firstView.model.getLines() %}
 
 <script>
-    function refundAll() {
-        const refundableQty = document.getElementsByClassName("refundable");
-        const inputToBeRefunded = document.getElementsByClassName("to_refund");
-        for (let i = 0; i < inputToBeRefunded.length; i++) {
-            inputToBeRefunded.item(i).value = refundableQty.item(i).value;
-        }
-        return false;
-    }
-
-    function refundNone() {
-        const inputToBeRefunded = document.getElementsByClassName("to_refund");
-        for (let i = 0; i < inputToBeRefunded.length; i++) {
-            inputToBeRefunded.item(i).value = 0;
-        }
-        return false;
-    }
+function refundAll(){document.querySelectorAll('[data-refund-max]').forEach(i=>i.value=i.dataset.refundMax);return false}
+function refundNone(){document.querySelectorAll('[data-refund-max]').forEach(i=>i.value=0);return false}
 </script>
 
-{% if currentView.count > 0 %}
-    <div class="table-responsive">
-        <table class="table table-hover mb-5">
-            <thead>
-            <tr>
-                <th>{{ trans('rectified-invoice') }}</th>
-                <th>{{ trans('number2') }}</th>
-                <th>{{ trans('observations') }}</th>
-                <th class="text-end">{{ trans('total') }}</th>
-                <th class="text-end">{{ trans('date') }}</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for rectified in currentView.cursor %}
-                <tr class="table-danger clickableRow" data-href="{{ rectified.url() }}">
-                    <td>{{ rectified.codigo }}</td>
-                    <td>{{ rectified.numero2 | raw }}</td>
-                    <td>{{ rectified.observaciones | raw }}</td>
-                    <td class="text-end">{{ money(rectified.total) }}</td>
-                    <td class="text-end">{{ rectified.fecha }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
-{% endif %}
+<div class="container-fluid py-3">
+    {% if currentView.count > 0 %}
+        <div class="mb-4">
+            <div class="d-flex flex-column flex-md-row justify-content-between gap-2 mb-2">
+                <div>
+                    <h2 class="h5 mb-1">{{ trans('refunds') }}</h2>
+                    <p class="text-secondary mb-0">{{ currentView.count }} {{ trans('refunds') | lower }}</p>
+                </div>
+            </div>
+            <div class="table-responsive border rounded">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>{{ trans('rectified-invoice') }}</th>
+                        <th>{{ trans('number2') }}</th>
+                        <th>{{ trans('observations') }}</th>
+                        <th class="text-end">{{ trans('total') }}</th>
+                        <th class="text-end">{{ trans('date') }}</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for rectified in currentView.cursor %}
+                        <tr>
+                            <td class="fw-semibold">{{ rectified.codigo }}</td>
+                            <td>{{ rectified.numero2 | raw }}</td>
+                            <td class="text-secondary">{{ rectified.observaciones | raw }}</td>
+                            <td class="text-end fw-semibold">{{ money(rectified.total) }}</td>
+                            <td class="text-end text-nowrap">{{ rectified.fecha }}</td>
+                            <td class="text-end">
+                                <a href="{{ rectified.url() }}" class="btn btn-sm btn-outline-secondary">{{ trans('open') }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
 
-<form action="{{ firstView.model.url() }}" method="post" onsubmit="animateSpinner('add')">
-    {{ formToken() }}
-    <input type="hidden" name="action" value="new-refund"/>
-    <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
-    <input type="hidden" name="idfactura" value="{{ firstView.model.primaryColumnValue() }}"/>
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col">
-                <div class="card border-warning shadow mb-4">
-                    <div class="card-header bg-warning">
-                        <i class="fa-solid fa-share me-1" aria-hidden="true"></i> {{ trans('new-refund') }}
-                    </div>
-                    <div class="card-body">
-                        <p>{{ trans('rectified-invoice-p') }}</p>
-                        <div class="row g-2 align-items-end">
-                            <div class="col-sm-6 col-md-4 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('serie') }}
-                                    <select name="codserie" class="form-select">
-                                        {% set series = fsc.series('R') %}
-                                        {% if series is empty %}
-                                            {% set series = fsc.series() %}
-                                        {% endif %}
-                                        {% for serie in series %}
-                                            {% if serie.codserie == settings('default','codserierec','R') %}
-                                                <option value="{{ serie.codserie }}" selected>
-                                                    {{ serie.descripcion }}
-                                                </option>
-                                            {% else %}
-                                                <option value="{{ serie.codserie }}">{{ serie.descripcion }}</option>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="col-sm-6 col-md-4 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('date') }}
-                                    <input type="date" name="fecha" value="{{ task.end | date('Y-m-d') }}"
-                                           class="form-control" required>
-                                </div>
-                            </div>
-                            <div class="col-sm-6 col-md-4 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('status') }}
-                                    <select name="idestado" class="form-select">
-                                        {% for status in firstView.model.getAvailableStatus() %}
-                                            {% if status.idestado is same as(11) %}
-                                                <option value="{{ status.idestado }}" selected>
-                                                    {{ status.nombre }}
-                                                </option>
-                                            {% else %}
-                                                <option value="{{ status.idestado }}">
-                                                    {{ status.nombre }}
-                                                </option>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="col-auto">
-                                <div class="btn-group mb-3">
-                                    <div class="dropdown">
-                                        <button class="btn btn-secondary dropdown-toggle" type="button"
-                                                data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <i class="fa-solid fa-check-square me-1"></i> {{ trans('select') }}
-                                        </button>
-                                        <div class="dropdown-menu dropdown-menu-end">
-                                            <a class="dropdown-item" href="#" onClick="return refundNone();">
-                                                <i class="fa-regular fa-square fa-fw me-1"></i> {{ trans('select-none') }}
-                                            </a>
-                                            <a class="dropdown-item" href="#" onClick="return refundAll();">
-                                                <i class="fa-solid fa-square fa-fw me-1"></i> {{ trans('select-all') }}
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-auto">
-                                <div class="btn-group mb-3">
-                                    <button type="submit" class="btn btn-spin-action btn-warning">
-                                        <i class="fa-solid fa-save me-1" aria-hidden="true"></i>
-                                        {{ trans('save') }}
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="table-responsive">
-                        <table class="table table-sm table-hover mb-0">
-                            <thead>
-                            <tr>
-                                <th>{{ trans('description') }}</th>
-                                <th class="text-end">{{ trans('quantity') }}</th>
-                                <th class="text-end">{{ trans('to-refund') }}</th>
-                                <th class="text-end">{{ trans('refund-amount') }}</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            {% for line in firstView.model.getLines() %}
-                                {% set refunded = line.refundedQuantity() %}
-                                <tr>
-                                    <td class="align-middle">
-                                        <a href="{{ line.getProducto().url() }}">{{ line.referencia }}</a>
-                                        {{ line.descripcion | raw }}
-                                    </td>
-                                    <td class="align-middle text-end">
-                                        {{ number(line.cantidad) }}
-                                    </td>
-                                    <td class="table-warning">
-                                        <input type="hidden" value="{{ line.cantidad }}" class="refundable">
-                                        {% if line.cantidad > 0 %}
-                                            <input type="number" name="refund_{{ line.primaryColumnValue() }}"
-                                                   value="0" min="0" max="{{ line.cantidad - refunded }}" step="any"
-                                                   class="form-control text-end to_refund" autocomplete="off"/>
-                                        {% else %}
-                                            <input type="number" name="refund_{{ line.primaryColumnValue() }}"
-                                                   value="0" step="any" class="form-control text-end to_refund"
-                                                   autocomplete="off"/>
-                                        {% endif %}
-                                    </td>
-                                    <td class="align-middle table-warning text-end">
-                                        {% if refunded == 0 %}
-                                            -
-                                        {% else %}
-                                            {{ number(refunded) }}
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <textarea name="observaciones" class="form-control"
-                                      placeholder="{{ trans('observations') }}"></textarea>
-                        </div>
+    <form action="{{ firstView.model.url() }}" method="post" onsubmit="animateSpinner('add')">
+        {{ formToken() }}
+        <input type="hidden" name="action" value="new-refund"/>
+        <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
+        <input type="hidden" name="idfactura" value="{{ firstView.model.primaryColumnValue() }}"/>
+
+        <div class="card border-warning shadow-sm">
+            <div class="card-header bg-warning bg-opacity-25 border-warning">
+                <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                    <div>
+                        <h2 class="h5 mb-1">{{ trans('new-refund') }}</h2>
+                        <p class="text-dark mb-0">{{ trans('rectified-invoice-p') }}</p>
                     </div>
                 </div>
             </div>
+
+            <div class="card-body">
+                <div class="row g-3 align-items-end mb-4">
+                    <div class="col-md-4">
+                        <label class="form-label">{{ trans('serie') }}</label>
+                        <select name="codserie" class="form-select">
+                            {% set series = fsc.series('R') %}
+                            {% if series is empty %}{% set series = fsc.series() %}{% endif %}
+                            {% for serie in series %}
+                                <option value="{{ serie.codserie }}"{% if serie.codserie == settings('default','codserierec','R') %} selected{% endif %}>{{ serie.descripcion }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">{{ trans('date') }}</label>
+                        <input type="date" name="fecha" value="{{ task.end | date('Y-m-d') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">{{ trans('status') }}</label>
+                        <select name="idestado" class="form-select">
+                            {% for status in firstView.model.getAvailableStatus() %}
+                                <option value="{{ status.idestado }}"{% if status.idestado is same as(11) %} selected{% endif %}>{{ status.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">{{ trans('observations') }}</label>
+                        <textarea name="observaciones" class="form-control" rows="3" placeholder="{{ trans('observations') }}"></textarea>
+                    </div>
+                    <div class="col-12 text-end">
+                        <button type="submit" class="btn btn-warning fw-semibold">{{ trans('save') }}</button>
+                    </div>
+                </div>
+
+                <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-2">
+                    <h3 class="h6 mb-0 text-primary">{{ trans('lines') }}</h3>
+                    <div class="d-flex flex-wrap gap-2">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" onclick="return refundNone();">{{ trans('select-none') }}</button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" onclick="return refundAll();">{{ trans('select-all') }}</button>
+                    </div>
+                </div>
+
+                <div class="table-responsive border border-primary rounded mb-4">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead class="table-primary">
+                        <tr>
+                            <th>{{ trans('description') }}</th>
+                            <th class="text-end" style="width:10ch">{{ trans('quantity') }}</th>
+                            <th class="text-end" style="width:10ch">{{ trans('refund-amount') }}</th>
+                            <th class="text-end" style="width:10ch">{{ trans('to-refund') }}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for line in lines %}
+                            {% set refunded = line.refundedQuantity() %}
+                            {% set available = line.cantidad - refunded %}
+                            {% set max = line.cantidad > 0 ? (available > 0 ? available : 0) : '' %}
+                            {% if max is not same as(0) %}
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold"><a href="{{ line.getProducto().url() }}" class="link-dark">{{ line.referencia }}</a></div>
+                                    <div class="text-secondary">{{ line.descripcion | raw }}</div>
+                                </td>
+                                <td class="text-end text-nowrap" style="width:10ch">{{ number(line.cantidad) }}</td>
+                                <td class="text-end text-nowrap" style="width:10ch">{% if refunded == 0 %}-{% else %}{{ number(refunded) }}{% endif %}</td>
+                                <td class="text-end" style="width:10ch">
+                                    {% if max is same as(0) %}
+                                        <span class="badge text-bg-success">{{ trans('completed') }}</span>
+                                    {% else %}
+                                        <input type="number" name="refund_{{ line.primaryColumnValue() }}" value="0" min="0"{% if max is not same as('') %} max="{{ max }}"{% endif %} step="any" data-refund-max="{{ max is same as('') ? 0 : max }}" class="form-control text-end ms-auto" autocomplete="off">
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endif %}
+                        {% endfor %}
+                        {% for line in lines %}
+                            {% set refunded = line.refundedQuantity() %}
+                            {% set available = line.cantidad - refunded %}
+                            {% set max = line.cantidad > 0 ? (available > 0 ? available : 0) : '' %}
+                            {% if max is same as(0) %}
+                            <tr class="table-success">
+                                <td>
+                                    <div class="fw-semibold"><a href="{{ line.getProducto().url() }}" class="link-dark">{{ line.referencia }}</a></div>
+                                    <div class="text-secondary">{{ line.descripcion | raw }}</div>
+                                </td>
+                                <td class="text-end text-nowrap" style="width:10ch">{{ number(line.cantidad) }}</td>
+                                <td class="text-end text-nowrap" style="width:10ch">{% if refunded == 0 %}-{% else %}{{ number(refunded) }}{% endif %}</td>
+                                <td class="text-end" style="width:10ch">
+                                    <span class="badge text-bg-success">{{ trans('completed') }}</span>
+                                </td>
+                            </tr>
+                            {% endif %}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
-    </div>
-</form>
+    </form>
+</div>

--- a/Core/View/Tab/RefundFacturaProveedor.html.twig
+++ b/Core/View/Tab/RefundFacturaProveedor.html.twig
@@ -1,221 +1,164 @@
-{#
-/**
- * This file is part of FacturaScripts
- * Copyright (C) 2018-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
- */
-#}
 {% set currentView = fsc.getCurrentView() %}
 {% set firstView = fsc.views | first %}
+{% set lines = firstView.model.getLines() %}
 
 <script>
-    function refundAll() {
-        const refundableQty = document.getElementsByClassName("refundable");
-        const inputToBeRefunded = document.getElementsByClassName("to_refund");
-        for (let i = 0; i < inputToBeRefunded.length; i++) {
-            inputToBeRefunded.item(i).value = refundableQty.item(i).value;
-        }
-        return false;
-    }
-
-    function refundNone() {
-        const inputToBeRefunded = document.getElementsByClassName("to_refund");
-        for (let i = 0; i < inputToBeRefunded.length; i++) {
-            inputToBeRefunded.item(i).value = 0;
-        }
-        return false;
-    }
+function refundAll(){document.querySelectorAll('[data-refund-max]').forEach(i=>i.value=i.dataset.refundMax);return false}
+function refundNone(){document.querySelectorAll('[data-refund-max]').forEach(i=>i.value=0);return false}
 </script>
 
-{% if currentView.count > 0 %}
-    <div class="table-responsive">
-        <table class="table table-hover mb-5">
-            <thead>
-            <tr>
-                <th>{{ trans('code') }}</th>
-                <th>{{ trans('numsupplier') }}</th>
-                <th>{{ trans('observations') }}</th>
-                <th class="text-end">{{ trans('total') }}</th>
-                <th class="text-end">{{ trans('date') }}</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for rectified in currentView.cursor %}
-                <tr class="table-danger clickableRow" data-href="{{ rectified.url() }}">
-                    <td>{{ rectified.codigo }}</td>
-                    <td>{{ rectified.numproveedor | raw }}</td>
-                    <td>{{ rectified.observaciones | raw }}</td>
-                    <td class="text-end">{{ money(rectified.total) }}</td>
-                    <td class="text-end">{{ rectified.fecha }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
-{% endif %}
+<div class="container-fluid py-3">
+    {% if currentView.count > 0 %}
+        <div class="mb-4">
+            <div class="d-flex flex-column flex-md-row justify-content-between gap-2 mb-2">
+                <div>
+                    <h2 class="h5 mb-1">{{ trans('refunds') }}</h2>
+                    <p class="text-secondary mb-0">{{ currentView.count }} {{ trans('refunds') | lower }}</p>
+                </div>
+            </div>
+            <div class="table-responsive border rounded">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>{{ trans('code') }}</th>
+                        <th>{{ trans('numsupplier') }}</th>
+                        <th>{{ trans('observations') }}</th>
+                        <th class="text-end">{{ trans('total') }}</th>
+                        <th class="text-end">{{ trans('date') }}</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for rectified in currentView.cursor %}
+                        <tr>
+                            <td class="fw-semibold">{{ rectified.codigo }}</td>
+                            <td>{{ rectified.numproveedor | raw }}</td>
+                            <td class="text-secondary">{{ rectified.observaciones | raw }}</td>
+                            <td class="text-end fw-semibold">{{ money(rectified.total) }}</td>
+                            <td class="text-end text-nowrap">{{ rectified.fecha }}</td>
+                            <td class="text-end">
+                                <a href="{{ rectified.url() }}" class="btn btn-sm btn-outline-secondary">{{ trans('open') }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
 
-<form action="{{ firstView.model.url() }}" method="post" onsubmit="animateSpinner('add')">
-    {{ formToken() }}
-    <input type="hidden" name="action" value="new-refund"/>
-    <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
-    <input type="hidden" name="idfactura" value="{{ firstView.model.primaryColumnValue() }}"/>
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col">
-                <div class="card border-warning shadow mb-4">
-                    <div class="card-header bg-warning">
-                        <i class="fa-solid fa-share me-1" aria-hidden="true"></i> {{ trans('new-refund') }}
-                    </div>
-                    <div class="card-body">
-                        <p>{{ trans('rectified-invoice-p') }}</p>
-                        <div class="row g-2 align-items-end">
-                            <div class="col-sm-6 col-md-3 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('serie') }}
-                                    <select name="codserie" class="form-select">
-                                        {% set series = fsc.series('R') %}
-                                        {% if series is empty %}
-                                            {% set series = fsc.series() %}
-                                        {% endif %}
-                                        {% for serie in series %}
-                                            {% if serie.codserie == settings('default','codserierec','R') %}
-                                                <option value="{{ serie.codserie }}" selected>
-                                                    {{ serie.descripcion }}
-                                                </option>
-                                            {% else %}
-                                                <option value="{{ serie.codserie }}">{{ serie.descripcion }}</option>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="col-sm-6 col-md-3 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('date') }}
-                                    <input type="date" name="fecha" value="{{ task.end | date('Y-m-d') }}"
-                                           class="form-control" required>
-                                </div>
-                            </div>
-                            <div class="col-sm-6 col-md-3 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('numsupplier') }}
-                                    <input type="text" name="numproveedor" class="form-control" maxlength="50">
-                                </div>
-                            </div>
-                            <div class="col-sm-6 col-md-3 col-lg">
-                                <div class="mb-3">
-                                    {{ trans('status') }}
-                                    <select name="idestado" class="form-select">
-                                        {% for status in firstView.model.getAvailableStatus() %}
-                                            {% if status.idestado is same as(22) %}
-                                                <option value="{{ status.idestado }}" selected>
-                                                    {{ status.nombre }}
-                                                </option>
-                                            {% else %}
-                                                <option value="{{ status.idestado }}">
-                                                    {{ status.nombre }}
-                                                </option>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="col-auto">
-                                <div class="btn-group mb-3">
-                                    <div class="dropdown">
-                                        <button class="btn btn-secondary dropdown-toggle" type="button"
-                                                data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <i class="fa-solid fa-check-square me-1"></i>
-                                            {{ trans('select') }}
-                                        </button>
-                                        <div class="dropdown-menu dropdown-menu-end">
-                                            <a class="dropdown-item" href="#" onClick="return refundNone();">
-                                                <i class="fa-regular fa-square fa-fw me-1"></i>
-                                                {{ trans('select-none') }}
-                                            </a>
-                                            <a class="dropdown-item" href="#" onClick="return refundAll();">
-                                                <i class="fa-solid fa-square fa-fw me-1"></i>
-                                                {{ trans('select-all') }}
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-auto">
-                                <div class="btn-group mb-3">
-                                    <button type="submit" class="btn btn-spin-action btn-warning">
-                                        <i class="fa-solid fa-save me-1" aria-hidden="true"></i>
-                                        {{ trans('save') }}
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="table-responsive">
-                        <table class="table table-sm table-hover mb-0">
-                            <thead>
-                            <tr>
-                                <th>{{ trans('description') }}</th>
-                                <th class="text-end">{{ trans('quantity') }}</th>
-                                <th class="text-end">{{ trans('to-refund') }}</th>
-                                <th class="text-end">{{ trans('refund-amount') }}</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            {% for line in firstView.model.getLines() %}
-                                {% set refunded = line.refundedQuantity() %}
-                                <tr>
-                                    <td class="align-middle">
-                                        <a href="{{ line.getProducto().url() }}">{{ line.referencia }}</a>
-                                        {{ line.descripcion | raw }}
-                                    </td>
-                                    <td class="align-middle text-end">
-                                        {{ number(line.cantidad) }}
-                                    </td>
-                                    <td class="table-warning">
-                                        <input type="hidden" value="{{ line.cantidad }}" class="refundable">
-                                        {% if line.cantidad > 0 %}
-                                            <input type="number" name="refund_{{ line.primaryColumnValue() }}"
-                                                   value="0" min="0" max="{{ line.cantidad - refunded }}" step="any"
-                                                   class="form-control text-end to_refund" autocomplete="off"/>
-                                        {% else %}
-                                            <input type="number" name="refund_{{ line.primaryColumnValue() }}"
-                                                   value="0" step="any" class="form-control text-end to_refund"
-                                                   autocomplete="off"/>
-                                        {% endif %}
-                                    </td>
-                                    <td class="align-middle table-warning text-end">
-                                        {% if refunded == 0 %}
-                                            -
-                                        {% else %}
-                                            {{ number(refunded) }}
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                                <textarea name="observaciones" class="form-control"
-                                          placeholder="{{ trans('observations') }}"></textarea>
-                        </div>
+    <form action="{{ firstView.model.url() }}" method="post" onsubmit="animateSpinner('add')">
+        {{ formToken() }}
+        <input type="hidden" name="action" value="new-refund"/>
+        <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}"/>
+        <input type="hidden" name="idfactura" value="{{ firstView.model.primaryColumnValue() }}"/>
+
+        <div class="card border-warning shadow-sm">
+            <div class="card-header bg-warning bg-opacity-25 border-warning">
+                <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                    <div>
+                        <h2 class="h5 mb-1">{{ trans('new-refund') }}</h2>
+                        <p class="text-dark mb-0">{{ trans('rectified-invoice-p') }}</p>
                     </div>
                 </div>
             </div>
+
+            <div class="card-body">
+                <div class="row g-3 align-items-end mb-4">
+                    <div class="col-md-3">
+                        <label class="form-label">{{ trans('serie') }}</label>
+                        <select name="codserie" class="form-select">
+                            {% set series = fsc.series('R') %}
+                            {% if series is empty %}{% set series = fsc.series() %}{% endif %}
+                            {% for serie in series %}
+                                <option value="{{ serie.codserie }}"{% if serie.codserie == settings('default','codserierec','R') %} selected{% endif %}>{{ serie.descripcion }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">{{ trans('date') }}</label>
+                        <input type="date" name="fecha" value="{{ task.end | date('Y-m-d') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">{{ trans('numsupplier') }}</label>
+                        <input type="text" name="numproveedor" class="form-control" maxlength="50">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">{{ trans('status') }}</label>
+                        <select name="idestado" class="form-select">
+                            {% for status in firstView.model.getAvailableStatus() %}
+                                <option value="{{ status.idestado }}"{% if status.idestado is same as(22) %} selected{% endif %}>{{ status.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">{{ trans('observations') }}</label>
+                        <textarea name="observaciones" class="form-control" rows="3" placeholder="{{ trans('observations') }}"></textarea>
+                    </div>
+                    <div class="col-12 text-end">
+                        <button type="submit" class="btn btn-warning fw-semibold">{{ trans('save') }}</button>
+                    </div>
+                </div>
+
+                <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-2">
+                    <h3 class="h6 mb-0 text-primary">{{ trans('lines') }}</h3>
+                    <div class="d-flex flex-wrap gap-2">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" onclick="return refundNone();">{{ trans('select-none') }}</button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" onclick="return refundAll();">{{ trans('select-all') }}</button>
+                    </div>
+                </div>
+
+                <div class="table-responsive border border-primary rounded mb-4">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead class="table-primary">
+                        <tr>
+                            <th>{{ trans('description') }}</th>
+                            <th class="text-end" style="width:10ch">{{ trans('quantity') }}</th>
+                            <th class="text-end" style="width:10ch">{{ trans('refund-amount') }}</th>
+                            <th class="text-end" style="width:10ch">{{ trans('to-refund') }}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for line in lines %}
+                            {% set refunded = line.refundedQuantity() %}
+                            {% set available = line.cantidad - refunded %}
+                            {% set max = line.cantidad > 0 ? (available > 0 ? available : 0) : '' %}
+                            {% if max is not same as(0) %}
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold"><a href="{{ line.getProducto().url() }}" class="link-dark">{{ line.referencia }}</a></div>
+                                    <div class="text-secondary">{{ line.descripcion | raw }}</div>
+                                </td>
+                                <td class="text-end text-nowrap" style="width:10ch">{{ number(line.cantidad) }}</td>
+                                <td class="text-end text-nowrap" style="width:10ch">{% if refunded == 0 %}-{% else %}{{ number(refunded) }}{% endif %}</td>
+                                <td class="text-end" style="width:10ch">
+                                    <input type="number" name="refund_{{ line.primaryColumnValue() }}" value="0" min="0"{% if max is not same as('') %} max="{{ max }}"{% endif %} step="any" data-refund-max="{{ max is same as('') ? 0 : max }}" class="form-control text-end ms-auto" autocomplete="off">
+                                </td>
+                            </tr>
+                            {% endif %}
+                        {% endfor %}
+                        {% for line in lines %}
+                            {% set refunded = line.refundedQuantity() %}
+                            {% set available = line.cantidad - refunded %}
+                            {% set max = line.cantidad > 0 ? (available > 0 ? available : 0) : '' %}
+                            {% if max is same as(0) %}
+                            <tr class="table-success">
+                                <td>
+                                    <div class="fw-semibold"><a href="{{ line.getProducto().url() }}" class="link-dark">{{ line.referencia }}</a></div>
+                                    <div class="text-secondary">{{ line.descripcion | raw }}</div>
+                                </td>
+                                <td class="text-end text-nowrap" style="width:10ch">{{ number(line.cantidad) }}</td>
+                                <td class="text-end text-nowrap" style="width:10ch">{% if refunded == 0 %}-{% else %}{{ number(refunded) }}{% endif %}</td>
+                                <td class="text-end" style="width:10ch">
+                                    <span class="badge text-bg-success">{{ trans('completed') }}</span>
+                                </td>
+                            </tr>
+                            {% endif %}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
-    </div>
-</form>
+    </form>
+</div>


### PR DESCRIPTION
## Resumen
- Rediseñadas las pestañas de devoluciones de facturas de cliente y proveedor usando clases Bootstrap 5.3.
- Agrupados los datos de la factura rectificativa: serie, fecha, estado, observaciones y guardar.
- Movidos los controles de selección junto a la tabla de líneas.
- Al pulsar "Seleccionar todo" ahora se asigna la cantidad restante pendiente de devolver, no el total de la línea como antes.
- Las líneas completamente devueltas se muestran al final de la tabla y sin input innecesario.

<img width="814" height="921" alt="imagen" src="https://github.com/user-attachments/assets/7c451358-40f8-491b-a1e4-c7cf7255b028" />
