### PR TITLE
Añade soporte para abrir el claim en una nueva pestaña tras el registro

### DIFF
--- a/Core/Controller/Updater.php
+++ b/Core/Controller/Updater.php
@@ -42,10 +42,14 @@ use ZipArchive;
 class Updater extends Controller
 {
     const CORE_ZIP_FOLDER = 'facturascripts';
+
     const UPDATE_CORE_URL = 'https://facturascripts.com/DownloadBuild';
 
     /** @var array */
     public $coreUpdateWarnings = [];
+
+    /** @var bool */
+    public $justRegistered = false;
 
     /** @var Telemetry */
     public $telemetryManager;
@@ -63,6 +67,11 @@ class Updater extends Controller
         parent::__construct($className, $uri);
     }
 
+    public static function getCoreVersion(): float
+    {
+        return Kernel::version();
+    }
+
     public function getPageData(): array
     {
         $data = parent::getPageData();
@@ -70,11 +79,6 @@ class Updater extends Controller
         $data['title'] = 'updater';
         $data['icon'] = 'fa-solid fa-cloud-download-alt';
         return $data;
-    }
-
-    public static function getCoreVersion(): float
-    {
-        return Kernel::version();
     }
 
     public static function getUpdateItems(): array
@@ -215,6 +219,10 @@ class Updater extends Controller
             case 'register':
                 if ($this->telemetryManager->install()) {
                     Tools::log()->notice('record-updated-correctly');
+                    // marcamos que se acaba de registrar para que la vista abra el claim
+                    // en una pestaña nueva y se vincule la instalación con el contacto
+                    // (la petición de registro es servidor-a-servidor y no lleva la cookie del portal)
+                    $this->justRegistered = true;
                     break;
                 }
                 Tools::log()->error('record-save-error');

--- a/Core/View/Updater.html.twig
+++ b/Core/View/Updater.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2017-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -262,5 +262,26 @@
                 </div>
             </div>
         </div>
+    {% endif %}
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {% if fsc.justRegistered %}
+        <script>
+            // tras registrar, abrimos el claim en una pestaña nueva para vincular la
+            // instalación con el contacto, dejando esta pestaña en el programa ya registrado
+            document.addEventListener('DOMContentLoaded', function () {
+                const claimWindow = window.open('{{ fsc.url() }}?action=claim-install', '_blank');
+
+                // si el navegador bloquea la pestaña nueva, mostramos el modal con el botón manual
+                if (!claimWindow) {
+                    const modalEl = document.getElementById('modalTelemetry');
+                    if (modalEl) {
+                        new bootstrap.Modal(modalEl).show();
+                    }
+                }
+            });
+        </script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Actualmente cuando un usuario registra la instalación se registra bien en Froja, pero no se vincula con el idcontacto porque ese paso es manual, ahora después de registrar una nueva instalación salta un js en una nueva pestaña que vincula el idcontacto con la instalación registrada, solucionando en parte el problema de tener tantas instalaciones registradas sin idcontacto.

Si el navegador del usuario bloquea el popup de redirección, entonces se muestra el modal de Administrar que ya existe facilitando al usuario el siguiente paso.

PR de forja necesario: https://github.com/FacturaScripts/forja/pull/201

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.