### PR TITLE
Incluye versión y orden de plugins en informes de errores

### DIFF
--- a/Core/CrashReport.php
+++ b/Core/CrashReport.php
@@ -98,7 +98,7 @@ final class CrashReport
             'core_version' => Kernel::version(),
             'php_version' => phpversion(),
             'os' => PHP_OS,
-            'plugin_list' => implode(',', Plugins::enabled()),
+            'plugin_list' => implode(',', Plugins::enabledWithVersion()),
             'idinstall' => $telemetryId,
             'site_url' => $siteUrl,
         ];

--- a/Core/Plugins.php
+++ b/Core/Plugins.php
@@ -215,6 +215,26 @@ final class Plugins
         return array_keys($enabled);
     }
 
+    /**
+     * devuelve los plugins activos con su versión, respetando el orden de carga
+     *
+     * @return array
+     */
+    public static function enabledWithVersion(): array
+    {
+        $enabled = [];
+
+        self::load();
+        foreach (self::$plugins as $plugin) {
+            if ($plugin->enabled) {
+                $enabled[] = $plugin;
+            }
+        }
+
+        usort($enabled, static fn(Plugin $a, Plugin $b): int => $a->order <=> $b->order);
+        return array_map(static fn(Plugin $plugin): string => $plugin->name . ':' . $plugin->version, $enabled);
+    }
+
     public static function folder(): string
     {
         return Tools::folder('Plugins');


### PR DESCRIPTION
Este cambio es muy útil para los mensaje de Informe de errores que nos llegan a los desarrolladores a la Forja.

## Necesidad

Los informes de errores ya identifican los plugins activos, pero solo por nombre. La versión permite detectar incompatibilidades y regresiones concretas. El orden también es relevante porque determina la carga y el orden de ejecución/despliegue, pudiendo explicar conflictos entre plugins.

## Resolución

Se añade `Plugins::enabledWithVersion()`, que reutiliza los objetos `Plugin` cargados, filtra los activos, los ordena por `order` y devuelve entradas `nombre:versión`. `CrashReport` usa este método para construir `plugin_list`; `Plugins::enabled()` permanece sin cambios para no afectar a sus consumidores existentes.