### PR TITLE
Fix #1110: refresca y valida el token AJAX en el editor de asientos

### DIFF
--- a/Core/Controller/EditAsiento.php
+++ b/Core/Controller/EditAsiento.php
@@ -194,6 +194,23 @@ class EditAsiento extends PanelController
      */
     protected function execPreviousAction($action)
     {
+        // estas acciones se ejecutan por AJAX desde el editor de asientos y deben
+        // validar el token para asegurar que la petición procede del formulario (CSRF, tarea #1110)
+        $tokenActions = ['find-subaccount', 'new-line', 'rm-line', 'recalculate', 'save-doc'];
+        if (in_array($action, $tokenActions, true) && false === $this->validateFormToken()) {
+            $this->setTemplate(false);
+            $this->response->json([
+                'header' => '',
+                'lines' => '',
+                'footer' => '',
+                'list' => '',
+                'ok' => false,
+                'messages' => Tools::log()::read('master', $this->logLevels),
+                'multireqtoken' => $this->multiRequestProtection->newToken()
+            ]);
+            return false;
+        }
+
         switch ($action) {
             case 'add-file':
                 return $this->addFileAction();
@@ -268,7 +285,8 @@ class EditAsiento extends PanelController
             'lines' => '',
             'footer' => '',
             'list' => AccountingModalHTML::renderSubaccountList($model),
-            'messages' => Tools::log()::read('master', $this->logLevels)
+            'messages' => Tools::log()::read('master', $this->logLevels),
+            'multireqtoken' => $this->multiRequestProtection->newToken()
         ];
         $this->response->json($content);
         return false;
@@ -344,7 +362,8 @@ class EditAsiento extends PanelController
             'lines' => $renderLines ? AccountingLineHTML::render($lines, $model) : '',
             'footer' => AccountingFooterHTML::render($model),
             'list' => '',
-            'messages' => Tools::log()::read('master', $this->logLevels)
+            'messages' => Tools::log()::read('master', $this->logLevels),
+            'multireqtoken' => $this->multiRequestProtection->newToken()
         ];
         $this->response->json($content);
         return false;
@@ -395,7 +414,11 @@ class EditAsiento extends PanelController
 
     protected function sendJsonError(): bool
     {
-        $this->response->json(['ok' => false, 'messages' => Tools::log()::read('master', $this->logLevels)]);
+        $this->response->json([
+            'ok' => false,
+            'messages' => Tools::log()::read('master', $this->logLevels),
+            'multireqtoken' => $this->multiRequestProtection->newToken()
+        ]);
         return false;
     }
 

--- a/Core/View/Tab/AccountingEntry.html.twig
+++ b/Core/View/Tab/AccountingEntry.html.twig
@@ -69,6 +69,9 @@
             animateSpinner('remove', false);
             return Promise.reject(response);
         }).then(function (data) {
+            if (typeof data.multireqtoken === 'string') {
+                document.forms['accEntryForm']['multireqtoken'].value = data.multireqtoken;
+            }
             if (data.header !== '') {
                 document.getElementById("accEntryFormHeader").innerHTML = data.header;
             }
@@ -124,6 +127,9 @@
             animateSpinner('remove', false);
             return Promise.reject(response);
         }).then(function (data) {
+            if (typeof data.multireqtoken === 'string') {
+                document.forms['accEntryForm']['multireqtoken'].value = data.multireqtoken;
+            }
             if (Array.isArray(data.messages)) {
                 data.messages.forEach(item => alert(item.message));
             }


### PR DESCRIPTION
# Descripción
Implementa la tarea #1110 en la parte de asientos: refresca el token en cada petición AJAX del editor de asientos y lo valida en el controlador (protección CSRF / anti-duplicado). Ventas y compras ya lo tenían; esto completa la parte de asientos.

- `Core/Controller/EditAsiento.php`: valida el token en las acciones AJAX (find-subaccount, new-line, rm-line, recalculate, save-doc) y devuelve un token nuevo (`multireqtoken`) en cada respuesta JSON.
- `Core/View/Tab/AccountingEntry.html.twig`: el JS actualiza el token del formulario con el que devuelve cada respuesta.

Probado en una instancia real: el token se valida, se refresca en cada acción, y un token ya usado se rechaza como "petición duplicada".

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.
