### PR TITLE
Mejorar búsqueda rápida de productos por referencia

### DIFF
--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -154,6 +154,7 @@ class Variante extends ModelClass
                 $where,
                 new DataBaseWhere('LOWER(v.referencia)', $find . '%', 'LIKE'),
                 new DataBaseWhere('LOWER(v.referencia)', '%' . $find, 'LIKE', 'OR'),
+                new DataBaseWhere('LOWER(v.referencia)', '%' . $find . '%', 'LIKE', 'OR'),
                 new DataBaseWhere('LOWER(v.codbarras)', $find, '=', 'OR'),
                 new DataBaseWhere('LOWER(p.descripcion)', $find, 'LIKE', 'OR')
             );


### PR DESCRIPTION
# Descripción
Se ha ajustado la búsqueda de variantes para que el autocompletado de productos encuentre referencias que contienen el texto buscado en cualquier posición.

Antes, en formularios como EditFacturaCliente, al escribir una parte intermedia de una referencia en #findProductInput, por ejemplo ABC para una referencia 123ABC456/24, el producto no aparecía porque la búsqueda solo contemplaba coincidencias al inicio o al final de la referencia.

El buscador del modal #productModalInput sí encontraba esos productos, por lo que el comportamiento era inconsistente. Con este cambio, la búsqueda rápida queda alineada con el modal y permite localizar referencias por coincidencia parcial interna.

## Description (english)
The product variant search has been adjusted so the product autocomplete can find references containing the searched text in any position.

Previously, in forms such as EditFacturaCliente, typing a middle fragment of a reference in #findProductInput, for example ABC for reference 123ABC456/24, did not return the product because the search only matched the beginning or the end of the reference.

The #productModalInput modal search already found those products, so the behavior was inconsistent. This change aligns the quick search with the modal and allows references to be found by internal partial match.

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [ ] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

### How has the changes been tested? (english)
- [x] I have reviewed my code before sending it.
- [ ] I have tested it on my PC.
- [ ] I have tested it on an empty database.
- [ ] I have run the unit tests.