### PR TITLE
registrar-log-solo-si-se-ejecuta-el-job

### DIFF
--- a/Core/Controller/Cron.php
+++ b/Core/Controller/Cron.php
@@ -286,9 +286,6 @@ END;
                 continue;
             }
 
-            echo PHP_EOL . Tools::trans('running-plugin-cron', ['%pluginName%' => $pluginName]) . ' ... ';
-            Tools::log('cron')->notice('running-plugin-cron', ['%pluginName%' => $pluginName]);
-
             try {
                 $cron = new $cronClass($pluginName);
                 $cron->run();

--- a/Core/Model/CronJob.php
+++ b/Core/Model/CronJob.php
@@ -85,6 +85,9 @@ class CronJob extends ModelClass
     /** @var bool */
     private $ready = false;
 
+    /** @var Closure|null */
+    private $ready_callback;
+
     /** @var int */
     public $running;
 
@@ -261,6 +264,10 @@ class CronJob extends ModelClass
             return false;
         }
 
+        if ($this->ready_callback !== null) {
+            ($this->ready_callback)();
+        }
+
         try {
             $function();
         } catch (Throwable $e) {
@@ -303,6 +310,12 @@ class CronJob extends ModelClass
         $this->save();
 
         return true;
+    }
+
+    public function setReadyCallback(?Closure $callback): self
+    {
+        $this->ready_callback = $callback;
+        return $this;
     }
 
     public function setMockDateTime(?string $dateTime, bool $update_microtime = true): void

--- a/Core/Template/CronClass.php
+++ b/Core/Template/CronClass.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Template;
 
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\CronJob;
 
@@ -26,6 +27,9 @@ abstract class CronClass
 {
     /** @var string */
     public $pluginName;
+
+    /** @var bool */
+    private $runningLog = false;
 
     abstract public function run(): void;
 
@@ -49,6 +53,16 @@ abstract class CronClass
 
         // si es un proceso zombie, lo liberamos
         $job->releaseIfStale();
+
+        $job->setReadyCallback(function () {
+            if ($this->runningLog) {
+                return;
+            }
+
+            echo PHP_EOL . Tools::trans('running-plugin-cron', ['%pluginName%' => $this->pluginName]) . ' ... ';
+            Tools::log('cron')->notice('running-plugin-cron', ['%pluginName%' => $this->pluginName]);
+            $this->runningLog = true;
+        });
 
         return $job;
     }

--- a/Test/Core/Model/CronJobTest.php
+++ b/Test/Core/Model/CronJobTest.php
@@ -343,6 +343,27 @@ final class CronJobTest extends TestCase
         $this->assertTrue($job->delete());
     }
 
+    public function testReadyCallback(): void
+    {
+        $called = false;
+        $job = new CronJob();
+        $job->jobname = 'TestReadyCallback';
+        $job->pluginname = 'TestPluginReadyCallback';
+        $job->setReadyCallback(function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertFalse($job->run(function () {
+        }));
+        $this->assertFalse($called);
+
+        $this->assertTrue($job->everyDayAt(0)->run(function () {
+        }));
+        $this->assertTrue($called);
+
+        $this->assertTrue($job->delete());
+    }
+
     public function testRunningCounterAfterSuccess(): void
     {
         $job = new CronJob();


### PR DESCRIPTION
# Descripción

El cambio corrige que el cron registrase running-plugin-cron al detectar una clase Cron de plugin, aunque ninguno de sus trabajos estuviera listo para ejecutarse.

  Antes el flujo era:

  1. Core\Controller\Cron::runPlugins() recorría plugins activos.
  2. Si existía FacturaScripts\Plugins\X\Cron, escribía siempre:
      - salida por pantalla running-plugin-cron
      - log Tools::log('cron')->notice(...)

  3. Después instanciaba el cron del plugin y llamaba a run().
  4. Dentro del plugin, cada trabajo llamaba a $this->job(...)->every(...)->run(...).
  5. CronJob::run() comprobaba isReady() y podía devolver false sin ejecutar nada.

  El bug estaba en que el log ocurría en el paso 2, antes de saber si algún CronJob iba a pasar isReady().

  Ahora el flujo queda así:

  1. Core\Controller\Cron::runPlugins() solo detecta e instancia la clase Cron del plugin.
  2. Ya no registra ni imprime running-plugin-cron de forma anticipada.
  3. El plugin ejecuta su método run() como antes.
  4. Cada trabajo se obtiene con CronClass::job().
  5. CronClass::job() asigna al CronJob un callback interno mediante setReadyCallback().
  6. El plugin sigue llamando igual:

     $this->job('name')->every(...)->run(function () {
         ...
     });

  7. CronJob::run() comprueba primero isReady().
  8. Si isReady() es false, devuelve false y no ejecuta ni el callback ni el trabajo.
  9. Si isReady() es true, guarda el estado inicial del job y entonces ejecuta el callback.
  10. Ese callback imprime y registra running-plugin-cron.
  11. Después se ejecuta el closure real del trabajo.
  12. Al terminar, CronJob::run() mantiene el comportamiento anterior: duración, done, failed, running, daily_exec, control de excepciones y logs críticos.

  La retrocompatibilidad se mantiene porque no cambia la API usada por los plugins. CronJob::run(Closure $function): bool conserva firma y comportamiento externo; solo se añade un hook opcional que el core usa
  internamente para retrasar el log hasta el punto correcto.

  Además, CronClass evita duplicar el mensaje con una bandera interna: si un plugin tiene varios jobs listos en la misma ejecución, running-plugin-cron se registra una sola vez por plugin.