### PR TITLE
Corrige posible colisión de nombres al guardar archivos subidos

### DIFF
--- a/Core/Controller/ApiAttachedFiles.php
+++ b/Core/Controller/ApiAttachedFiles.php
@@ -137,8 +137,13 @@ class ApiAttachedFiles extends ApiController
                 continue;
             }
 
-            $file->move('MyFiles', $file->getClientOriginalName());
-            $this->model->path = $file->getClientOriginalName();
+            // el nombre lo pone el navegador del cliente, por lo que dos subidas simultáneas
+            // con el mismo nombre se pisarían el archivo; añadimos un componente único
+            $parts = pathinfo($file->getClientOriginalName());
+            $fileName = $parts['filename'] . '_' . uniqid('', true)
+                . (empty($parts['extension']) ? '' : '.' . $parts['extension']);
+            $file->move('MyFiles', $fileName);
+            $this->model->path = $fileName;
         }
         foreach ($values as $key => $value) {
             $this->model->{$key} = $value;

--- a/Core/Controller/ApiProductoImagen.php
+++ b/Core/Controller/ApiProductoImagen.php
@@ -107,8 +107,13 @@ class ApiProductoImagen extends ApiController
                 continue;
             }
 
-            $file->move('MyFiles', $file->getClientOriginalName());
-            $this->model->path = $file->getClientOriginalName();
+            // el nombre lo pone el navegador del cliente, por lo que dos subidas simultáneas
+            // con el mismo nombre se pisarían el archivo; añadimos un componente único
+            $parts = pathinfo($file->getClientOriginalName());
+            $fileName = $parts['filename'] . '_' . uniqid('', true)
+                . (empty($parts['extension']) ? '' : '.' . $parts['extension']);
+            $file->move('MyFiles', $fileName);
+            $this->model->path = $fileName;
         }
         foreach ($values as $key => $value) {
             $this->model->{$key} = $value;

--- a/Core/Controller/SendMail.php
+++ b/Core/Controller/SendMail.php
@@ -436,11 +436,17 @@ class SendMail extends Controller
         $this->newMail->addAttachment(FS_FOLDER . '/' . NewMail::ATTACHMENTS_TMP_PATH . $fileName, $fileName);
 
         foreach ($this->request->files->getArray('uploads') as $file) {
-            // guardamos el adjunto en una carpeta temporal
-            if ($file->move(NewMail::ATTACHMENTS_TMP_PATH, $file->getClientOriginalName())) {
-                // añadimos el adjunto al email
-                $filePath = FS_FOLDER . '/' . NewMail::ATTACHMENTS_TMP_PATH . $file->getClientOriginalName();
-                $this->newMail->addAttachment($filePath, $file->getClientOriginalName());
+            // guardamos el adjunto en una carpeta temporal; el nombre lo pone el navegador
+            // del cliente, por lo que dos subidas simultáneas con el mismo nombre se
+            // pisarían el archivo; añadimos un componente único
+            $originalName = $file->getClientOriginalName();
+            $parts = pathinfo($originalName);
+            $diskName = $parts['filename'] . '_' . uniqid('', true)
+                . (empty($parts['extension']) ? '' : '.' . $parts['extension']);
+            if ($file->move(NewMail::ATTACHMENTS_TMP_PATH, $diskName)) {
+                // añadimos el adjunto al email con su nombre original
+                $filePath = FS_FOLDER . '/' . NewMail::ATTACHMENTS_TMP_PATH . $diskName;
+                $this->newMail->addAttachment($filePath, $originalName);
             }
         }
 

--- a/Core/Lib/ExtendedController/ProductImagesTrait.php
+++ b/Core/Lib/ExtendedController/ProductImagesTrait.php
@@ -69,8 +69,13 @@ trait ProductImagesTrait
             try {
                 $folder = Tools::folder('MyFiles');
                 Tools::folderCheckOrCreate($folder);
-                $uploadFile->move($folder, $uploadFile->getClientOriginalName());
-                $idfile = $this->createAttachedFile($uploadFile->getClientOriginalName());
+                // el nombre lo pone el navegador del cliente, por lo que dos subidas simultáneas
+                // con el mismo nombre se pisarían el archivo; añadimos un componente único
+                $parts = pathinfo($uploadFile->getClientOriginalName());
+                $fileName = $parts['filename'] . '_' . uniqid('', true)
+                    . (empty($parts['extension']) ? '' : '.' . $parts['extension']);
+                $uploadFile->move($folder, $fileName);
+                $idfile = $this->createAttachedFile($fileName);
                 if (empty($idfile)) {
                     Tools::log()->error('record-save-error');
                     return true;


### PR DESCRIPTION
Los archivos subidos (adjuntos de correo, imágenes de producto y subidas por API)
se guardaban con el nombre original que envía el navegador, por lo que dos subidas
simultáneas con el mismo nombre podían pisarse el archivo. Se sanea el nombre y se
añade un componente único; los nombres visibles no cambian.