### PR TITLE
Bloquea el asiento generado automaticamente desde la factura

### DIFF
--- a/Core/Lib/Accounting/InvoiceToAccounting.php
+++ b/Core/Lib/Accounting/InvoiceToAccounting.php
@@ -594,6 +594,15 @@ class InvoiceToAccounting extends AccountingClass
             return;
         }
 
+        // el asiento generado automáticamente desde la factura queda bloqueado:
+        // así se evita descuadrarlo a mano. Al modificar/eliminar la factura, el
+        // flujo de contabilización vuelve a marcarlo editable antes de borrarlo.
+        $entry->editable = false;
+        if (false === $entry->save()) {
+            Tools::log()->warning('accounting-entry-error', ['%document%' => $this->document->codigo]);
+            return;
+        }
+
         $this->document->idasiento = $entry->id();
     }
 
@@ -660,6 +669,15 @@ class InvoiceToAccounting extends AccountingClass
                 '%difference%' => abs($entry->debe - $entry->haber)
             ]);
             $entry->delete();
+            return;
+        }
+
+        // el asiento generado automáticamente desde la factura queda bloqueado:
+        // así se evita descuadrarlo a mano. Al modificar/eliminar la factura, el
+        // flujo de contabilización vuelve a marcarlo editable antes de borrarlo.
+        $entry->editable = false;
+        if (false === $entry->save()) {
+            Tools::log()->warning('accounting-entry-error', ['%document%' => $this->document->codigo]);
             return;
         }
 

--- a/Test/Core/Model/FacturaClienteTest.php
+++ b/Test/Core/Model/FacturaClienteTest.php
@@ -277,6 +277,9 @@ final class FacturaClienteTest extends TestCase
         $this->assertEquals($invoice->fecha, $entry->fecha, 'accounting-entry-bad-date');
         $this->assertEquals($invoice->idasiento, $entry->idasiento, 'accounting-entry-bad-idasiento');
 
+        // el asiento generado desde la factura debe nacer bloqueado (no editable)
+        $this->assertFalse($entry->editable, 'accounting-entry-should-be-locked');
+
         // aplicamos un descuento para modificar el total de la factura
         $invoice->dtopor1 = 50;
         Calculator::calculate($invoice, $lines, false);

--- a/Test/Core/Model/FacturaProveedorTest.php
+++ b/Test/Core/Model/FacturaProveedorTest.php
@@ -198,6 +198,9 @@ final class FacturaProveedorTest extends TestCase
         $this->assertEquals($invoice->fecha, $entry->fecha, 'accounting-entry-bad-fecha');
         $this->assertEquals($invoice->idasiento, $entry->idasiento, 'accounting-entry-bad-idasiento');
 
+        // el asiento generado desde la factura debe nacer bloqueado (no editable)
+        $this->assertFalse($entry->editable, 'accounting-entry-should-be-locked');
+
         // cambiamos el descuento para que cambie el total (el asiento debe cambiar)
         $invoice->dtopor1 = 50;
         $this->assertTrue(Calculator::calculate($invoice, $lines, true), 'cant-update-invoice-discount');


### PR DESCRIPTION
## Descripción

El asiento contable que genera `InvoiceToAccounting` a partir de una factura de venta o compra nace ahora bloqueado (`editable = false`), para evitar que se descuadre editándolo a mano.

Al modificar el total o eliminar la factura, el flujo de contabilización (`InvoiceTrait`) ya marca el asiento como editable antes de borrarlo, así que la regeneración y el borrado de la factura siguen funcionando con normalidad.

Se añade la comprobación en `FacturaClienteTest` y `FacturaProveedorTest`: el asiento nace con `editable = false` y la factura se puede seguir modificando y eliminando.

Roadmap: https://facturascripts.com/roadmap/1111

## ¿Cómo has probado los cambios?

- [x] He revisado mi código antes de enviarlo.
- [x] He probado en una instancia real que la factura genera su asiento bloqueado y que al eliminar la factura el asiento se borra correctamente.
