### PR TITLE
Amplía el campo operacion de 20 a 30 caracteres

### DIFF
--- a/Core/Lib/InvoiceOperation.php
+++ b/Core/Lib/InvoiceOperation.php
@@ -36,6 +36,9 @@ class InvoiceOperation
 
     const INTRA_COMMUNITY_SERVICES = 'intracom-servicios';
 
+    /** Longitud máxima de la clave, igual que la del campo operacion de las tablas de documentos. */
+    const MAX_KEY_LENGTH = 30;
+
     const REVERSE_CHARGE = 'inv-sujeto-pasivo';
 
     const SUCCESSIVE_TRACT = 'successive-tract';
@@ -57,7 +60,7 @@ class InvoiceOperation
 
     public static function add(string $key, string $value, ?string $type = null): void
     {
-        $fixedKey = substr($key, 0, 20);
+        $fixedKey = substr($key, 0, self::MAX_KEY_LENGTH);
         self::$all[$fixedKey] = $value;
         unset(self::$removed[$fixedKey]);
 
@@ -93,7 +96,7 @@ class InvoiceOperation
 
     public static function remove(string $key): void
     {
-        $fixedKey = substr($key, 0, 20);
+        $fixedKey = substr($key, 0, self::MAX_KEY_LENGTH);
         unset(self::$all[$fixedKey], self::$types[$fixedKey]);
         self::$removed[$fixedKey] = true;
     }

--- a/Core/Table/albaranescli.xml
+++ b/Core/Table/albaranescli.xml
@@ -167,7 +167,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>provincia</name>

--- a/Core/Table/albaranesprov.xml
+++ b/Core/Table/albaranesprov.xml
@@ -148,7 +148,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>provincia</name>

--- a/Core/Table/clientes.xml
+++ b/Core/Table/clientes.xml
@@ -100,7 +100,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>personafisica</name>

--- a/Core/Table/facturascli.xml
+++ b/Core/Table/facturascli.xml
@@ -184,7 +184,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>pagada</name>

--- a/Core/Table/facturasprov.xml
+++ b/Core/Table/facturasprov.xml
@@ -164,7 +164,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>pagada</name>

--- a/Core/Table/pedidoscli.xml
+++ b/Core/Table/pedidoscli.xml
@@ -171,7 +171,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>provincia</name>

--- a/Core/Table/pedidosprov.xml
+++ b/Core/Table/pedidosprov.xml
@@ -147,7 +147,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>provincia</name>

--- a/Core/Table/presupuestoscli.xml
+++ b/Core/Table/presupuestoscli.xml
@@ -170,7 +170,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>provincia</name>

--- a/Core/Table/presupuestosprov.xml
+++ b/Core/Table/presupuestosprov.xml
@@ -147,7 +147,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>provincia</name>

--- a/Core/Table/proveedores.xml
+++ b/Core/Table/proveedores.xml
@@ -85,7 +85,7 @@
     </column>
     <column>
         <name>operacion</name>
-        <type>character varying(20)</type>
+        <type>character varying(30)</type>
     </column>
     <column>
         <name>personafisica</name>


### PR DESCRIPTION
## Descripción

Las claves de operación de facturación se truncaban a 20 caracteres tanto en `InvoiceOperation::add()` como en `remove()`, lo que limitaba los identificadores que pueden registrar los plugins. Se amplía el límite a 30 caracteres.

## Cambios

- Nueva constante `InvoiceOperation::MAX_KEY_LENGTH` con valor `30`, utilizada en `add()` y `remove()` en lugar del literal `20`.
- La columna `operacion` pasa a `character varying(30)` en las tablas:
  - `clientes`, `proveedores`
  - `presupuestoscli`, `pedidoscli`, `albaranescli`, `facturascli`
  - `presupuestosprov`, `pedidosprov`, `albaranesprov`, `facturasprov`

## Notas

La ampliación de la columna es compatible hacia atrás: los valores existentes no se ven afectados y el actualizador de esquema aplica el `ALTER TABLE` automáticamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)