### PR TITLE
Fix #2944: corrige el widget datetime en Safari

### DIFF
--- a/Core/Assets/JS/WidgetDatetime.js
+++ b/Core/Assets/JS/WidgetDatetime.js
@@ -1,0 +1,52 @@
+/*
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * Completa y valida los campos datetime del formulario.
+ *
+ * En navegadores como Safari el input datetime-local se comporta como un campo
+ * de texto: el usuario puede enviar el formulario con la hora sin rellenar, o
+ * incluso con una fecha incompleta. Este script, al cambiar el valor:
+ *   1. Rellena automáticamente la hora y los minutos con la hora actual si faltan.
+ *   2. Avisa (y limpia el campo) si falta el día, el mes o el año.
+ *
+ * Se usa delegación de eventos sobre document para cubrir también las filas
+ * añadidas dinámicamente (EditListView).
+ */
+document.addEventListener('change', function (event) {
+    const input = event.target;
+    if (input && input.matches && input.matches('input.widget-datetime')) {
+        widgetDatetimeComplete(input);
+    }
+});
+
+function widgetDatetimeComplete(input) {
+    let value = (input.value || '').trim();
+    if (value === '') {
+        return;
+    }
+
+    // separa fecha y hora aceptando como separador la "T" o un espacio
+    const parts = value.split(/[T ]/);
+    const datePart = parts[0];
+    let timePart = parts.length > 1 ? parts[1] : '';
+
+    // la fecha debe tener año, mes y día (formato YYYY-MM-DD)
+    if (/^\d{4}-\d{2}-\d{2}$/.test(datePart) === false) {
+        window.alert('Fecha incompleta. Indica día, mes y año.');
+        input.value = '';
+        input.focus();
+        return;
+    }
+
+    // completa la hora con la actual si falta o está incompleta (formato HH:MM)
+    if (/^\d{2}:\d{2}/.test(timePart) === false) {
+        const now = new Date();
+        const hh = String(now.getHours()).padStart(2, '0');
+        const mm = String(now.getMinutes()).padStart(2, '0');
+        timePart = hh + ':' + mm;
+    }
+
+    // normaliza el valor al formato esperado por datetime-local: YYYY-MM-DDTHH:MM
+    input.value = datePart + 'T' + timePart.substring(0, 5);
+}

--- a/Core/Lib/Widget/WidgetDatetime.php
+++ b/Core/Lib/Widget/WidgetDatetime.php
@@ -19,7 +19,9 @@
 
 namespace FacturaScripts\Core\Lib\Widget;
 
+use FacturaScripts\Core\Lib\AssetManager;
 use FacturaScripts\Core\Request;
+use FacturaScripts\Core\Tools;
 
 /**
  * Description of WidgetDatetime
@@ -28,9 +30,15 @@ use FacturaScripts\Core\Request;
  */
 class WidgetDatetime extends BaseWidget
 {
+    protected function assets(): void
+    {
+        $route = Tools::config('route');
+        AssetManager::addJs($route . '/Dinamic/Assets/JS/WidgetDatetime.js?v=1');
+    }
+
     protected function inputHtml($type = 'datetime-local', $extraClass = '')
     {
-        $class = $this->combineClasses($this->css('form-control'), $this->class, $extraClass);
+        $class = $this->combineClasses($this->css('form-control'), 'widget-datetime', $this->class, $extraClass);
         $value = empty($this->value) ? '' : date('Y-m-d H:i:s', strtotime($this->value));
         return '<input type="' . $type . '" name="' . $this->fieldname . '" value="' . $value
             . '" class="' . $class . '"' . $this->inputHtmlExtraParams() . '/>';


### PR DESCRIPTION
# Descripción
Corrige el comportamiento del widget datetime en Safari (tarea #2944 del roadmap, con +1 de carlos).

En Safari el input datetime-local se comporta como un campo de texto y se podía enviar el formulario con la hora sin rellenar o con la fecha incompleta. Se añade un manejador `onchange` (nuevo `Core/Assets/JS/WidgetDatetime.js`) que:
- rellena hora y minutos con la hora actual si faltan,
- avisa y limpia el campo si falta el día, el mes o el año.

`WidgetDatetime.php` registra el nuevo JS con `assets()` y marca el input con la clase `widget-datetime`. No se modifican traducciones.

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [ ] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
