### PR TITLE
permitir required en widget number

### DIFF
--- a/Core/Lib/Widget/WidgetNumber.php
+++ b/Core/Lib/Widget/WidgetNumber.php
@@ -129,8 +129,8 @@ class WidgetNumber extends BaseWidget
     protected function setValue($model)
     {
         parent::setValue($model);
-        if (null === $this->value && $this->required) {
-            $this->value = empty($this->min) ? 0 : (float)$this->min;
+        if (null === $this->value && $this->required && $this->min !== '') {
+            $this->value = (float)$this->min;
         }
     }
 


### PR DESCRIPTION
# Descripción
- Actualmente al crear un registro nuevo, no es posible que la lógica de html5 no permita el envío de un formulario con un widget number REQUIRED.

Esto ocurre porque siempre se le está asignando un valor al input y por lo tanto html5 no lo detecta como vacío y siempre se envía el formulario.

En esta corrección no se asigna ningún valor(a menos que se indique un min o se asigne un valor en el clear()) por lo que al enviar el formulario html5 bloquea el envío solicitando al usuario que es un campo requerido.

Por lo que a partir de ahora si el desarrollador quiere que sea required desde un inicio no debe asignar ningún valor en el clear ni en min en el widget.
Si el desarrollador quiere que sea required pero tener un valor inicial por defecto, pues entonces puede usar el clear del modelo.