### PR TITLE
mostrar plugins instalados en "mas plugins"

### DIFF
--- a/Core/Controller/AdminPlugins.php
+++ b/Core/Controller/AdminPlugins.php
@@ -207,9 +207,11 @@ class AdminPlugins extends Controller
         $installedPlugins = Plugins::list();
         foreach (Forja::plugins() as $item) {
             // plugin is already installed?
+            $item['installed'] = false;
             foreach ($installedPlugins as $plugin) {
                 if ($plugin->name == $item['name']) {
-                    continue 2;
+                    $item['installed'] = true;
+                    break;
                 }
             }
 

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -354,15 +354,8 @@
                     <div class="card-body p-3">
                         <h5 class="card-title d-flex align-items-start justify-content-between mb-2">
                             <span>{{ plugin.name }}</span>
-                            <span class="ms-2 flex-shrink-0">
-                                {% if plugin.installed %}
-                                    <span class="badge bg-success fw-normal">
-                                        <i class="fa-solid fa-check me-1" aria-hidden="true"></i>{{ trans('installed') }}
-                                    </span>
-                                {% endif %}
-                                <span class="badge bg-light text-dark border fw-normal">
-                                    v{{ plugin.version }}
-                                </span>
+                            <span class="badge bg-light text-dark border fw-normal ms-2 flex-shrink-0">
+                                v{{ plugin.version }}
                             </span>
                         </h5>
                         <p class="card-text text-muted mb-0"

--- a/Core/View/AdminPlugins.html.twig
+++ b/Core/View/AdminPlugins.html.twig
@@ -354,8 +354,15 @@
                     <div class="card-body p-3">
                         <h5 class="card-title d-flex align-items-start justify-content-between mb-2">
                             <span>{{ plugin.name }}</span>
-                            <span class="badge bg-light text-dark border fw-normal ms-2 flex-shrink-0">
-                                v{{ plugin.version }}
+                            <span class="ms-2 flex-shrink-0">
+                                {% if plugin.installed %}
+                                    <span class="badge bg-success fw-normal">
+                                        <i class="fa-solid fa-check me-1" aria-hidden="true"></i>{{ trans('installed') }}
+                                    </span>
+                                {% endif %}
+                                <span class="badge bg-light text-dark border fw-normal">
+                                    v{{ plugin.version }}
+                                </span>
                             </span>
                         </h5>
                         <p class="card-text text-muted mb-0"
@@ -364,9 +371,16 @@
                         </p>
                     </div>
                     <div class="card-footer p-2 bg-transparent d-flex align-items-center justify-content-between">
-                        <a href="{{ plugin.url }}" class="btn btn-sm btn-success" target="_blank">
-                            <i class="fa-solid fa-plus fa-fw me-1" aria-hidden="true"></i> {{ trans('add') }}
-                        </a>
+                        {% if plugin.installed %}
+                            <a href="#installed" class="btn btn-sm btn-outline-success"
+                               onclick="document.getElementById('installedPluginsTab').click();">
+                                <i class="fa-solid fa-check fa-fw me-1" aria-hidden="true"></i> {{ trans('installed') }}
+                            </a>
+                        {% else %}
+                            <a href="{{ plugin.url }}" class="btn btn-sm btn-success" target="_blank">
+                                <i class="fa-solid fa-plus fa-fw me-1" aria-hidden="true"></i> {{ trans('add') }}
+                            </a>
+                        {% endif %}
                         <span class="text-danger small" title="{{ trans('health') }}">
                             {{ _self.healthStatus(plugin.health) }}
                         </span>


### PR DESCRIPTION

# Descripción
- Se ha modificado AdminPlugins para que ahora tenga en cuenta los plugins instalados de manera que aparecen con el botón de "instalado" en vez de "instalar" y si lo pulsas te envía a adminplugins para ver los plugins listados.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

## Ayuda
Aquí tienes algunos enlaces de ayuda:
- (Documentación para programadores) https://facturascripts.com/ayuda?type=developer
- (Plan de desarrollo) https://facturascripts.com/roadmap
- (Discord) https://discord.gg/qKm7j9AaJT