### PR TITLE
Forzar descarga de archivos de hoja de cálculo/CSV servidos por token en Myfiles

### DIFF
--- a/Core/Controller/Myfiles.php
+++ b/Core/Controller/Myfiles.php
@@ -108,8 +108,9 @@ class Myfiles implements ControllerInterface
             ob_end_flush();
         }
 
-        // forzamos la descarga de archivos svg, xml y html para evitar ataques XSS
-        if ($this->shouldForceDownload($this->filePath)) {
+        // forzamos la descarga de archivos svg, xml y html para evitar ataques XSS,
+        // y también de los tipos de archivo marcados como descarga forzosa en MyFilesToken
+        if ($this->shouldForceDownload($this->filePath) || MyFilesToken::shouldForceDownload($this->filePath)) {
             header('Content-Disposition: attachment; filename="' . basename($this->filePath) . '"');
         }
 

--- a/Core/Lib/MyFilesToken.php
+++ b/Core/Lib/MyFilesToken.php
@@ -29,6 +29,12 @@ class MyFilesToken
     /** @var string */
     private static $date;
 
+    /**
+     * Extensiones que, al servirse a través de un token, deben forzar la descarga
+     * (Content-Disposition: attachment) en lugar de abrirse/previsualizarse en el navegador.
+     */
+    private const FORCE_DOWNLOAD_EXTENSIONS = ['csv', 'ods', 'xls', 'xlsx'];
+
     public static function get(string $path, bool $permanent, string $expiration = ''): string
     {
         self::checkPath($path);
@@ -62,6 +68,16 @@ class MyFilesToken
     public static function setCurrentDate(string $date): void
     {
         self::$date = $date;
+    }
+
+    /**
+     * Indica si el archivo, por su extensión, debe forzar la descarga en lugar
+     * de dejar que el navegador decida cómo mostrarlo.
+     */
+    public static function shouldForceDownload(string $path): bool
+    {
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        return in_array($extension, self::FORCE_DOWNLOAD_EXTENSIONS, true);
     }
 
     public static function validate(string $path, string $token): bool


### PR DESCRIPTION
## Resumen

`Myfiles` solo forzaba `Content-Disposition: attachment` para extensiones consideradas peligrosas (svg, xml, html...), dejando que el navegador decidiera cómo mostrar el resto. Esto provoca que archivos como `.xlsx` o `.csv` servidos mediante un token de `MyFilesToken` se abran/previsualicen en el navegador en lugar de descargarse.

## Cambios

- `MyFilesToken`: nuevo método estático `shouldForceDownload(string $path): bool`, que determina si la extensión del archivo (`csv`, `ods`, `xls`, `xlsx`) debe forzar la descarga.
- `Myfiles::run()`: la condición que decide si enviar `Content-Disposition: attachment` ahora también consulta `MyFilesToken::shouldForceDownload()`, además de su propia lista de extensiones peligrosas.