### PR TITLE
Enlaza el asiento con su documento original (no solo facturas)

### DIFF
--- a/Core/Lib/AjaxForms/AccountingHeaderHTML.php
+++ b/Core/Lib/AjaxForms/AccountingHeaderHTML.php
@@ -22,12 +22,9 @@ namespace FacturaScripts\Core\Lib\AjaxForms;
 use FacturaScripts\Core\DataSrc\Empresas;
 use FacturaScripts\Core\Lib\CodePatterns;
 use FacturaScripts\Core\Tools;
-use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\Asiento;
 use FacturaScripts\Dinamic\Model\ConceptoPartida;
 use FacturaScripts\Dinamic\Model\Diario;
-use FacturaScripts\Dinamic\Model\FacturaCliente;
-use FacturaScripts\Dinamic\Model\FacturaProveedor;
 
 /**
  * Description of AccountingHeaderHTML
@@ -90,19 +87,12 @@ class AccountingHeaderHTML
             return '';
         }
 
+        // el documento original puede ser una factura de venta/compra o, en los
+        // pagos, el recibo. getDoc() lo resuelve a partir del idasiento.
         $link = '';
-        $facturaCliente = new FacturaCliente();
-        $where = [
-            Where::eq('codigo', $model->documento),
-            Where::eq('idasiento', $model->idasiento),
-        ];
-        if ($facturaCliente->loadWhere($where)) {
-            $link = $facturaCliente->url();
-        } else {
-            $facturaProveedor = new FacturaProveedor();
-            if ($facturaProveedor->loadWhere($where)) {
-                $link = $facturaProveedor->url();
-            }
+        $doc = $model->getDoc();
+        if ($doc !== null && method_exists($doc, 'url')) {
+            $link = $doc->url();
         }
 
         if ($link) {

--- a/Core/Model/Asiento.php
+++ b/Core/Model/Asiento.php
@@ -108,6 +108,47 @@ class Asiento extends ModelClass
         $this->operacion = self::OPERATION_GENERAL;
     }
 
+    /**
+     * Devuelve el documento original que generó este asiento (factura de venta o
+     * compra, o el recibo en el caso de los pagos) o null si no se puede localizar.
+     *
+     * En FacturaScripts cada documento guarda su idasiento, así que resolvemos el
+     * enlace al revés: buscamos qué documento apunta a este asiento. En los pagos
+     * devolvemos el recibo, que es el documento con el que se relaciona el asiento.
+     *
+     * @return mixed|null
+     */
+    public function getDoc()
+    {
+        if (empty($this->idasiento)) {
+            return null;
+        }
+
+        $models = ['FacturaCliente', 'FacturaProveedor', 'PagoCliente', 'PagoProveedor'];
+        foreach ($models as $model) {
+            $class = '\\FacturaScripts\\Dinamic\\Model\\' . $model;
+            if (false === class_exists($class)) {
+                continue;
+            }
+
+            $docs = (new $class())->all([Where::eq('idasiento', $this->idasiento)], [], 0, 1);
+            if (empty($docs)) {
+                continue;
+            }
+
+            $doc = $docs[0];
+
+            // en los pagos el documento relacionado con el asiento es el recibo
+            if (in_array($doc->modelClassName(), ['PagoCliente', 'PagoProveedor'], true)) {
+                return $doc->getReceipt();
+            }
+
+            return $doc;
+        }
+
+        return null;
+    }
+
     public function delete(): bool
     {
         if (false === $this->editable()) {


### PR DESCRIPTION
## Descripción

Hasta ahora el enlace al documento original que se muestra en el asiento (`AccountingHeaderHTML`) solo resolvía facturas de venta y compra. Se añade `Asiento::getDoc()`, que resuelve el documento a partir del `idasiento` (cada documento guarda su asiento): devuelve la `FacturaCliente`/`FacturaProveedor` o, en los asientos de pago, el `ReciboCliente`/`ReciboProveedor`.

`AccountingHeaderHTML::documento()` pasa a usar `getDoc()`, de modo que el botón de enlace del asiento apunta también a los recibos, no solo a las facturas.

No cambia la base de datos ni requiere migración.

Roadmap: https://facturascripts.com/roadmap/2724

## ¿Cómo has probado los cambios?

- [x] He revisado mi código antes de enviarlo.
- [x] He probado en una instancia real que el asiento de una factura enlaza a la FacturaCliente y el asiento de un pago enlaza al ReciboCliente.
