### PR TITLE
Añadir compatibilidad de pipe() para getApiFieldsToHide()

### DIFF
--- a/Core/Model/ApiKey.php
+++ b/Core/Model/ApiKey.php
@@ -99,12 +99,6 @@ class ApiKey extends ModelClass
         $this->fullaccess = false;
     }
 
-    public function getAccesses(): array
-    {
-        $where = [Where::eq('idapikey', $this->id)];
-        return ApiAccess::all($where, [], 0, 0);
-    }
-
     /**
      * Retrieves the API access entry for the specified resource.
      *
@@ -128,6 +122,12 @@ class ApiKey extends ModelClass
         return null;
     }
 
+    public function getAccesses(): array
+    {
+        $where = [Where::eq('idapikey', $this->id)];
+        return ApiAccess::all($where, [], 0, 0);
+    }
+
     /**
      * Devuelve los nombres de campos que no deben exponerse en la API.
      *
@@ -135,7 +135,7 @@ class ApiKey extends ModelClass
      */
     public function getApiFieldsToHide(): array
     {
-        return ['apikey'];
+        return $this->pipeArray('getApiFieldsToHide', ['apikey']);
     }
 
     /**

--- a/Core/Model/User.php
+++ b/Core/Model/User.php
@@ -43,11 +43,12 @@ use FacturaScripts\Dinamic\Model\Serie as DinSerie;
  */
 class User extends ModelClass
 {
-    use ModelTrait;
     use CompanyRelationTrait;
     use GravatarTrait;
+    use ModelTrait;
 
     const DEFAULT_LEVEL = 2;
+
     const UPDATE_ACTIVITY_PERIOD = 3600;
 
     /** @var bool */
@@ -93,13 +94,13 @@ class User extends ModelClass
     public $logkey;
 
     /** @var string */
-    public $nick;
-
-    /** @var string */
     public $newPassword;
 
     /** @var string */
     public $newPassword2;
+
+    /** @var string */
+    public $nick;
 
     /** @var string */
     public $password;
@@ -254,7 +255,7 @@ class User extends ModelClass
      */
     public function getApiFieldsToHide(): array
     {
-        return ['password', 'logkey', 'two_factor_secret_key'];
+        return $this->pipeArray('getApiFieldsToHide', ['password', 'logkey', 'two_factor_secret_key']);
     }
 
     /**
@@ -274,15 +275,6 @@ class User extends ModelClass
         return $roles;
     }
 
-    public function getTwoFactorUrl(): string
-    {
-        return TwoFactorManager::getQRCodeUrl(
-            $this->getCompany()->nombrecorto ?? 'FacturaScripts',
-            $this->email,
-            $this->two_factor_secret_key
-        );
-    }
-
     public function getTwoFactorQR(): string
     {
         return $this->two_factor_enabled && !empty($this->two_factor_secret_key) ?
@@ -290,25 +282,13 @@ class User extends ModelClass
             '';
     }
 
-    public function install(): string
+    public function getTwoFactorUrl(): string
     {
-        // we need this models to be checked before
-        new DinPage();
-        new DinEmpresa();
-        new DinSerie();
-
-        $nick = Tools::config('initial_user', 'admin');
-        $pass = Tools::config('initial_pass', 'admin');
-        $email = filter_var($this->nick, FILTER_VALIDATE_EMAIL) ?
-            $this->nick :
-            Tools::config('initial_email', '');
-        $lang = Tools::config('lang');
-
-        Tools::log()->notice('created-default-admin-account', ['%nick%' => $nick, '%pass%' => $pass]);
-
-        return 'INSERT INTO ' . static::tableName() . ' (nick,password,email,admin,enabled,idempresa,codalmacen,langcode,homepage,level)'
-            . " VALUES ('" . $nick . "','" . password_hash($pass, PASSWORD_DEFAULT) . "','" . $email
-            . "',TRUE,TRUE,'1','1','" . $lang . "','Wizard','99');";
+        return TwoFactorManager::getQRCodeUrl(
+            $this->getCompany()->nombrecorto ?? 'FacturaScripts',
+            $this->email,
+            $this->two_factor_secret_key
+        );
     }
 
     /**
@@ -336,9 +316,25 @@ class User extends ModelClass
         return $this->homepage;
     }
 
-    private static function isSafePageName(string $name): bool
+    public function install(): string
     {
-        return $name !== '' && 1 === preg_match('/^[A-Za-z][A-Za-z0-9_]{0,49}$/', $name);
+        // we need this models to be checked before
+        new DinPage();
+        new DinEmpresa();
+        new DinSerie();
+
+        $nick = Tools::config('initial_user', 'admin');
+        $pass = Tools::config('initial_pass', 'admin');
+        $email = filter_var($this->nick, FILTER_VALIDATE_EMAIL) ?
+            $this->nick :
+            Tools::config('initial_email', '');
+        $lang = Tools::config('lang');
+
+        Tools::log()->notice('created-default-admin-account', ['%nick%' => $nick, '%pass%' => $pass]);
+
+        return 'INSERT INTO ' . static::tableName() . ' (nick,password,email,admin,enabled,idempresa,codalmacen,langcode,homepage,level)'
+            . " VALUES ('" . $nick . "','" . password_hash($pass, PASSWORD_DEFAULT) . "','" . $email
+            . "',TRUE,TRUE,'1','1','" . $lang . "','Wizard','99');";
     }
 
     public function newLogkey(string $ipAddress, string $browser = ''): string
@@ -478,21 +474,9 @@ class User extends ModelClass
         return TwoFactorManager::verifyCode($this->two_factor_secret_key, $code);
     }
 
-    protected function testPassword(): bool
+    private static function isSafePageName(string $name): bool
     {
-        if (isset($this->newPassword, $this->newPassword2) && $this->newPassword !== '' && $this->newPassword2 !== '') {
-            if ($this->newPassword !== $this->newPassword2) {
-                Tools::log()->warning('different-passwords', ['%userNick%' => $this->nick]);
-                return false;
-            }
-
-            if (false === $this->setPassword($this->newPassword)) {
-                Tools::log()->warning('weak-password', ['%userNick%' => $this->nick]);
-                return false;
-            }
-        }
-
-        return true;
+        return $name !== '' && 1 === preg_match('/^[A-Za-z][A-Za-z0-9_]{0,49}$/', $name);
     }
 
     protected function saveInsert(): bool
@@ -520,6 +504,23 @@ class User extends ModelClass
         $agent = new DinAgente();
         if (false === $agent->load($this->codagente)) {
             $this->codagente = null;
+        }
+
+        return true;
+    }
+
+    protected function testPassword(): bool
+    {
+        if (isset($this->newPassword, $this->newPassword2) && $this->newPassword !== '' && $this->newPassword2 !== '') {
+            if ($this->newPassword !== $this->newPassword2) {
+                Tools::log()->warning('different-passwords', ['%userNick%' => $this->nick]);
+                return false;
+            }
+
+            if (false === $this->setPassword($this->newPassword)) {
+                Tools::log()->warning('weak-password', ['%userNick%' => $this->nick]);
+                return false;
+            }
         }
 
         return true;

--- a/Core/Template/ExtensionsTrait.php
+++ b/Core/Template/ExtensionsTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2019-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2019-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -27,18 +27,18 @@ use ReflectionMethod;
 trait ExtensionsTrait
 {
     /**
-     * Stores class extensions.
-     *
-     * @var array
-     */
-    protected static $extensions = [];
-
-    /**
      * Cache for extension lookups by method name.
      *
      * @var array
      */
     protected static $extensionCache = [];
+
+    /**
+     * Stores class extensions.
+     *
+     * @var array
+     */
+    protected static $extensions = [];
 
     /**
      * Executes the first matched extension.
@@ -150,6 +150,34 @@ trait ExtensionsTrait
         }
 
         return null;
+    }
+
+    /**
+     * Ejecuta todas las extensiones registradas con este nombre encadenando un
+     * array acumulador: cada extensión recibe el array actual y devuelve el array
+     * modificado. Permite que varios plugins añadan elementos (no corta como pipe).
+     *
+     * @param string $name
+     * @param array $values valores iniciales del acumulador
+     * @param mixed ...$arguments argumentos extra pasados a cada extensión
+     *
+     * @return array
+     */
+    public function pipeArray(string $name, array $values = [], ...$arguments): array
+    {
+        // Build cache if needed
+        if (!isset(static::$extensionCache[$name])) {
+            $this->buildExtensionCache($name);
+        }
+
+        foreach (static::$extensionCache[$name] as $function) {
+            $return = call_user_func_array($function->bindTo($this, static::class), array_merge([$values], $arguments));
+            if (is_array($return)) {
+                $values = $return;
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/Core/Template/ModelClass.php
+++ b/Core/Template/ModelClass.php
@@ -66,9 +66,9 @@ abstract class ModelClass
 
     abstract public static function find($code): ?static;
 
-    abstract public static function findWhere(array $where, array $order = []): ?static;
-
     abstract public static function findOrCreate(array $where, array $data = []): ?static;
+
+    abstract public static function findWhere(array $where, array $order = []): ?static;
 
     abstract public function getModelFields(): array;
 
@@ -79,6 +79,8 @@ abstract class ModelClass
     abstract public function modelClassName(): string;
 
     abstract public function pipe($name, ...$arguments);
+
+    abstract public function pipeArray(string $name, array $values = [], ...$arguments): array;
 
     abstract public function pipeFalse($name, ...$arguments): bool;
 
@@ -285,7 +287,7 @@ abstract class ModelClass
      */
     public function getApiFieldsToHide(): array
     {
-        return [];
+        return $this->pipeArray('getApiFieldsToHide');
     }
 
     /**
@@ -811,6 +813,15 @@ abstract class ModelClass
         return in_array(strtolower($value), ['true', 't', '1'], false);
     }
 
+    private function getFloatValueForField(array $field, $value): ?float
+    {
+        if (is_numeric($value)) {
+            return (float)$value;
+        }
+
+        return $field['is_nullable'] === 'NO' ? 0.0 : null;
+    }
+
     private function getIntegerValueForField(array $field, $value): ?int
     {
         if (is_numeric($value)) {
@@ -822,15 +833,6 @@ abstract class ModelClass
         }
 
         return $field['is_nullable'] === 'NO' ? 0 : null;
-    }
-
-    private function getFloatValueForField(array $field, $value): ?float
-    {
-        if (is_numeric($value)) {
-            return (float)$value;
-        }
-
-        return $field['is_nullable'] === 'NO' ? 0.0 : null;
     }
 
     /**


### PR DESCRIPTION
Necesitamos que la función nueva getApiFieldsToHide() tenga compatibilidad para usar Pipes(), si no, se obliga a hacer herencias en los plugins para añadir columnas ocultas en la api.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.