### PR TITLE
Añade la operación ES_04 (IPSI) a OperacionIVA

### DIFF
--- a/Core/Lib/OperacionIVA.php
+++ b/Core/Lib/OperacionIVA.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of FacturaScripts
- * Copyright (C) 2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2025-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -29,6 +29,7 @@ class OperacionIVA
     const ES_OPERATION_01 = 'ES_01'; // valor añadido
     const ES_OPERATION_02 = 'ES_02'; // Ceuta y Melilla
     const ES_OPERATION_03 = 'ES_03'; // IGIC
+    const ES_OPERATION_04 = 'ES_04'; // IPSI
     const ES_OPERATION_99 = 'ES_99'; // otro
 
     /** @var array */
@@ -46,6 +47,7 @@ class OperacionIVA
             self::ES_OPERATION_01 => 'es-operation-tax-added-value',
             self::ES_OPERATION_02 => 'es-operation-tax-ceuta-melilla',
             self::ES_OPERATION_03 => 'es-operation-tax-igic',
+            self::ES_OPERATION_04 => 'es-operation-tax-ipsi',
             self::ES_OPERATION_99 => 'es-operation-tax-other',
         ];
 


### PR DESCRIPTION
## Descripción

Añade la operación de IVA `ES_04` correspondiente al **IPSI** (Impuesto sobre la Producción, los Servicios y la Importación), aplicable en Ceuta y Melilla.

## Cambios

- Nueva constante `OperacionIVA::ES_OPERATION_04` con valor `ES_04`.
- Nueva entrada en el listado de operaciones con la clave de traducción `es-operation-tax-ipsi`.

## Notas

La clave de traducción `es-operation-tax-ipsi` aún no existe en los archivos de idioma; habría que añadirla desde el sistema de traducciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)