### PR TITLE
Permite anidar controladores dentro de carpetas para cargarlos solo c…

### DIFF
--- a/Core/Internal/PluginsDeploy.php
+++ b/Core/Internal/PluginsDeploy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of FacturaScripts
  * Copyright (C) 2017-2025 Carlos Garcia Gomez <carlos@facturascripts.com>
@@ -20,6 +21,7 @@
 namespace FacturaScripts\Core\Internal;
 
 use Exception;
+use FacturaScripts\Core\Plugins;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Translator;
 use FacturaScripts\Dinamic\Model\Page;
@@ -37,40 +39,8 @@ final class PluginsDeploy
 
     public static function initControllers(): void
     {
-        $files = Tools::folderScan(Tools::folder('Dinamic', 'Controller'), false);
-        foreach ($files as $fileName) {
-            if (substr($fileName, -4) !== '.php') {
-                continue;
-            }
-
-            // excluimos Installer y los que comienzan por Api
-            $controllerName = basename($fileName, '.php');
-            if ($controllerName === 'Installer' || str_starts_with($controllerName, 'Api')) {
-                continue;
-            }
-
-            // validamos el nombre del controlador para evitar el path traversal
-            if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $controllerName)) {
-                Tools::log()->warning('Invalid controller name: ' . $controllerName);
-                continue;
-            }
-
-            $controllerNamespace = '\\FacturaScripts\\Dinamic\\Controller\\' . $controllerName;
-            Tools::log()->debug('Loading controller: ' . $controllerName);
-
-            if (!class_exists($controllerNamespace)) {
-                // forzamos la carga del archivo porque en este punto el autoloader no lo encontrará
-                require Tools::folder('Dinamic', 'Controller', $controllerName . '.php');
-            }
-
-            try {
-                $controller = new $controllerNamespace($controllerName);
-                self::loadPage($controller->getPageData());
-            } catch (Exception $exc) {
-                Tools::log()->critical('cant-load-controller', ['%controllerName%' => $controllerName]);
-                Tools::log()->critical($exc->getMessage());
-            }
-        }
+        // comprobamos los controladores del núcleo y de los plugins
+        self::initControllersCheck(Tools::folder('Dinamic', 'Controller'), true);
 
         self::removeOldPages();
 
@@ -177,6 +147,67 @@ final class PluginsDeploy
         }
 
         return $isAbstract ? 'abstract class' : 'class';
+    }
+
+    private static function initControllersCheck(string $path, bool $isRoot = false): void
+    {
+        if (!is_dir($path) && !is_file($path)) {
+            return;
+        }
+
+        if (is_dir($path)) {
+            $relativePath = str_replace(Tools::folder('Dinamic', 'Controller') . DIRECTORY_SEPARATOR, '', $path);
+            $segments = array_values(array_filter(explode(DIRECTORY_SEPARATOR, $relativePath), 'strlen'));
+            $firstSegment = $segments[0] ?? '';
+
+            if (!$isRoot && !empty($firstSegment) && !Plugins::isEnabled($firstSegment)) {
+                return;
+            }
+
+            foreach (Tools::folderScan($path, false) as $childName) {
+                self::initControllersCheck($path . DIRECTORY_SEPARATOR . $childName);
+            }
+
+            return;
+        }
+
+        if (substr($path, -4) !== '.php') {
+            return;
+        }
+
+        $controllerFileName = basename($path);
+
+        // excluimos Installer y los que comienzan por Api
+        $controllerName = basename($controllerFileName, '.php');
+        if ($controllerName === 'Installer' || str_starts_with($controllerName, 'Api')) {
+            return;
+        }
+
+        // validamos el nombre del controlador para evitar el path traversal
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $controllerName)) {
+            Tools::log()->warning('Invalid controller name: ' . $controllerName);
+            return;
+        }
+
+        $relativePath = str_replace(Tools::folder('Dinamic', 'Controller') . DIRECTORY_SEPARATOR, '', $path);
+        $relativePath = str_replace('.php', '', $relativePath);
+        $relativePath = str_replace(DIRECTORY_SEPARATOR, '\\', $relativePath);
+
+        $controllerNamespace = '\\FacturaScripts\\Dinamic\\Controller\\' . $relativePath;
+        Tools::log()->debug('Loading controller: ' . $controllerName);
+
+        if (!class_exists($controllerNamespace)) {
+            // forzamos la carga del archivo porque en este punto el autoloader no lo encontrará
+            require $path;
+        }
+
+        try {
+            $controller = new $controllerNamespace($controllerName);
+            self::loadPage($controller->getPageData());
+        } catch (Exception $exc) {
+            Tools::log()->critical('cant-load-controller', ['%controllerName%' => $controllerName]);
+            Tools::log()->critical($exc->getMessage());
+        }
     }
 
     private static function linkFile(string $fileName, string $folder, string $filePath): void

--- a/Core/Kernel.php
+++ b/Core/Kernel.php
@@ -216,28 +216,6 @@ final class Kernel
         self::$routes = [];
         self::loadDefaultRoutes();
 
-        // cargamos la página por defecto
-        $homePage = Tools::settings('default', 'homepage', 'Root');
-
-        // recorremos toda la lista de archivos de la carpeta Dinamic/Controller
-        $dir = Tools::folder('Dinamic', 'Controller');
-        foreach (Tools::folderScan($dir) as $file) {
-            // si no es un archivo php, lo ignoramos
-            if ('.php' !== substr($file, -4)) {
-                continue;
-            }
-
-            // añadimos la ruta
-            $route = substr($file, 0, -4);
-            $controller = '\\FacturaScripts\\Dinamic\\Controller\\' . $route;
-            self::addRoute('/' . $route, $controller);
-
-            // si la ruta coincide con homepage, la añadimos como raíz
-            if ($route === $homePage) {
-                self::addRoute('/', $controller);
-            }
-        }
-
         // ejecutamos los callbacks para añadir rutas
         foreach (self::$routesCallbacks as $callback) {
             $callback(self::$routes);
@@ -368,20 +346,66 @@ final class Kernel
      */
     private static function checkControllerClass(string $controller): array
     {
-        $class = explode('\\', $controller);
+        $normalizedController = trim(str_replace('/', '\\', $controller), '\\');
+        $class = explode('\\', $normalizedController);
         $name = end($class);
 
-        // si la clase no tiene namespace, lo añadimos
+        $candidates = [];
         if (count($class) === 1) {
-            $controller = '\\FacturaScripts\\Dinamic\\Controller\\' . $controller;
+            $candidates[] = '\\FacturaScripts\\Dinamic\\Controller\\' . $normalizedController;
+            $candidates[] = '\\FacturaScripts\\Core\\Controller\\' . $normalizedController;
+        } else {
+            $candidates[] = '\\' . $normalizedController;
         }
 
-        // si el controlador no existe, lo buscamos en la carpeta Core
-        if (!class_exists($controller)) {
-            $controller = '\\FacturaScripts\\Core\\Controller\\' . end($class);
+        foreach ($candidates as $candidate) {
+            if (class_exists($candidate)) {
+                return [$candidate, $name];
+            }
         }
 
-        return [$controller, $name];
+        $searchRoots = [
+            ['dir' => Tools::folder('Dinamic', 'Controller'), 'prefix' => '\\FacturaScripts\\Dinamic\\Controller'],
+            ['dir' => Tools::folder('Core', 'Controller'), 'prefix' => '\\FacturaScripts\\Core\\Controller'],
+        ];
+
+        foreach ($searchRoots as $searchRoot) {
+            if (!is_dir($searchRoot['dir'])) {
+                continue;
+            }
+
+            foreach (Tools::folderScan($searchRoot['dir'], true) as $file) {
+                if (substr($file, -4) !== '.php') {
+                    continue;
+                }
+
+                if (basename($file, '.php') !== $name) {
+                    continue;
+                }
+
+                $relativePath = substr($file, 0, -4);
+                $resolvedController = $searchRoot['prefix'] . '\\' . str_replace('/', '\\', $relativePath);
+                $absolutePath = Tools::folder($searchRoot['dir'], $file);
+
+                if (!class_exists($resolvedController)) {
+                    require $absolutePath;
+                }
+
+                if (class_exists($resolvedController)) {
+                    return [$resolvedController, $name];
+                }
+            }
+        }
+
+        $fallbackController = count($class) === 1
+            ? '\\FacturaScripts\\Dinamic\\Controller\\' . $normalizedController
+            : '\\' . $normalizedController;
+
+        if (!class_exists($fallbackController)) {
+            $fallbackController = '\\FacturaScripts\\Core\\Controller\\' . $name;
+        }
+
+        return [$fallbackController, $name];
     }
 
     /**
@@ -550,6 +574,26 @@ final class Kernel
             }
 
             self::addRoute($route, '\\FacturaScripts\\Core\\Controller\\' . $controller, $position);
+        }
+
+        $homePage = Tools::settings('default', 'homepage', 'Root');
+        $dir = Tools::folder('Dinamic', 'Controller');
+        if (is_dir($dir)) {
+            foreach (Tools::folderScan($dir, true) as $file) {
+                if (substr($file, -4) !== '.php') {
+                    continue;
+                }
+
+                $relativePath = substr($file, 0, -4);
+                $route = '/' . str_replace(DIRECTORY_SEPARATOR, '/', $relativePath);
+                $controller = '\\FacturaScripts\\Dinamic\\Controller\\' . str_replace('/', '\\', $relativePath);
+
+                self::addRoute($route, $controller);
+
+                if ($relativePath === $homePage) {
+                    self::addRoute('/', $controller);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
…uando el plugin X está activado

En ocasiones queremos crear un controlador que depende de un controlador del plugin X pero no queremos poner como required el plugin X, ya es que más un compatibilidad que un requisito. De este modo dentro de la carpeta Controller podemos crear una carpeta con el nombre del plugin X y solo se copiarán esos controladores cuando el plugin X este activado.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [x] He ejecutado los tests unitarios.