### PR TITLE
Tarea3448

### DIFF
--- a/Core/Lib/AjaxForms/CommonSalesPurchases.php
+++ b/Core/Lib/AjaxForms/CommonSalesPurchases.php
@@ -405,15 +405,25 @@ trait CommonSalesPurchases
 
         // añadimos los estados posibles
         $options = [];
+        $modals = [];
         foreach ($model->getAvailableStatus() as $sta) {
             // si está seleccionado o no activo, lo saltamos
             if ($sta->idestado === $model->idestado || false === $sta->activo) {
                 continue;
             }
 
-            $options[] = '<a class="dropdown-item' . static::idestadoTextColor($sta) . '"'
-                . ' href="#" onclick="return ' . $jsName . '(\'save-status\', \'' . $sta->idestado . '\', this);">'
-                . '<i class="' . static::idestadoIcon($sta, true) . ' fa-fw"></i> ' . $sta->nombre . '</a>';
+            if ($sta->generadoc) {
+                // abrimos un modal para pedir la fecha del nuevo documento
+                $modalId = 'modalNewDocDate-' . $sta->idestado;
+                $options[] = '<a class="dropdown-item' . static::idestadoTextColor($sta) . '"'
+                    . ' href="#" data-bs-toggle="modal" data-bs-target="#' . $modalId . '">'
+                    . '<i class="' . static::idestadoIcon($sta, true) . ' fa-fw"></i> ' . $sta->nombre . '</a>';
+                $modals[] = static::modalNewDocDate($sta->idestado, $sta->nombre, $modalId, $jsName);
+            } else {
+                $options[] = '<a class="dropdown-item' . static::idestadoTextColor($sta) . '"'
+                    . ' href="#" onclick="return ' . $jsName . '(\'save-status\', \'' . $sta->idestado . '\', this);">'
+                    . '<i class="' . static::idestadoIcon($sta, true) . ' fa-fw"></i> ' . $sta->nombre . '</a>';
+            }
         }
 
         // añadimos la opción de agrupar o partir (excepto facturas y documentos no editables)
@@ -433,7 +443,8 @@ trait CommonSalesPurchases
             . '<div class="dropdown-menu dropdown-menu-right">' . implode('', $options) . '</div>'
             . '</div>'
             . '</div>'
-            . '</div>';
+            . '</div>'
+            . implode('', $modals);
     }
 
     protected static function idestadoIcon(EstadoDocumento $status, bool $alternative = false): string
@@ -454,6 +465,37 @@ trait CommonSalesPurchases
         }
 
         return false === $status->editable && empty($status->actualizastock) ? ' text-danger' : '';
+    }
+
+    protected static function modalNewDocDate(int $idestado, string $nombre, string $modalId, string $jsName): string
+    {
+        return '<div class="modal fade" id="' . $modalId . '" tabindex="-1" aria-hidden="true">'
+            . '<div class="modal-dialog modal-dialog-centered">'
+            . '<div class="modal-content">'
+            . '<div class="modal-header">'
+            . '<h5 class="modal-title"><i class="fa-solid fa-forward fa-fw"></i> ' . $nombre . '</h5>'
+            . '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="' . Tools::trans('close') . '"></button>'
+            . '</div>'
+            . '<div class="modal-body">'
+            . '<div class="mb-2">'
+            . Tools::trans('date')
+            . '<input type="date" id="new-doc-date-' . $idestado . '" value="' . date('Y-m-d') . '" class="form-control" required/>'
+            . '</div>'
+            . '</div>'
+            . '<div class="modal-footer">'
+            . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Tools::trans('close') . '</button>'
+            . '<button type="button" class="btn btn-success btn-spin-action" data-bs-dismiss="modal" onclick="(function(){'
+            . 'var fecha = document.getElementById(\'new-doc-date-' . $idestado . '\').value;'
+            . 'var form = document.forms[\'salesForm\'] || document.forms[\'purchasesForm\'];'
+            . 'var input = document.createElement(\'input\');'
+            . 'input.type = \'hidden\'; input.name = \'new-doc-date\'; input.value = fecha;'
+            . 'form.appendChild(input);'
+            . $jsName . '(\'save-status\', \'' . $idestado . '\');'
+            . '})()">' . Tools::trans('accept') . '</button>'
+            . '</div>'
+            . '</div>'
+            . '</div>'
+            . '</div>';
     }
 
     public static function modalDocList(array $documents, string $title, string $id): string

--- a/Core/Lib/AjaxForms/PurchasesController.php
+++ b/Core/Lib/AjaxForms/PurchasesController.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Core\Lib\AjaxForms;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Series;
+use FacturaScripts\Core\Lib\BusinessDocumentGenerator;
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\DocFilesTrait;
@@ -497,13 +498,21 @@ abstract class PurchasesController extends PanelController
         $model = $this->getModel();
         $model->idestado = (int)$this->request->input('selectedLine');
 
+        $formData = json_decode($this->request->input('data'), true);
+        $newDocDate = $this->request->input('new-doc-date') ?? ($formData['new-doc-date'] ?? null);
+        if ($newDocDate) {
+            BusinessDocumentGenerator::setNewDocDate($newDocDate);
+        }
+
         try {
             if (false === $model->save()) {
+                BusinessDocumentGenerator::setNewDocDate(null);
                 $this->db()->rollback();
                 $this->sendJsonWithLogs(['ok' => false]);
                 return false;
             }
         } catch (Throwable $e) {
+            BusinessDocumentGenerator::setNewDocDate(null);
             $this->db()->rollback();
             Tools::log()->error($e->getMessage());
             $this->sendJsonWithLogs(['ok' => false]);

--- a/Core/Lib/AjaxForms/SalesController.php
+++ b/Core/Lib/AjaxForms/SalesController.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Core\Lib\AjaxForms;
 
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\DataSrc\Series;
+use FacturaScripts\Core\Lib\BusinessDocumentGenerator;
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\DocFilesTrait;
@@ -511,13 +512,21 @@ abstract class SalesController extends PanelController
         $model = $this->getModel();
         $model->idestado = (int)$this->request->input('selectedLine');
 
+        $formData = json_decode($this->request->input('data'), true);
+        $newDocDate = $this->request->input('new-doc-date') ?? ($formData['new-doc-date'] ?? null);
+        if ($newDocDate) {
+            BusinessDocumentGenerator::setNewDocDate($newDocDate);
+        }
+
         try {
             if (false === $model->save()) {
+                BusinessDocumentGenerator::setNewDocDate(null);
                 $this->db()->rollback();
                 $this->sendJsonWithLogs(['ok' => false]);
                 return false;
             }
         } catch (Throwable $e) {
+            BusinessDocumentGenerator::setNewDocDate(null);
             $this->db()->rollback();
             Tools::log()->error($e->getMessage());
             $this->sendJsonWithLogs(['ok' => false]);

--- a/Core/Lib/BusinessDocumentGenerator.php
+++ b/Core/Lib/BusinessDocumentGenerator.php
@@ -42,6 +42,9 @@ class BusinessDocumentGenerator
     /** @var array */
     protected $lastDocs = [];
 
+    /** @var string|null */
+    private static $newDocDate = null;
+
     /** @var bool */
     private static $sameDate = false;
 
@@ -84,7 +87,10 @@ class BusinessDocumentGenerator
         // assign the user
         $newDoc->nick = Session::user()->nick;
 
-        if (self::$sameDate) {
+        if (self::$newDocDate) {
+            $newDoc->fecha = self::$newDocDate;
+            self::$newDocDate = null;
+        } elseif (self::$sameDate) {
             $newDoc->fecha = $prototype->fecha;
             $newDoc->hora = $prototype->hora;
         }
@@ -120,6 +126,11 @@ class BusinessDocumentGenerator
     public function getLastDocs(): array
     {
         return $this->lastDocs;
+    }
+
+    public static function setNewDocDate(?string $date): void
+    {
+        self::$newDocDate = $date;
     }
 
     public static function setSameDate(bool $value)

--- a/Test/Core/Lib/BusinessDocumentGeneratorTest.php
+++ b/Test/Core/Lib/BusinessDocumentGeneratorTest.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Lib;
+
+use FacturaScripts\Core\Lib\BusinessDocumentGenerator;
+use FacturaScripts\Dinamic\Model\AlbaranCliente;
+use FacturaScripts\Dinamic\Model\AlbaranProveedor;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+
+final class BusinessDocumentGeneratorTest extends TestCase
+{
+    use DefaultSettingsTrait;
+    use LogErrorsTrait;
+    use RandomDataTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::setDefaultSettings();
+    }
+
+    public function testSetNewDocDateAppliedOnPurchaseApproval(): void
+    {
+        // creamos un proveedor
+        $subject = $this->getRandomSupplier();
+        $this->assertTrue($subject->save(), 'can-not-save-supplier');
+
+        // creamos un albarán de compra con una línea
+        $doc = new AlbaranProveedor();
+        $doc->setSubject($subject);
+        $this->assertTrue($doc->save(), 'can-not-save-albaran-proveedor');
+
+        $line = $doc->getNewLine();
+        $line->cantidad = 1;
+        $line->pvpunitario = 100;
+        $this->assertTrue($line->save(), 'can-not-save-line');
+
+        // buscamos un estado que genere documento
+        $targetStatus = null;
+        foreach ($doc->getAvailableStatus() as $sta) {
+            if ($sta->generadoc) {
+                $targetStatus = $sta;
+                break;
+            }
+        }
+        $this->assertNotNull($targetStatus, 'no-status-with-generadoc-found');
+
+        // establecemos la fecha deseada para el nuevo documento
+        $expectedDate = '01-06-2025';
+        BusinessDocumentGenerator::setNewDocDate('2025-06-01');
+
+        // aprobamos el albarán
+        $doc->idestado = $targetStatus->idestado;
+        $this->assertTrue($doc->save(), 'can-not-approve-albaran-proveedor');
+
+        // comprobamos que la fecha del documento generado es la indicada
+        $children = $doc->childrenDocuments();
+        $this->assertNotEmpty($children, 'no-child-document-generated');
+        foreach ($children as $child) {
+            $this->assertEquals($expectedDate, $child->fecha, 'child-document-has-wrong-date');
+        }
+
+        // limpiamos
+        foreach ($children as $child) {
+            $this->assertTrue($child->delete(), 'can-not-delete-child');
+        }
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran-proveedor');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-supplier');
+    }
+
+    public function testSetNewDocDateAppliedOnSalesApproval(): void
+    {
+        // creamos un cliente
+        $subject = $this->getRandomCustomer();
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos un albarán de venta con una línea
+        $doc = new AlbaranCliente();
+        $doc->setSubject($subject);
+        $this->assertTrue($doc->save(), 'can-not-save-albaran-cliente');
+
+        $line = $doc->getNewLine();
+        $line->cantidad = 1;
+        $line->pvpunitario = 50;
+        $this->assertTrue($line->save(), 'can-not-save-line');
+
+        // buscamos un estado que genere documento
+        $targetStatus = null;
+        foreach ($doc->getAvailableStatus() as $sta) {
+            if ($sta->generadoc) {
+                $targetStatus = $sta;
+                break;
+            }
+        }
+        $this->assertNotNull($targetStatus, 'no-status-with-generadoc-found');
+
+        // establecemos la fecha deseada para el nuevo documento
+        $expectedDate = '15-03-2024';
+        BusinessDocumentGenerator::setNewDocDate('2024-03-15');
+
+        // aprobamos el albarán
+        $doc->idestado = $targetStatus->idestado;
+        $this->assertTrue($doc->save(), 'can-not-approve-albaran-cliente');
+
+        // comprobamos que la fecha del documento generado es la indicada
+        $children = $doc->childrenDocuments();
+        $this->assertNotEmpty($children, 'no-child-document-generated');
+        foreach ($children as $child) {
+            $this->assertEquals($expectedDate, $child->fecha, 'child-document-has-wrong-date');
+        }
+
+        // limpiamos
+        foreach ($children as $child) {
+            $this->assertTrue($child->delete(), 'can-not-delete-child');
+        }
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran-cliente');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
+    public function testNewDocDateResetAfterUse(): void
+    {
+        // verificamos que setNewDocDate se resetea tras el primer generate()
+        // y el segundo documento generado usa la fecha del día
+        $subject = $this->getRandomSupplier();
+        $this->assertTrue($subject->save(), 'can-not-save-supplier');
+
+        // primer albarán: aprobamos con fecha específica
+        $doc1 = new AlbaranProveedor();
+        $doc1->setSubject($subject);
+        $this->assertTrue($doc1->save(), 'can-not-save-doc1');
+
+        $line1 = $doc1->getNewLine();
+        $line1->cantidad = 1;
+        $line1->pvpunitario = 10;
+        $this->assertTrue($line1->save(), 'can-not-save-line1');
+
+        $targetStatus = null;
+        foreach ($doc1->getAvailableStatus() as $sta) {
+            if ($sta->generadoc) {
+                $targetStatus = $sta;
+                break;
+            }
+        }
+        $this->assertNotNull($targetStatus, 'no-status-with-generadoc-found');
+
+        BusinessDocumentGenerator::setNewDocDate('2023-01-20');
+        $doc1->idestado = $targetStatus->idestado;
+        $this->assertTrue($doc1->save(), 'can-not-approve-doc1');
+
+        // segundo albarán: aprobamos SIN setNewDocDate
+        $doc2 = new AlbaranProveedor();
+        $doc2->setSubject($subject);
+        $this->assertTrue($doc2->save(), 'can-not-save-doc2');
+
+        $line2 = $doc2->getNewLine();
+        $line2->cantidad = 1;
+        $line2->pvpunitario = 10;
+        $this->assertTrue($line2->save(), 'can-not-save-line2');
+
+        $doc2->idestado = $targetStatus->idestado;
+        $this->assertTrue($doc2->save(), 'can-not-approve-doc2');
+
+        // el segundo documento generado NO debe tener la fecha del primero
+        $children2 = $doc2->childrenDocuments();
+        $this->assertNotEmpty($children2, 'no-child-document-generated-2');
+        foreach ($children2 as $child) {
+            $this->assertNotEquals('20-01-2023', $child->fecha, 'new-doc-date-was-not-reset');
+        }
+
+        // limpiamos
+        foreach ($doc1->childrenDocuments() as $child) {
+            $child->delete();
+        }
+        foreach ($children2 as $child) {
+            $child->delete();
+        }
+        $doc1->delete();
+        $doc2->delete();
+        $subject->getDefaultAddress()->delete();
+        $subject->delete();
+    }
+
+    public function testWithoutNewDocDateUsesTodayDate(): void
+    {
+        // sin setNewDocDate, el documento generado tiene la fecha de hoy
+        $subject = $this->getRandomSupplier();
+        $this->assertTrue($subject->save(), 'can-not-save-supplier');
+
+        $doc = new AlbaranProveedor();
+        $doc->setSubject($subject);
+        $this->assertTrue($doc->save(), 'can-not-save-albaran');
+
+        $line = $doc->getNewLine();
+        $line->cantidad = 1;
+        $line->pvpunitario = 10;
+        $this->assertTrue($line->save(), 'can-not-save-line');
+
+        $targetStatus = null;
+        foreach ($doc->getAvailableStatus() as $sta) {
+            if ($sta->generadoc) {
+                $targetStatus = $sta;
+                break;
+            }
+        }
+        $this->assertNotNull($targetStatus, 'no-status-with-generadoc-found');
+
+        $doc->idestado = $targetStatus->idestado;
+        $this->assertTrue($doc->save(), 'can-not-approve-albaran');
+
+        $children = $doc->childrenDocuments();
+        $this->assertNotEmpty($children, 'no-child-document-generated');
+        foreach ($children as $child) {
+            $this->assertEquals(date('d-m-Y'), $child->fecha, 'child-without-new-doc-date-has-wrong-date');
+        }
+
+        // limpiamos
+        foreach ($children as $child) {
+            $child->delete();
+        }
+        $doc->delete();
+        $subject->getDefaultAddress()->delete();
+        $subject->delete();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}


### PR DESCRIPTION
# Añadir selección de fecha al transformar documentos (albarán → factura)

## ¿Qué se ha implementado?

Cuando se cambia el estado de un documento (albarán, pedido, presupuesto) a uno que genera un nuevo documento (por ejemplo, facturar un albarán), ahora se muestra un **modal previo** donde el usuario puede elegir la fecha del nuevo documento antes de confirmar la transformación.

Anteriormente la transformación se ejecutaba directamente al pulsar el estado en el desplegable, usando siempre la fecha del día. Con este cambio, el usuario tiene **control sobre la fecha** del documento generado.

---

## Cambios realizados

### `Core/Lib/AjaxForms/CommonSalesPurchases.php`

* Los estados del desplegable que tienen `generadoc` ya no ejecutan directamente la acción, sino que abren un modal.
* Se añade el método `modalNewDocDate()` que genera el HTML del modal con un campo de fecha (por defecto la fecha actual) y los botones **Cerrar** / **Aceptar**.
* Al aceptar, se añade la fecha como un *input* oculto al formulario y se llama a la función JS correspondiente (`salesFormSave` / `purchasesFormSave`) con el `idestado` correcto.

### `Core/Lib/AjaxForms/SalesController.php` y `PurchasesController.php`

* El método `saveStatusAction()` lee el parámetro `new-doc-date` tanto del POST directo como del JSON `data` del formulario.
* Si se ha proporcionado fecha, se pasa a `BusinessDocumentGenerator::setNewDocDate()` antes de guardar el modelo, y se limpia en caso de error.

### `Core/Lib/BusinessDocumentGenerator.php`

* Se añade el método estático `setNewDocDate()` y la propiedad `$newDocDate`.
* Al generar el nuevo documento, si hay fecha definida se asigna a `$newDoc->fecha` y se resetea para no afectar a generaciones posteriores.

## Tests Ejecutados

Se añade el archivo `Test/Core/Lib/BusinessDocumentGeneratorTest.php` con cuatro tests unitarios:

* **`testSetNewDocDateAppliedOnPurchaseApproval`**: crea un albarán de proveedor con una línea, establece una fecha personalizada mediante `setNewDocDate()`, lo transforma al estado que genera documento y verifica que el documento generado (factura de proveedor) tiene exactamente esa fecha.
* **`testSetNewDocDateAppliedOnSalesApproval`**: mismo flujo para albaranes de cliente, comprobando que la fecha personalizada se aplica correctamente al documento de venta generado.
* **`testNewDocDateResetAfterUse`**: verifica que la variable `$newDocDate` se resetea automáticamente tras la primera generación, de modo que una segunda transformación posterior (sin volver a llamar a `setNewDocDate()`) no hereda la fecha anterior.
* **`testWithoutNewDocDateUsesTodayDate`**: comprueba que, cuando no se establece ninguna fecha personalizada, el documento generado toma la fecha del día como comportamiento por defecto.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.
