### PR TITLE
Corregir error de permisos al editar adjuntos de producto con modelcode nulo

### DIFF
--- a/Core/Lib/ExtendedController/DocFilesTrait.php
+++ b/Core/Lib/ExtendedController/DocFilesTrait.php
@@ -157,8 +157,9 @@ trait DocFilesTrait
             return true;
         }
 
+        $modelId = $fileRelation->modelid ?? $fileRelation->modelcode;
         if (
-            $fileRelation->modelcode != $this->request->query('code') ||
+            $modelId != $this->request->query('code') ||
             $fileRelation->model !== $this->getModelClassName()
         ) {
             Tools::log()->warning('not-allowed-modify');
@@ -189,6 +190,33 @@ trait DocFilesTrait
             new DataBaseWhere('modelid|modelcode', $modelid) :
             new DataBaseWhere('modelcode', $modelid);
         $view->loadData('', $where, ['orden' => 'ASC', 'creationdate' => 'DESC']);
+    }
+
+    private function sortFilesAction(): bool
+    {
+        if (false === $this->permissions->allowUpdate) {
+            Tools::log()->warning('not-allowed-modify');
+            return true;
+        }
+
+        $idsOrdenadas = $this->request->request->getArray('orden');
+        if (false === empty($idsOrdenadas)) {
+            $orden = 1;
+            foreach ($idsOrdenadas as $id_archivo) {
+                $archivo = new AttachedFileRelation();
+                $archivo->load($id_archivo);
+                $archivo->orden = $orden;
+                if ($archivo->save()) {
+                    $orden++;
+                }
+            }
+        }
+
+        $this->setTemplate(false);
+
+        $this->response->json(['status' => 'ok']);
+
+        return false;
     }
 
     private function unlinkFileAction(): bool
@@ -248,32 +276,5 @@ trait DocFilesTrait
         }
 
         return true;
-    }
-
-    private function sortFilesAction(): bool
-    {
-        if (false === $this->permissions->allowUpdate) {
-            Tools::log()->warning('not-allowed-modify');
-            return true;
-        }
-
-        $idsOrdenadas = $this->request->request->getArray('orden');
-        if (false === empty($idsOrdenadas)) {
-            $orden = 1;
-            foreach ($idsOrdenadas as $id_archivo) {
-                $archivo = new AttachedFileRelation();
-                $archivo->load($id_archivo);
-                $archivo->orden = $orden;
-                if ($archivo->save()) {
-                    $orden++;
-                }
-            }
-        }
-
-        $this->setTemplate(false);
-
-        $this->response->json(['status' => 'ok']);
-
-        return false;
     }
 }

--- a/Core/Lib/ExtendedController/ProductImagesTrait.php
+++ b/Core/Lib/ExtendedController/ProductImagesTrait.php
@@ -95,6 +95,56 @@ trait ProductImagesTrait
     }
 
     /**
+     * Create the record in the AttachedFile model
+     * and returns its identifier.
+     *
+     * @param string $path
+     * @return int
+     */
+    protected function createAttachedFile(string $path): int
+    {
+        $newFile = new AttachedFile();
+        $newFile->path = $path;
+        $newFile->save();
+        return $newFile->idfile;
+    }
+
+    /**
+     * Create the record in the AttachedFileRelation model.
+     *
+     * @param int $idproduct
+     * @param int $idfile
+     */
+    protected function createFileRelation(int $idproduct, int $idfile): void
+    {
+        $fileRelation = new AttachedFileRelation();
+        $fileRelation->idfile = $idfile;
+        $fileRelation->model = 'Producto';
+        $fileRelation->modelid = $idproduct;
+        $fileRelation->modelcode = (string)$idproduct;
+        $fileRelation->nick = $this->user->nick;
+        $fileRelation->save();
+    }
+
+    /**
+     * Create the record in the ProductoImagen model
+     * and returns its idproducto.
+     *
+     * @param int $idfile
+     * @return ?int
+     */
+    protected function createProductImage(int $idfile): ?int
+    {
+        $productImage = new ProductoImagen();
+        $productImage->idproducto = $this->request->input('idproducto');
+        $productImage->idfile = $idfile;
+
+        $reference = $this->request->input('referencia', '');
+        $productImage->referencia = empty($reference) ? null : $reference;
+        return $productImage->save() ? $productImage->idproducto : null;
+    }
+
+    /**
      * Add view for product images.
      *
      * @param string $viewName
@@ -134,54 +184,5 @@ trait ProductImagesTrait
         $this->dataBase->rollback();
         Tools::log()->error('record-delete-error');
         return true;
-    }
-
-    /**
-     * Create the record in the AttachedFile model
-     * and returns its identifier.
-     *
-     * @param string $path
-     * @return int
-     */
-    protected function createAttachedFile(string $path): int
-    {
-        $newFile = new AttachedFile();
-        $newFile->path = $path;
-        $newFile->save();
-        return $newFile->idfile;
-    }
-
-    /**
-     * Create the record in the ProductoImagen model
-     * and returns its idproducto.
-     *
-     * @param int $idfile
-     * @return ?int
-     */
-    protected function createProductImage(int $idfile): ?int
-    {
-        $productImage = new ProductoImagen();
-        $productImage->idproducto = $this->request->input('idproducto');
-        $productImage->idfile = $idfile;
-
-        $reference = $this->request->input('referencia', '');
-        $productImage->referencia = empty($reference) ? null : $reference;
-        return $productImage->save() ? $productImage->idproducto : null;
-    }
-
-    /**
-     * Create the record in the AttachedFileRelation model.
-     *
-     * @param int $idproduct
-     * @param int $idfile
-     */
-    protected function createFileRelation(int $idproduct, int $idfile): void
-    {
-        $fileRelation = new AttachedFileRelation();
-        $fileRelation->idfile = $idfile;
-        $fileRelation->model = 'Producto';
-        $fileRelation->modelid = $idproduct;
-        $fileRelation->nick = $this->user->nick;
-        $fileRelation->save();
     }
 }


### PR DESCRIPTION
## Descripción
Al editar un archivo adjunto de un producto desde la pestaña "Documentos" (por ejemplo, para marcar cualquier campo del formulario de edición del adjunto), se mostraba el mensaje "No tiene permiso para modificar" incluso para usuarios administradores.

La causa es que los adjuntos subidos desde la pestaña "Imágenes" del producto (`ProductImagesTrait::createFileRelation()`) guardaban la relación con `modelcode` a `NULL`, dejando solo `modelid` relleno. Esos adjuntos sí aparecen listados en la pestaña "Documentos" (porque el listado filtra por `modelid|modelcode`), pero al guardar la edición, `DocFilesTrait::editFileAction()` comparaba únicamente `modelcode` contra el código de la URL, por lo que la comparación fallaba siempre.

## Cambios realizados
- `DocFilesTrait::editFileAction()`: usa `modelid ?? modelcode` para la comprobación, igual que ya hacía `deleteFileAction()`.
- `ProductImagesTrait::createFileRelation()`: rellena también `modelcode` al crear la relación, para que los nuevos registros queden consistentes desde el origen.

## Cómo probar
1. Subir una imagen a un producto desde la pestaña "Imágenes".
2. Ir a la pestaña "Documentos" del mismo producto.
3. Editar el adjunto correspondiente (por ejemplo, cambiar las observaciones o cualquier campo añadido por un plugin) y pulsar "Guardar".
4. Verificar que se guarda correctamente y ya no aparece el mensaje "No tiene permiso para modificar".

🤖 Generado con [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>