### PR TITLE
Fix/api irpf por linea

### DIFF
--- a/Core/Lib/ApiBusinessDocumentTrait.php
+++ b/Core/Lib/ApiBusinessDocumentTrait.php
@@ -44,6 +44,22 @@ trait ApiBusinessDocumentTrait
         $line->dtopor = (float)($data['dtopor'] ?? $line->dtopor);
         $line->dtopor2 = (float)($data['dtopor2'] ?? $line->dtopor2);
 
+        // el IRPF solo se sobrescribe si viene en los datos, para no perder
+        // el porcentaje heredado de la cabecera (retención del cliente o
+        // proveedor) ni el de una línea que ya existe.
+        if (isset($data['irpf'])) {
+            $line->irpf = (float)$data['irpf'];
+        }
+
+        if (isset($data['orden'])) {
+            $line->orden = (int)$data['orden'];
+        }
+
+        // coste solo existe en las líneas de venta.
+        if (isset($data['coste']) && property_exists($line, 'coste')) {
+            $line->coste = (float)$data['coste'];
+        }
+
         if (isset($data['excepcioniva'])) {
             $line->excepcioniva = $data['excepcioniva'] === 'null' ? null : $data['excepcioniva'];
         }

--- a/Test/Core/Controller/ApiCreateDocumentTest.php
+++ b/Test/Core/Controller/ApiCreateDocumentTest.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Controller;
+
+use FacturaScripts\Core\Controller\ApiCreateDocument;
+use FacturaScripts\Core\DataSrc\Retenciones;
+use FacturaScripts\Core\Model\AlbaranCliente;
+use FacturaScripts\Core\Model\FacturaCliente;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+
+final class ApiCreateDocumentTest extends TestCase
+{
+    use DefaultSettingsTrait;
+    use LogErrorsTrait;
+    use RandomDataTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::setDefaultSettings();
+        self::installAccountingPlan();
+        self::removeTaxRegularization();
+    }
+
+    public function testLineIrpfIsApplied(): void
+    {
+        // creamos un cliente sin retención, para que la cabecera no aporte IRPF
+        $subject = $this->getRandomCustomer();
+        $subject->codretencion = null;
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos un albarán con IRPF por línea
+        $payload = [
+            'codcliente' => $subject->codcliente,
+            'lineas' => json_encode([
+                ['descripcion' => 'línea con IRPF', 'cantidad' => 1, 'pvpunitario' => 100, 'irpf' => 15],
+            ]),
+        ];
+        $result = $this->callCreate('crearAlbaranCliente', $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'create-irpf-bad-code');
+
+        // cargamos el documento creado
+        $doc = new AlbaranCliente();
+        $this->assertTrue($doc->load($result['body']['doc']['idalbaran'] ?? 0), 'can-not-load-albaran');
+
+        // la línea conserva el IRPF enviado
+        $lines = $doc->getLines();
+        $this->assertCount(1, $lines, 'bad-line-count');
+        $this->assertEquals(15, $lines[0]->irpf, 'line-irpf-not-applied');
+
+        // y los totales lo reflejan
+        $this->assertEquals(100, $doc->neto, 'bad-neto');
+        $this->assertEquals(15, $doc->irpf, 'bad-doc-irpf');
+        $this->assertEquals(15, $doc->totalirpf, 'bad-totalirpf');
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
+    public function testLineIrpfOverridesSubjectRetention(): void
+    {
+        // necesitamos dos retenciones distintas para distinguir cabecera y línea
+        $percentages = [];
+        foreach (Retenciones::all() as $retention) {
+            if (false === in_array($retention->porcentaje, $percentages, true)) {
+                $percentages[] = $retention->porcentaje;
+            }
+            if (count($percentages) > 1) {
+                break;
+            }
+        }
+        if (count($percentages) < 2) {
+            $this->markTestSkipped('not-enough-retentions');
+        }
+
+        // creamos un cliente con la primera retención
+        $subject = $this->getRandomCustomer();
+        foreach (Retenciones::all() as $retention) {
+            if ($retention->porcentaje === $percentages[0]) {
+                $subject->codretencion = $retention->codretencion;
+                break;
+            }
+        }
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos el albarán enviando la segunda retención en la línea
+        $payload = [
+            'codcliente' => $subject->codcliente,
+            'lineas' => json_encode([
+                [
+                    'descripcion' => 'línea con IRPF propio',
+                    'cantidad' => 1,
+                    'pvpunitario' => 100,
+                    'irpf' => $percentages[1],
+                ],
+            ]),
+        ];
+        $result = $this->callCreate('crearAlbaranCliente', $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'create-irpf-override-bad-code');
+
+        $doc = new AlbaranCliente();
+        $this->assertTrue($doc->load($result['body']['doc']['idalbaran'] ?? 0), 'can-not-load-albaran');
+
+        // gana el IRPF de la línea, no el del cliente
+        $lines = $doc->getLines();
+        $this->assertCount(1, $lines, 'bad-line-count');
+        $this->assertEquals($percentages[1], $lines[0]->irpf, 'subject-retention-not-overridden');
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
+    public function testLineWithoutIrpfInheritsFromSubject(): void
+    {
+        // buscamos una retención cualquiera
+        $retention = null;
+        foreach (Retenciones::all() as $item) {
+            if ($item->porcentaje > 0) {
+                $retention = $item;
+                break;
+            }
+        }
+        if (null === $retention) {
+            $this->markTestSkipped('no-retentions-available');
+        }
+
+        // creamos un cliente con retención
+        $subject = $this->getRandomCustomer();
+        $subject->codretencion = $retention->codretencion;
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos el albarán sin enviar irpf en la línea
+        $payload = [
+            'codcliente' => $subject->codcliente,
+            'lineas' => json_encode([
+                ['descripcion' => 'línea sin IRPF', 'cantidad' => 1, 'pvpunitario' => 100],
+            ]),
+        ];
+        $result = $this->callCreate('crearAlbaranCliente', $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'create-no-irpf-bad-code');
+
+        $doc = new AlbaranCliente();
+        $this->assertTrue($doc->load($result['body']['doc']['idalbaran'] ?? 0), 'can-not-load-albaran');
+
+        // se mantiene el comportamiento anterior: hereda la retención del cliente
+        $lines = $doc->getLines();
+        $this->assertCount(1, $lines, 'bad-line-count');
+        $this->assertEquals($retention->porcentaje, $lines[0]->irpf, 'subject-retention-not-inherited');
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
+    public function testInvoiceLineIrpfIsApplied(): void
+    {
+        // el asiento de retención necesita una Retencion con ese porcentaje,
+        // así que usamos una de las que trae el país configurado
+        $retention = null;
+        foreach (Retenciones::all() as $item) {
+            if ($item->porcentaje > 0) {
+                $retention = $item;
+                break;
+            }
+        }
+        if (null === $retention) {
+            $this->markTestSkipped('no-retentions-available');
+        }
+
+        // creamos un cliente sin retención asignada
+        $subject = $this->getRandomCustomer();
+        $subject->codretencion = null;
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos la factura con IRPF por línea
+        $payload = [
+            'codcliente' => $subject->codcliente,
+            'lineas' => json_encode([
+                [
+                    'descripcion' => 'línea con IRPF',
+                    'cantidad' => 1,
+                    'pvpunitario' => 100,
+                    'irpf' => $retention->porcentaje,
+                ],
+            ]),
+        ];
+        $result = $this->callCreate('crearFacturaCliente', $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'create-invoice-irpf-bad-code');
+
+        $invoice = new FacturaCliente();
+        $this->assertTrue($invoice->load($result['body']['doc']['idfactura'] ?? 0), 'can-not-load-invoice');
+
+        // la línea conserva el IRPF enviado
+        $lines = $invoice->getLines();
+        $this->assertCount(1, $lines, 'bad-line-count');
+        $this->assertEquals($retention->porcentaje, $lines[0]->irpf, 'invoice-line-irpf-not-applied');
+
+        // y la factura descuenta la retención del total
+        $this->assertEquals(100, $invoice->neto, 'bad-neto');
+        $this->assertEquals($retention->porcentaje, $invoice->irpf, 'bad-invoice-irpf');
+        $this->assertEquals($retention->porcentaje, $invoice->totalirpf, 'bad-totalirpf');
+        $this->assertEquals(
+            round(100 + $invoice->totaliva - $invoice->totalirpf, 2),
+            round($invoice->total, 2),
+            'bad-total'
+        );
+
+        // limpiamos
+        $this->assertTrue($invoice->delete(), 'can-not-delete-invoice');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
+    public function testLineOrderAndCostAreApplied(): void
+    {
+        // creamos un cliente
+        $subject = $this->getRandomCustomer();
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos el albarán indicando orden y coste
+        $payload = [
+            'codcliente' => $subject->codcliente,
+            'lineas' => json_encode([
+                ['descripcion' => 'primera', 'cantidad' => 1, 'pvpunitario' => 100, 'orden' => 10, 'coste' => 40],
+            ]),
+        ];
+        $result = $this->callCreate('crearAlbaranCliente', $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'create-order-cost-bad-code');
+
+        $doc = new AlbaranCliente();
+        $this->assertTrue($doc->load($result['body']['doc']['idalbaran'] ?? 0), 'can-not-load-albaran');
+
+        $lines = $doc->getLines();
+        $this->assertCount(1, $lines, 'bad-line-count');
+        $this->assertEquals(10, $lines[0]->orden, 'line-orden-not-applied');
+        $this->assertEquals(40, $lines[0]->coste, 'line-coste-not-applied');
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
+    /**
+     * Ejecuta el controlador ApiCreateDocument simulando una petición, evitando
+     * la validación de token (que pertenece a ApiController) y capturando la
+     * respuesta sin enviarla.
+     *
+     * @param string $resource
+     * @param array $body
+     * @param string $method
+     *
+     * @return array{code: int, body: array}
+     */
+    private function callCreate(string $resource, array $body, string $method = 'POST'): array
+    {
+        $_SERVER['REQUEST_METHOD'] = $method;
+        unset($_SERVER['CONTENT_TYPE']);
+        $_POST = $body;
+        $_GET = [];
+
+        $url = '/api/3/' . $resource;
+
+        $api = new class ('ApiCreateDocument', $url) extends ApiCreateDocument {
+            public function exec(): array
+            {
+                $this->response->disableSend(true);
+                $this->runResource();
+                $decoded = json_decode($this->response->getContent(), true);
+
+                return [
+                    'code' => $this->response->getHttpCode(),
+                    'body' => is_array($decoded) ? $decoded : [],
+                ];
+            }
+        };
+
+        $result = $api->exec();
+
+        // limpiamos los globales
+        $_POST = [];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        return $result;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}

--- a/Test/Core/Controller/ApiCreateDocumentTest.php
+++ b/Test/Core/Controller/ApiCreateDocumentTest.php
@@ -37,6 +37,11 @@ final class ApiCreateDocumentTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        // los controladores crean el documento dentro de una transacción, y dentro
+        // no se pueden crear tablas. Instanciamos todos los modelos antes para que
+        // el esquema exista al empezar, incluso en una base de datos recién creada.
+        self::loadCoreModels();
+
         self::setDefaultSettings();
         self::installAccountingPlan();
         self::removeTaxRegularization();

--- a/Test/Core/Controller/ApiCreateDocumentTest.php
+++ b/Test/Core/Controller/ApiCreateDocumentTest.php
@@ -24,6 +24,7 @@ use FacturaScripts\Core\DataSrc\Retenciones;
 use FacturaScripts\Core\Model\AlbaranCliente;
 use FacturaScripts\Core\Model\FacturaCliente;
 use FacturaScripts\Core\Response;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -42,6 +43,9 @@ final class ApiCreateDocumentTest extends TestCase
         // el esquema exista al empezar, incluso en una base de datos recién creada.
         self::loadCoreModels();
 
+        // Al crear el esquema se cargan los ajustes base de España. Restauramos
+        // el país indicado en config.php antes de aplicar sus ajustes por defecto.
+        Tools::settingsSet('default', 'codpais', Tools::config('initial_codpais', 'ESP'));
         self::setDefaultSettings();
         self::installAccountingPlan();
         self::removeTaxRegularization();

--- a/Test/Core/Controller/ApiEditDocumentTest.php
+++ b/Test/Core/Controller/ApiEditDocumentTest.php
@@ -231,6 +231,75 @@ final class ApiEditDocumentTest extends TestCase
         $this->assertTrue($product->delete(), 'can-not-delete-product');
     }
 
+    public function testLineIrpfIsApplied(): void
+    {
+        // creamos un cliente sin retención, para que la cabecera no aporte IRPF
+        $subject = $this->getRandomCustomer();
+        $subject->codretencion = null;
+        $this->assertTrue($subject->save(), 'can-not-save-customer');
+
+        // creamos un albarán con una línea libre sin IRPF
+        $doc = new AlbaranCliente();
+        $this->assertTrue($doc->setSubject($subject), 'can-not-set-subject');
+        $this->assertTrue($doc->save(), 'can-not-create-albaran');
+
+        $line = $doc->getNewLine();
+        $line->descripcion = 'línea libre';
+        $line->cantidad = 1;
+        $line->pvpunitario = 100;
+        $lines = [$line];
+        $this->assertTrue(Calculator::calculate($doc, $lines, true), 'can-not-calculate');
+
+        $doc->reload();
+        $this->assertEquals(0, $doc->totalirpf, 'bad-initial-totalirpf');
+
+        // EDICIÓN 1: añadimos IRPF a la línea existente y creamos otra con IRPF distinto
+        $idlinea = $lines[0]->idlinea;
+        $payload = [
+            'lineas' => json_encode([
+                ['idlinea' => $idlinea, 'descripcion' => 'línea libre', 'cantidad' => 1, 'pvpunitario' => 100, 'irpf' => 15],
+                ['descripcion' => 'línea nueva', 'cantidad' => 1, 'pvpunitario' => 100, 'irpf' => 7],
+            ]),
+        ];
+        $result = $this->callEdit('editarAlbaranCliente', $doc->idalbaran, $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'edit-irpf-bad-code');
+
+        // ambas líneas guardan su propio porcentaje
+        $updated = [];
+        foreach ($doc->getLines() as $docLine) {
+            $updated[$docLine->descripcion] = $docLine->irpf;
+        }
+        $this->assertEquals(15, $updated['línea libre'] ?? null, 'existing-line-irpf-not-applied');
+        $this->assertEquals(7, $updated['línea nueva'] ?? null, 'new-line-irpf-not-applied');
+
+        // el documento acumula el IRPF de ambas: 100 * 15% + 100 * 7%
+        $doc->reload();
+        $this->assertEquals(15, $doc->irpf, 'bad-doc-irpf');
+        $this->assertEquals(22, $doc->totalirpf, 'bad-totalirpf');
+
+        // EDICIÓN 2: si no enviamos irpf, la línea existente conserva el suyo
+        $payload = [
+            'lineas' => json_encode([
+                ['idlinea' => $idlinea, 'descripcion' => 'línea libre', 'cantidad' => 2, 'pvpunitario' => 100],
+            ]),
+        ];
+        $result = $this->callEdit('editarAlbaranCliente', $doc->idalbaran, $payload);
+        $this->assertEquals(Response::HTTP_OK, $result['code'], 'edit-keep-irpf-bad-code');
+
+        $remaining = $doc->getLines();
+        $this->assertCount(1, $remaining, 'bad-line-count');
+        $this->assertEquals(15, $remaining[0]->irpf, 'line-irpf-not-preserved');
+
+        // 200 * 15%
+        $doc->reload();
+        $this->assertEquals(30, $doc->totalirpf, 'bad-totalirpf-after-keep');
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'can-not-delete-albaran');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'can-not-delete-contact');
+        $this->assertTrue($subject->delete(), 'can-not-delete-customer');
+    }
+
     public function testMethodNotAllowed(): void
     {
         $result = $this->callEdit('editarFacturaCliente', 1, ['lineas' => '[]'], 'POST');


### PR DESCRIPTION
## Descripción / Description

Al crear o editar un documento con la API en una sola petición (`crearFacturaCliente`, `editarFacturaCliente` y el resto de endpoints `crear*` / `editar*`), **el IRPF enviado en cada línea del array `lineas` se descarta en silencio**. La petición responde `200 OK`, guarda correctamente el resto de campos de la línea, y la retención simplemente no se aplica: la factura se queda sin IRPF y el total sale mal.

El impacto es alto para quien factura con retención por API: no hay ninguna forma de enviar el IRPF por línea en una sola petición, y como la respuesta es `200` sin ningún aviso, el error pasa desapercibido hasta que se revisa la factura o la contabilidad. Genera facturas incorrectas de forma silenciosa.

### Causa

`applyLineFields()`, en `Core/Lib/ApiBusinessDocumentTrait.php`, es el único punto donde el array `lineas` del payload se traslada al modelo de línea, y lo usan tanto `ApiCreateDocument::saveLines()` como `ApiEditDocument::syncLines()`. Su lista de campos no incluía `irpf`, así que el valor recibido nunca llegaba a la línea.

La línea acababa con el porcentaje heredado de la cabecera, que `FacturaCliente::getNewLine()` copia desde `$this->irpf` (la retención del cliente vía `Cliente::irpf()`, o `0.0` si no tiene ninguna configurada). Y como `Calculator::accumulate()` calcula `totalirpf` a partir de `$line->irpf`, y después `Calculator::calculate()` sobrescribe `$doc->irpf` con el máximo de las líneas, el porcentaje enviado no dejaba rastro en ningún sitio.

El flujo clásico en varias peticiones no tiene el problema, porque `APIModel::doPOST()` / `doPUT()` asignan todos los campos recibidos sin lista blanca. De ahí la asimetría entre las dos formas de crear una factura.

### Solución

Aplicar `irpf` en `applyLineFields()` cuando venga en los datos. Se usa `isset()` en lugar de asignación incondicional para no cambiar el comportamiento actual: si el campo no se envía, las líneas nuevas siguen heredando el porcentaje de la cabecera y las existentes conservan el suyo.

Se añaden por el mismo motivo otros dos campos que la misma lista descartaba:

- `orden`: posición de la línea, necesaria para poder ordenarlas explícitamente por API.
- `coste`: solo en líneas de venta, que son las que tienen la columna (de ahí el `property_exists`). Sin él, las líneas libres se guardan con coste `0` y `totalbeneficio` / `totalcoste` del documento quedan falseados.

Al estar el método compartido, la corrección cubre los 16 endpoints `crear*` / `editar*` de factura, albarán, pedido y presupuesto, tanto de ventas como de compras.

No he encontrado ninguna incidencia previa abierta sobre esto.

## Pruebas realizadas / Tests performed

- [x] He ejecutado `composer test`.
- [x] He ejecutado `composer cs-check`.
- [ ] He ejecutado `composer phpstan`.
- [x] He realizado pruebas manuales.

**`composer test`**: 1199 tests, 10433 aserciones, sin fallos (9 saltados), sobre una base de datos MariaDB 10.11 recién creada. Antes de aplicar la corrección, los 5 tests nuevos que cubren el comportamiento fallan; el sexto (`testLineWithoutIrpfInheritsFromSubject`) pasa en ambos casos, porque comprueba precisamente que no hay regresión en la herencia desde la cabecera.

**`composer cs-check`**: sin avisos en los tres archivos modificados.

**`composer phpstan`**: no he podido ejecutarlo. La versión que fija `composer.json` (`phpstan/phpstan: ^0.12.93`) no resuelve por `dist` en mi entorno y Composer cae a clonar el repositorio completo por `source`, que no llega a completarse. No es un problema de este cambio; no he tocado `composer.json`.

**Pruebas manuales**: verificado sobre una instalación de desarrollo real, enviando `irpf` por línea a `crearFacturaCliente` y comprobando en la factura resultante que la retención se aplica a las líneas y que `totalirpf` y `total` cuadran.

Tests añadidos:

| Test | Cubre |
|---|---|
| `ApiCreateDocumentTest::testLineIrpfIsApplied` | cliente sin retención + `irpf` por línea → línea y `totalirpf` correctos |
| `ApiCreateDocumentTest::testLineIrpfOverridesSubjectRetention` | el IRPF de la línea prevalece sobre la retención del cliente |
| `ApiCreateDocumentTest::testLineWithoutIrpfInheritsFromSubject` | sin `irpf` en el payload se mantiene la herencia (no regresión) |
| `ApiCreateDocumentTest::testInvoiceLineIrpfIsApplied` | el caso reportado, en `crearFacturaCliente`, incluido el cuadre de `total` |
| `ApiCreateDocumentTest::testLineOrderAndCostAreApplied` | `orden` y `coste` |
| `ApiEditDocumentTest::testLineIrpfIsApplied` | edición: IRPF en línea existente y en línea nueva, y que omitirlo lo preserva |

Los tests que dependen de retenciones se saltan con `markTestSkipped()` en las configuraciones de país que no traen `retenciones.csv` (solo lo tienen ESP, PER y DOM), para no romper la matriz de países de CI.

## Compatibilidad / Compatibility

Ninguna incompatibilidad.

- Los tres campos son opcionales y solo se aplican si vienen en el payload, así que ningún cliente actual de la API cambia de comportamiento.
- No hay cambios de esquema: `irpf`, `orden` y `coste` ya son columnas existentes en las tablas de líneas.
- No se modifica ninguna firma pública ni el contrato de la API; solo se amplía el conjunto de campos aceptados.

Nota: la documentación de la API vive fuera del repositorio, así que no he tocado nada aquí, pero convendría añadir `irpf`, `orden` y `coste` a la lista de campos aceptados en `lineas` cuando se actualice.

## Lista de comprobación / Checklist

- [x] El pull request contiene un único cambio coherente.
- [x] He revisado mi propio diff.
- [x] He añadido o actualizado los tests necesarios.
- [x] He actualizado la documentación cuando corresponde.
- [x] No he incluido credenciales, archivos generados ni cambios ajenos.
- [x] No he modificado directamente las [traducciones](https://facturascripts.com/traducciones).