### PR TITLE
fix(core): corrige comprobación de carpeta segura en Windows

### DIFF
--- a/Core/Controller/Files.php
+++ b/Core/Controller/Files.php
@@ -56,15 +56,16 @@ class Files implements ControllerInterface
             );
         }
 
-        if (false === $this->isFolderSafe($this->filePath)) {
-            throw new KernelException('UnsafeFolder', $url);
-        }
-
         $realPath = realpath($this->filePath);
         if (false === $realPath) {
             throw new KernelException('FileNotFound', Tools::trans('file-not-found', ['%fileName%' => $url]));
         }
         $this->filePath = $realPath;
+
+        if (false === $this->isFolderSafe($this->filePath)) {
+            throw new KernelException('UnsafeFolder', $url);
+        }
+
         if (false === $this->isFileSafe($this->filePath)) {
             throw new KernelException('UnsafeFile', $url);
         }


### PR DESCRIPTION
## Problema

Al ejecutar FacturaScripts con el servidor embebido de PHP en Windows nativo (`php -S 127.0.0.1:8080 -t . index.php`), todos los recursos estáticos (CSS, JS, imágenes de `Core`, `node_modules`, `vendor`...) devolvían el error `UnsafeFolder`, impidiendo el acceso a cualquier página excepto la de despliegue.

## Causa

En `Core/Controller/Files.php`, la ruta del archivo solicitado se construía concatenando `Tools::folder()` (que usa `DIRECTORY_SEPARATOR`) con la URL de la petición (que siempre usa `/`). La comprobación `isFolderSafe()` se ejecutaba sobre esa ruta **antes** de normalizarla con `realpath()`, comparando cadenas con separadores mezclados.

En Linux/macOS/WSL, `DIRECTORY_SEPARATOR` es `/`, por lo que nunca había mezcla y el bug pasaba desapercibido. En Windows, `DIRECTORY_SEPARATOR` es `\`, y la comparación de `isFolderSafe()` nunca encontraba coincidencia, rechazando cualquier archivo como carpeta insegura.

## Solución

Se mueve la comprobación `isFolderSafe()` a después de resolver `realpath()`, igual que ya hacía `Myfiles.php` para el mismo tipo de comparación. Así la ruta queda siempre normalizada con el separador correcto del sistema operativo antes de compararla.

## Pruebas

- Servidor embebido de PHP en Windows nativo: los recursos estáticos (`node_modules`, `Core/Assets`, etc.) se sirven correctamente.
- Sin cambios de comportamiento en Linux/WSL (la ruta ya coincidía en esos sistemas).

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
