### PR TITLE
Modernizar estilo plantilla factura

### DIFF
--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -53,6 +53,13 @@ abstract class PDFDocument extends PDFCore
 
     const INVOICE_TOTALS_Y = 200;
 
+    private const COLOR_ACCENT = [0.08, 0.39, 0.70];
+    private const COLOR_HEADER = [0.88, 0.94, 0.98];
+    private const COLOR_ROW = [0.97, 0.99, 1.00];
+    private const COLOR_TEXT = [0.14, 0.18, 0.23];
+    private const COLOR_LINE = [0.78, 0.86, 0.93];
+    private const COLOR_TOTAL = [0.84, 0.92, 0.98];
+
     /** @var FormatoDocumento */
     protected $format;
 
@@ -178,6 +185,23 @@ abstract class PDFDocument extends PDFCore
         ];
     }
 
+    protected function businessTableOptions(array $cols = [], bool $showHeadings = true): array
+    {
+        return [
+            'cols' => $cols,
+            'shaded' => $showHeadings ? 1 : 0,
+            'showHeadings' => $showHeadings ? 1 : 0,
+            'shadeCol' => self::COLOR_ROW,
+            'shadeHeadingCol' => self::COLOR_HEADER,
+            'textCol' => self::COLOR_TEXT,
+            'lineCol' => self::COLOR_LINE,
+            'innerLineThickness' => 0.35,
+            'outerLineThickness' => 0.7,
+            'rowGap' => 3,
+            'width' => $this->tableWidth
+        ];
+    }
+
     /**
      * @param BusinessDocument $model
      *
@@ -278,12 +302,7 @@ abstract class PDFDocument extends PDFCore
         $qrSubtitle = $this->pipe('qrSubtitleAfterLines', $model);
 
         $headers = [];
-        $tableOptions = [
-            'cols' => [],
-            'shadeCol' => [0.95, 0.95, 0.95],
-            'shadeHeadingCol' => [0.95, 0.95, 0.95],
-            'width' => $this->tableWidth
-        ];
+        $tableOptions = $this->businessTableOptions();
 
         // fill headers and options with the line headers information
         foreach ($this->getLineHeaders() as $key => $value) {
@@ -384,19 +403,14 @@ abstract class PDFDocument extends PDFCore
             'taxsurcharge' => $this->i18n->trans('amount')
         ];
         $taxRows = $this->getTaxesRows($model);
-        $taxTableOptions = [
-            'cols' => [
+        $taxTableOptions = $this->businessTableOptions([
                 'tax' => ['justification' => 'right'],
                 'taxbase' => ['justification' => 'right'],
                 'taxp' => ['justification' => 'right'],
                 'taxamount' => ['justification' => 'right'],
                 'taxsurchargep' => ['justification' => 'right'],
                 'taxsurcharge' => ['justification' => 'right']
-            ],
-            'shadeCol' => [0.95, 0.95, 0.95],
-            'shadeHeadingCol' => [0.95, 0.95, 0.95],
-            'width' => $this->tableWidth
-        ];
+            ]);
         if (count($taxRows) > 1) {
             $this->removeEmptyCols($taxRows, $taxHeaders, Tools::number(0));
             $this->pdf->ezTable($taxRows, $taxHeaders, '', $taxTableOptions);
@@ -433,8 +447,10 @@ abstract class PDFDocument extends PDFCore
             ]
         ];
         $this->removeEmptyCols($rows, $headers, Tools::number(0));
-        $tableOptions = [
-            'cols' => [
+        if (isset($headers['total'])) {
+            $rows[0]['total'] = '<b>' . $rows[0]['total'] . '</b>';
+        }
+        $tableOptions = $this->businessTableOptions([
                 'subtotal' => ['justification' => 'right'],
                 'dto' => ['justification' => 'right'],
                 'dto-2' => ['justification' => 'right'],
@@ -443,12 +459,9 @@ abstract class PDFDocument extends PDFCore
                 'totalSurcharge' => ['justification' => 'right'],
                 'totalIrpf' => ['justification' => 'right'],
                 'totalSupplied' => ['justification' => 'right'],
-                'total' => ['justification' => 'right']
-            ],
-            'shadeCol' => [0.95, 0.95, 0.95],
-            'shadeHeadingCol' => [0.95, 0.95, 0.95],
-            'width' => $this->tableWidth
-        ];
+                'total' => ['justification' => 'right', 'bgcolor' => self::COLOR_TOTAL]
+            ]);
+        $rows[0]['totalColor'] = [0, 0, 0];
         $this->pdf->ezTable($rows, $headers, '', $tableOptions);
 
         // receipts
@@ -510,17 +523,15 @@ abstract class PDFDocument extends PDFCore
         }
 
         // Título alineado a la izquierda y dentro del bloque
-        $this->pdf->ezText("\n" . $headerData['title'] . ': ' . $model->codigo, self::FONT_SIZE + 6, [
-            'justification' => 'left',
-            'left' => $startX - $this->pdf->ez['leftMargin'], // compensar margen
-            'width' => $leftBlockWidth
-        ]);
-
-        // Línea divisoria solo del 80%
-        $lineY = $this->pdf->y;
-        $this->pdf->setStrokeColor(0, 0, 0);
-        $this->pdf->line($startX, $lineY - 8, $startX + $leftBlockWidth, $lineY - 8);
-        $this->pdf->y -= 10;
+        $title = $headerData['title'] . ': ' . Tools::fixHtml($model->codigo);
+        $barHeight = 28;
+        $barY = $startY - $barHeight;
+        $this->pdf->setColor(...self::COLOR_ACCENT);
+        $this->pdf->filledRectangle($startX, $barY, $leftBlockWidth, $barHeight);
+        $this->pdf->setColor(1, 1, 1);
+        $this->pdf->addText($startX + 10, $startY - 19, self::FONT_SIZE + 6, $title, $leftBlockWidth - 20, 'left');
+        $this->pdf->setColor(...self::COLOR_TEXT);
+        $this->pdf->y = $barY - 14;
         $subject = $model->getSubject();
         $tipoIdFiscal = empty($subject->tipoidfiscal) ? $this->i18n->trans('cifnif') : $subject->tipoidfiscal;
         $serie = $model->getSerie();
@@ -551,15 +562,10 @@ abstract class PDFDocument extends PDFCore
         }
 
         // Opciones de la tabla
-        $tableWidth = $leftBlockWidth + 5;
-        $tableOptions = [
-            'width' => $tableWidth,
-            'showHeadings' => 0,
-            'shaded' => 0,
-            'lineCol' => [1, 1, 1],
-            'cols' => [],
-            'xPos' => $startX + ($tableWidth / 2) - 5, // Posicionar el centro de la tabla para que empiece en el margen izquierdo
-        ];
+        $tableWidth = $leftBlockWidth;
+        $tableOptions = $this->businessTableOptions([], false);
+        $tableOptions['xPos'] = $startX + ($tableWidth / 2);
+        $tableOptions['width'] = $tableWidth;
         $this->insertParallelTable($tableData, '', $tableOptions);
         $this->pdf->ezText('');
         $this->pdf->restoreState();
@@ -580,7 +586,9 @@ abstract class PDFDocument extends PDFCore
      */
     protected function insertBusinessDocShipping($model)
     {
+        $this->pdf->setColor(...self::COLOR_ACCENT);
         $this->pdf->ezText("\n" . $this->i18n->trans('shipping-address') . "\n", self::FONT_SIZE + 6);
+        $this->pdf->setColor(...self::COLOR_TEXT);
         $this->newLine();
 
         $contacto = new Contacto();
@@ -595,13 +603,7 @@ abstract class PDFDocument extends PDFCore
                 ['key' => $this->i18n->trans('tracking-code'), 'value' => $model->codigoenv]
             ];
 
-            $tableOptions = [
-                'width' => $this->tableWidth,
-                'showHeadings' => 0,
-                'shaded' => 0,
-                'lineCol' => [1, 1, 1],
-                'cols' => []
-            ];
+            $tableOptions = $this->businessTableOptions([], false);
             $this->insertParallelTable($tableData, '', $tableOptions);
             $this->pdf->ezText('');
         }
@@ -666,7 +668,9 @@ abstract class PDFDocument extends PDFCore
         }
 
         $size = mb_strlen($company->nombre) > 20 ? self::FONT_SIZE + 2 : self::FONT_SIZE + 7;
+        $this->pdf->setColor(...self::COLOR_ACCENT);
         $this->pdf->ezText(Tools::fixHtml($company->nombre), $size, ['justification' => 'right']);
+        $this->pdf->setColor(...self::COLOR_TEXT);
         $address = $company->direccion;
         $address .= empty($company->codpostal) ? "\n" : "\n" . $company->codpostal . ', ';
         $address .= empty($company->ciudad) ? '' : $company->ciudad;
@@ -684,6 +688,9 @@ abstract class PDFDocument extends PDFCore
 
         $idLogo = $this->format->idlogo ?? $company->idlogo;
         $this->insertCompanyLogo($idLogo);
+        $this->pdf->setStrokeColor(...self::COLOR_ACCENT);
+        $this->pdf->line(self::CONTENT_X, $this->pdf->y + 8, $this->tableWidth + self::CONTENT_X, $this->pdf->y + 8);
+        $this->pdf->setStrokeColor(0, 0, 0);
     }
 
     /**
@@ -701,15 +708,10 @@ abstract class PDFDocument extends PDFCore
             ['method' => $this->getBankData($invoice), 'expiration' => $expiration]
         ];
 
-        $tableOptions = [
-            'cols' => [
+        $tableOptions = $this->businessTableOptions([
                 'method' => ['justification' => 'left'],
                 'expiration' => ['justification' => 'right']
-            ],
-            'shadeCol' => [0.95, 0.95, 0.95],
-            'shadeHeadingCol' => [0.95, 0.95, 0.95],
-            'width' => $this->tableWidth
-        ];
+            ]);
         $this->pdf->ezText("\n");
         $this->pdf->ezTable($rows, $headers, '', $tableOptions);
     }
@@ -738,17 +740,12 @@ abstract class PDFDocument extends PDFCore
                     'vencimiento' => $receipt->pagado ? $this->i18n->trans('paid') : $receipt->vencimiento
                 ];
             }
-            $tableOptions = [
-                'cols' => [
+            $tableOptions = $this->businessTableOptions([
                     'numero' => ['justification' => 'center'],
                     'bank' => ['justification' => 'center'],
                     'importe' => ['justification' => 'right'],
                     'vencimiento' => ['justification' => 'right']
-                ],
-                'shadeCol' => [0.95, 0.95, 0.95],
-                'shadeHeadingCol' => [0.95, 0.95, 0.95],
-                'width' => $this->tableWidth
-            ];
+                ]);
             $this->pdf->ezText("\n");
             $this->pdf->ezTable($rows, $headers, '', $tableOptions);
         }

--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -53,12 +53,12 @@ abstract class PDFDocument extends PDFCore
 
     const INVOICE_TOTALS_Y = 200;
 
-    private const COLOR_ACCENT = [0.08, 0.39, 0.70];
-    private const COLOR_HEADER = [0.88, 0.94, 0.98];
-    private const COLOR_ROW = [0.97, 0.99, 1.00];
-    private const COLOR_TEXT = [0.14, 0.18, 0.23];
-    private const COLOR_LINE = [0.78, 0.86, 0.93];
-    private const COLOR_TOTAL = [0.84, 0.92, 0.98];
+    private const COLOR_ACCENT = [0.15, 0.15, 0.15];
+    private const COLOR_HEADER = [0.95, 0.95, 0.95];
+    private const COLOR_ROW = [0.98, 0.98, 0.98];
+    private const COLOR_TEXT = [0.10, 0.10, 0.10];
+    private const COLOR_LINE = [0.75, 0.75, 0.75];
+    private const COLOR_TOTAL = [0.88, 0.88, 0.88];
 
     /** @var FormatoDocumento */
     protected $format;


### PR DESCRIPTION
# Descripción
- Modernizar estilo del PDF de los documentos. De cara a los nuevos usuarios que llegan a probar el ERP, el PDF de documentos es mas atractivo y actual.
- Se suavizan las líneas y bordes de las tablas.
- Se añade más aire mediante márgenes y separación interna en las celdas.
- Se da mayor énfasis al tipo de documento —por ejemplo, “Factura”— y a su código.
- Se mejora la alineación entre los datos del cliente, las líneas y los totales.
- Se mantiene una paleta basada en grises y negros.
- Se destaca el importe total con fondo gris, texto negro y negrita.
- Se mejora la jerarquía visual de cabecera, datos fiscales, líneas y resumen final.

https://github.com/user-attachments/assets/6d4caa78-70d0-48cd-a4b5-ba7b23a1d895

