### PR TITLE
Permite bloquear variantes sin bloquear el producto

### DIFF
--- a/Core/Lib/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Lib/AjaxForms/PurchasesLineHTML.php
@@ -250,9 +250,9 @@ class PurchasesLineHTML
         // buscamos el código de barras en las variantes
         $whereBarcode = [Where::eq('codbarras', $formData['fastli'])];
         foreach (Variante::all($whereBarcode, [], 0, 5) as $variante) {
-            // comprobamos que el producto se puede comprar
+            // comprobamos que la variante no esté bloqueada y que el producto se pueda comprar
             $product = $variante->getProducto();
-            if (!$product->bloqueado && $product->secompra) {
+            if (false === $variante->bloqueada && !$product->bloqueado && $product->secompra) {
                 return $model->getNewProductLine($variante->referencia);
             }
         }

--- a/Core/Lib/AjaxForms/PurchasesModalHTML.php
+++ b/Core/Lib/AjaxForms/PurchasesModalHTML.php
@@ -223,7 +223,7 @@ class PurchasesModalHTML
             . ' LEFT JOIN productosprov pp ON pp.referencia = p.referencia'
             . ' AND pp.codproveedor = ' . $dataBase->var2str(self::$codproveedor)
             . ' AND pp.coddivisa = ' . $dataBase->var2str(self::$coddivisa)
-            . ' WHERE p.secompra = true AND p.bloqueado = false';
+            . ' WHERE p.secompra = true AND p.bloqueado = false AND v.bloqueada = false';
 
         if (self::$codfabricante) {
             $sql .= ' AND p.codfabricante = ' . $dataBase->var2str(self::$codfabricante);

--- a/Core/Lib/AjaxForms/SalesLineHTML.php
+++ b/Core/Lib/AjaxForms/SalesLineHTML.php
@@ -295,9 +295,9 @@ class SalesLineHTML
         // buscamos el código de barras en las variantes
         $whereBarcode = [Where::eq('codbarras', $formData['fastli'])];
         foreach (Variante::all($whereBarcode, [], 0, 5) as $variante) {
-            // comprobamos que el producto se pueda vender
+            // comprobamos que la variante no esté bloqueada y que el producto se pueda vender
             $product = $variante->getProducto();
-            if (!$product->bloqueado && $product->sevende) {
+            if (false === $variante->bloqueada && !$product->bloqueado && $product->sevende) {
                 return $model->getNewProductLine($variante->referencia);
             }
         }

--- a/Core/Lib/AjaxForms/SalesModalHTML.php
+++ b/Core/Lib/AjaxForms/SalesModalHTML.php
@@ -241,7 +241,7 @@ class SalesModalHTML
             . ' FROM variantes v'
             . ' LEFT JOIN productos p ON v.idproducto = p.idproducto'
             . ' LEFT JOIN stocks s ON v.referencia = s.referencia AND s.codalmacen = ' . $dataBase->var2str(self::$codalmacen)
-            . ' WHERE p.sevende = true AND p.bloqueado = false';
+            . ' WHERE p.sevende = true AND p.bloqueado = false AND v.bloqueada = false';
 
         if (self::$codfabricante) {
             $sql .= ' AND p.codfabricante = ' . $dataBase->var2str(self::$codfabricante);

--- a/Core/Model/Variante.php
+++ b/Core/Model/Variante.php
@@ -42,6 +42,9 @@ class Variante extends ModelClass
     use ModelTrait;
     use ProductRelationTrait;
 
+    /** @var bool Indica si la variante está bloqueada (no se vende ni se compra), sin afectar al producto. */
+    public $bloqueada;
+
     /** @var string Código de barras de la variante. */
     public $codbarras;
 
@@ -78,6 +81,7 @@ class Variante extends ModelClass
     public function clear(): void
     {
         parent::clear();
+        $this->bloqueada = false;
         $this->coste = 0.0;
         $this->margen = 0.0;
         $this->precio = 0.0;

--- a/Core/Table/variantes.xml
+++ b/Core/Table/variantes.xml
@@ -7,6 +7,11 @@
 -->
 <table>
     <column>
+        <name>bloqueada</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+    <column>
         <name>codbarras</name>
         <type>character varying(20)</type>
     </column>

--- a/Core/XMLView/EditVariante.xml
+++ b/Core/XMLView/EditVariante.xml
@@ -55,6 +55,9 @@
             <column name="stock" display="right" numcolumns="2" order="200">
                 <widget type="number" fieldname="stockfis" readonly="true"/>
             </column>
+            <column name="blocked" title="blocked" numcolumns="2" order="210">
+                <widget type="checkbox" fieldname="bloqueada"/>
+            </column>
         </group>
     </columns>
 </view>

--- a/Test/Core/Model/VarianteTest.php
+++ b/Test/Core/Model/VarianteTest.php
@@ -56,6 +56,32 @@ final class VarianteTest extends TestCase
         $this->assertEmpty($variante->exists());
     }
 
+    public function testBloqueada(): void
+    {
+        // creamos un producto
+        $producto = new Producto();
+        $this->assertTrue($producto->save(), 'cant-save-product');
+
+        // por defecto la variante no está bloqueada
+        $variante = $producto->getVariants()[0];
+        $this->assertFalse((bool)$variante->bloqueada, 'variant-blocked-by-default');
+
+        // bloqueamos la variante
+        $variante->bloqueada = true;
+        $this->assertTrue($variante->save(), 'cant-save-variant');
+
+        // la recargamos y comprobamos que sigue bloqueada
+        $reload = new Variante();
+        $this->assertTrue($reload->load($variante->idvariante), 'cant-reload-variant');
+        $this->assertTrue((bool)$reload->bloqueada, 'variant-not-blocked-after-reload');
+
+        // bloquear la variante no bloquea el producto
+        $this->assertFalse((bool)$producto->bloqueado, 'product-should-not-be-blocked');
+
+        // eliminamos el producto
+        $this->assertTrue($producto->delete(), 'cant-delete-product');
+    }
+
     public function testSetPriceWithTax(): void
     {
         $default_tax = Impuestos::default();


### PR DESCRIPTION
## Descripción
Implementa la tarea #1810 del roadmap: https://facturascripts.com/roadmap/1810

Permite bloquear una variante concreta sin bloquear el producto completo. Se añade el campo booleano `bloqueada` a la tabla `variantes` (por defecto `false`). Una variante bloqueada deja de aparecer en los buscadores de ventas y compras, pero el resto de variantes del producto siguen disponibles y el producto sigue activo.

Cambios:
- Campo `bloqueada` en el modelo `Variante` y en `Core/Table/variantes.xml`.
- Checkbox "blocked" en la vista `EditVariante`.
- Los buscadores de ventas (`SalesModalHTML`, `SalesLineHTML`) y de compras (`PurchasesModalHTML`, `PurchasesLineHTML`) excluyen las variantes bloqueadas.
- Test `testBloqueada`.

## Description (english)
Implements roadmap task #1810. Adds a `bloqueada` (blocked) boolean field to the `variantes` table so a single variant can be blocked without blocking the whole product. Blocked variants are excluded from the sales and purchases search, while the other variants of the product remain available and the product stays active.

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en un entorno real de FacturaScripts.