### PR TITLE
Enfocar cantidad tras añadir línea rápida

### DIFF
--- a/Core/View/Tab/PurchasesDocument.html.twig
+++ b/Core/View/Tab/PurchasesDocument.html.twig
@@ -127,7 +127,7 @@
                     break;
 
                 case 'fast-line':
-                    document.forms['purchasesForm']['fastli'].focus();
+                    $(".doc-line-qty:last").select();
                     break;
 
                 case 'new-line':

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -127,7 +127,7 @@
                     break;
 
                 case 'fast-line':
-                    document.forms['salesForm']['fastli'].focus();
+                    $(".doc-line-qty:last").select();
                     break;
 
                 case 'new-line':


### PR DESCRIPTION
## Qué cambia

Al añadir una línea rápida desde el campo de código de barras con Intro, ahora se selecciona el campo de cantidad de la última línea añadida.

## Fallo anterior

Cuando se introducía una referencia desde el buscador de productos, la línea se añadía y el foco pasaba correctamente al campo cantidad. Sin embargo, al introducir un código de barras en el campo rápido y pulsar Intro, la línea se añadía pero el foco volvía al campo de código de barras, obligando al usuario a cambiar manualmente a la cantidad.

## Mejora

El comportamiento queda unificado para documentos de venta y compra: tanto al seleccionar una referencia como al usar código de barras, el cursor queda en la cantidad de la nueva línea para poder ajustarla directamente.