### PR TITLE
feat: añadir soporte para retenciones en líneas de documentos

### DIFF
--- a/Core/Lib/AjaxForms/CommonLineHTML.php
+++ b/Core/Lib/AjaxForms/CommonLineHTML.php
@@ -179,16 +179,27 @@ trait CommonLineHTML
 
     private static function irpf(string $idlinea, BusinessDocumentLine $line, TransformerDocument $model, string $jsFunc): string
     {
+        // si la línea no tiene retención asignada, por compatibilidad buscamos la primera con el mismo porcentaje
+        $selected = $line->codretencion;
+        if (empty($selected) && !empty($line->irpf)) {
+            foreach (Retenciones::all() as $ret) {
+                if ($ret->activa && $line->irpf == $ret->porcentaje) {
+                    $selected = $ret->codretencion;
+                    break;
+                }
+            }
+        }
+
         $options = ['<option value="">------</option>'];
         foreach (Retenciones::all() as $ret) {
-            // si la retención no está activa o seleccionada, la saltamos
-            if (!$ret->activa && $line->irpf != $ret->porcentaje) {
+            // si la retención no está activa ni seleccionada, la saltamos
+            if (!$ret->activa && $selected !== $ret->codretencion) {
                 continue;
             }
 
-            $options[] = $line->irpf === $ret->porcentaje ?
-                '<option value="' . $ret->porcentaje . '" selected>' . $ret->descripcion . '</option>' :
-                '<option value="' . $ret->porcentaje . '">' . $ret->descripcion . '</option>';
+            $options[] = $selected === $ret->codretencion ?
+                '<option value="' . $ret->codretencion . '" data-irpf="' . $ret->porcentaje . '" selected>' . $ret->descripcion . '</option>' :
+                '<option value="' . $ret->codretencion . '" data-irpf="' . $ret->porcentaje . '">' . $ret->descripcion . '</option>';
         }
 
         $attributes = $model->editable && false === $line->suplido ?

--- a/Core/Lib/AjaxForms/PurchasesLineHTML.php
+++ b/Core/Lib/AjaxForms/PurchasesLineHTML.php
@@ -196,7 +196,7 @@ class PurchasesLineHTML
         $line->dtopor2 = (float)$formData['dtopor2_' . $id];
         $line->descripcion = $formData['descripcion_' . $id];
         $line->excepcioniva = $formData['excepcioniva_' . $id] ?? null;
-        $line->irpf = (float)($formData['irpf_' . $id] ?? '0');
+        $line->setRetention($formData['irpf_' . $id] ?? null);
         $line->suplido = (bool)($formData['suplido_' . $id] ?? '0');
         $line->pvpunitario = (float)$formData['pvpunitario_' . $id];
 

--- a/Core/Lib/AjaxForms/SalesLineHTML.php
+++ b/Core/Lib/AjaxForms/SalesLineHTML.php
@@ -187,7 +187,7 @@ class SalesLineHTML
         $line->dtopor2 = (float)$formData['dtopor2_' . $id];
         $line->descripcion = $formData['descripcion_' . $id];
         $line->excepcioniva = $formData['excepcioniva_' . $id] ?? null;
-        $line->irpf = (float)($formData['irpf_' . $id] ?? '0');
+        $line->setRetention($formData['irpf_' . $id] ?? null);
         $line->mostrar_cantidad = (bool)($formData['mostrar_cantidad_' . $id] ?? '0');
         $line->mostrar_precio = (bool)($formData['mostrar_precio_' . $id] ?? '0');
         $line->salto_pagina = (bool)($formData['salto_pagina_' . $id] ?? '0');

--- a/Core/Lib/PDF/PDFDocument.php
+++ b/Core/Lib/PDF/PDFDocument.php
@@ -40,6 +40,7 @@ use FacturaScripts\Dinamic\Model\Impuesto;
 use FacturaScripts\Dinamic\Model\Pais;
 use FacturaScripts\Dinamic\Model\Proveedor;
 use FacturaScripts\Dinamic\Model\ReciboCliente;
+use FacturaScripts\Dinamic\Model\Retencion;
 
 /**
  * PDF document data.
@@ -240,7 +241,7 @@ abstract class PDFDocument extends PDFCore
                 continue;
             }
 
-            $key = 'irpf_' . $line->irpf;
+            $key = 'irpf_' . ($line->codretencion ?: $line->irpf);
             if (!isset($subtotals[$key])) {
                 $subtotals[$key] = [
                     'tax' => $this->i18n->trans('irpf') . ' ' . $line->irpf . '%',
@@ -250,6 +251,11 @@ abstract class PDFDocument extends PDFCore
                     'taxsurchargep' => 0,
                     'taxsurcharge' => 0
                 ];
+
+                $retencion = new Retencion();
+                if (!empty($line->codretencion) && $retencion->load($line->codretencion)) {
+                    $subtotals[$key]['tax'] = $retencion->descripcion;
+                }
             }
 
             $subtotals[$key]['taxbase'] += $line->pvptotal * $eud;

--- a/Core/Model/Base/BusinessDocumentLine.php
+++ b/Core/Model/Base/BusinessDocumentLine.php
@@ -19,6 +19,7 @@
 
 namespace FacturaScripts\Core\Model\Base;
 
+use FacturaScripts\Core\DataSrc\Retenciones;
 use FacturaScripts\Core\Template\ModelClass as NewModelClass;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Where;
@@ -50,6 +51,9 @@ abstract class BusinessDocumentLine extends NewModelClass
      * @var float|int
      */
     public $cantidad;
+
+    /** @var string Código de la retención aplicada a la línea. */
+    public $codretencion;
 
     /**
      * Descripción de la línea.
@@ -173,6 +177,7 @@ abstract class BusinessDocumentLine extends NewModelClass
 
         $this->actualizastock = 0;
         $this->cantidad = 1.0;
+        $this->codretencion = null;
         $this->descripcion = '';
         $this->dtopor = 0.0;
         $this->dtopor2 = 0.0;
@@ -364,6 +369,26 @@ abstract class BusinessDocumentLine extends NewModelClass
         $this->pvpunitario = round($newPrice, Producto::ROUND_DECIMALS);
     }
 
+    public function setRetention(?string $codretencion): void
+    {
+        if (empty($codretencion)) {
+            $this->codretencion = null;
+            $this->irpf = 0.0;
+            return;
+        }
+
+        $retencion = Retenciones::get($codretencion);
+        if (empty($retencion->codretencion)) {
+            // la retención no existe
+            $this->codretencion = null;
+            $this->irpf = 0.0;
+            return;
+        }
+
+        $this->codretencion = $retencion->codretencion;
+        $this->irpf = (float)$retencion->porcentaje;
+    }
+
     public function setTax(?string $codimpuesto): void
     {
         if (empty($codimpuesto)) {
@@ -435,6 +460,10 @@ abstract class BusinessDocumentLine extends NewModelClass
             $this->codimpuesto = null;
             $this->iva = 0.0;
             $this->recargo = 0.0;
+        }
+
+        if (empty($this->codretencion)) {
+            $this->codretencion = null;
         }
 
         if ($this->servido < 0 && $this->cantidad >= 0) {

--- a/Core/Table/lineasalbaranescli.xml
+++ b/Core/Table/lineasalbaranescli.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>coste</name>
         <type>double precision</type>
     </column>

--- a/Core/Table/lineasalbaranesprov.xml
+++ b/Core/Table/lineasalbaranesprov.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>descripcion</name>
         <type>text</type>
     </column>

--- a/Core/Table/lineasfacturascli.xml
+++ b/Core/Table/lineasfacturascli.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>coste</name>
         <type>double precision</type>
     </column>

--- a/Core/Table/lineasfacturasprov.xml
+++ b/Core/Table/lineasfacturasprov.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>descripcion</name>
         <type>text</type>
     </column>

--- a/Core/Table/lineaspedidoscli.xml
+++ b/Core/Table/lineaspedidoscli.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>coste</name>
         <type>double precision</type>
     </column>

--- a/Core/Table/lineaspedidosprov.xml
+++ b/Core/Table/lineaspedidosprov.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>descripcion</name>
         <type>text</type>
     </column>

--- a/Core/Table/lineaspresupuestoscli.xml
+++ b/Core/Table/lineaspresupuestoscli.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>coste</name>
         <type>double precision</type>
     </column>

--- a/Core/Table/lineaspresupuestosprov.xml
+++ b/Core/Table/lineaspresupuestosprov.xml
@@ -22,6 +22,10 @@
         <type>character varying(10)</type>
     </column>
     <column>
+        <name>codretencion</name>
+        <type>character varying(10)</type>
+    </column>
+    <column>
         <name>descripcion</name>
         <type>text</type>
     </column>

--- a/Core/View/Tab/PurchasesDocument.html.twig
+++ b/Core/View/Tab/PurchasesDocument.html.twig
@@ -312,7 +312,9 @@
         const globalDiscount = (100 - globalDtopor) * (100 - globalDtopor2) / 10000;
         const iva = parseFloat(document.forms['purchasesForm']['iva_' + id].value) || 0;
         const recargo = document.forms['purchasesForm']['recargo_' + id] ? parseFloat(document.forms['purchasesForm']['recargo_' + id].value) || 0 : 0;
-        const irpf = parseFloat(document.forms['purchasesForm']['irpf_' + id].value) || 0;
+        const irpfSelect = document.forms['purchasesForm']['irpf_' + id];
+        const irpfOption = irpfSelect && irpfSelect.selectedIndex >= 0 ? irpfSelect.options[irpfSelect.selectedIndex] : null;
+        const irpf = irpfOption ? parseFloat(irpfOption.dataset.irpf) || 0 : 0;
         const cantidad = parseFloat(document.forms['purchasesForm']['cantidad_' + id].value) || 0;
         if (total <= 0) {
             alert('total > 0');

--- a/Core/View/Tab/SalesDocument.html.twig
+++ b/Core/View/Tab/SalesDocument.html.twig
@@ -309,7 +309,9 @@
         const globalDiscount = (100 - globalDtopor) * (100 - globalDtopor2) / 10000;
         const iva = parseFloat(document.forms['salesForm']['iva_' + id].value) || 0;
         const recargo = document.forms['salesForm']['recargo_' + id] ? parseFloat(document.forms['salesForm']['recargo_' + id].value) || 0 : 0;
-        const irpf = parseFloat(document.forms['salesForm']['irpf_' + id].value) || 0;
+        const irpfSelect = document.forms['salesForm']['irpf_' + id];
+        const irpfOption = irpfSelect && irpfSelect.selectedIndex >= 0 ? irpfSelect.options[irpfSelect.selectedIndex] : null;
+        const irpf = irpfOption ? parseFloat(irpfOption.dataset.irpf) || 0 : 0;
         const cantidad = parseFloat(document.forms['salesForm']['cantidad_' + id].value) || 0;
         if (total <= 0) {
             alert('total > 0');

--- a/Test/Core/Lib/PDF/PDFDocumentTest.php
+++ b/Test/Core/Lib/PDF/PDFDocumentTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2026 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Test\Core\Lib\PDF;
+
+use FacturaScripts\Core\Lib\Calculator;
+use FacturaScripts\Core\Lib\Export\PDFExport;
+use FacturaScripts\Core\Model\PresupuestoCliente;
+use FacturaScripts\Core\Model\Retencion;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use FacturaScripts\Test\Traits\RandomDataTrait;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class PDFDocumentTest extends TestCase
+{
+    use DefaultSettingsTrait;
+    use LogErrorsTrait;
+    use RandomDataTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::setDefaultSettings();
+    }
+
+    /**
+     * Comprueba que dos líneas con el mismo porcentaje de IRPF pero con retenciones
+     * distintas (codretencion) generan dos filas de subtotal distintas en el PDF,
+     * en lugar de mezclarse en una sola fila.
+     */
+    public function testTaxesRowsGroupByRetentionNotByPercentage(): void
+    {
+        // creamos dos retenciones con el mismo porcentaje pero distinto código
+        $retentionA = new Retencion();
+        $retentionA->codretencion = 'A' . Tools::randomString(4);
+        $retentionA->descripcion = 'Retención A ' . Tools::randomString(4);
+        $retentionA->porcentaje = 4;
+        $this->assertTrue($retentionA->save(), 'retention-a-cant-save');
+
+        $retentionB = new Retencion();
+        $retentionB->codretencion = 'B' . Tools::randomString(4);
+        $retentionB->descripcion = 'Retención B ' . Tools::randomString(4);
+        $retentionB->porcentaje = 4;
+        $this->assertTrue($retentionB->save(), 'retention-b-cant-save');
+
+        // creamos el documento con dos líneas, una para cada retención
+        $subject = $this->getRandomCustomer();
+        $this->assertTrue($subject->save(), 'customer-cant-save');
+
+        $doc = new PresupuestoCliente();
+        $this->assertTrue($doc->setSubject($subject), 'document-cant-set-subject');
+        $this->assertTrue($doc->save(), 'document-cant-save');
+
+        $firstLine = $doc->getNewLine();
+        $firstLine->cantidad = 1;
+        $firstLine->descripcion = 'Linea con retención A';
+        $firstLine->pvpunitario = 100;
+        $firstLine->setRetention($retentionA->codretencion);
+        $this->assertTrue($firstLine->save(), 'first-line-cant-save');
+
+        $secondLine = $doc->getNewLine();
+        $secondLine->cantidad = 1;
+        $secondLine->descripcion = 'Linea con retención B';
+        $secondLine->pvpunitario = 200;
+        $secondLine->setRetention($retentionB->codretencion);
+        $this->assertTrue($secondLine->save(), 'second-line-cant-save');
+
+        $lines = $doc->getLines();
+        $this->assertTrue(Calculator::calculate($doc, $lines, true), 'document-cant-calculate');
+
+        // invocamos el método protegido getTaxesRows() mediante reflection
+        $pdfExport = new PDFExport();
+        $method = new ReflectionMethod($pdfExport, 'getTaxesRows');
+        $rows = $method->invoke($pdfExport, $doc);
+
+        // deben existir dos filas de irpf distintas, una por cada retención
+        $irpfRows = [];
+        foreach ($rows as $key => $row) {
+            if (str_starts_with($key, 'irpf_')) {
+                $irpfRows[$key] = $row;
+            }
+        }
+        $this->assertCount(2, $irpfRows, 'retentions-with-same-percentage-were-merged');
+
+        // las etiquetas deben corresponder a la descripción de cada retención,
+        // no al texto genérico "irpf 4%"
+        $labels = array_column($irpfRows, 'tax');
+        $this->assertContains($retentionA->descripcion, $labels, 'missing-retention-a-label');
+        $this->assertContains($retentionB->descripcion, $labels, 'missing-retention-b-label');
+        foreach ($labels as $label) {
+            $this->assertStringNotContainsString('%', $label, 'label-should-not-be-generic-percentage-text');
+        }
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'document-cant-delete');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'address-cant-delete');
+        $this->assertTrue($subject->delete(), 'customer-cant-delete');
+        $this->assertTrue($retentionA->delete(), 'retention-a-cant-delete');
+        $this->assertTrue($retentionB->delete(), 'retention-b-cant-delete');
+    }
+}

--- a/Test/Core/Model/Base/BusinessDocumentLineTest.php
+++ b/Test/Core/Model/Base/BusinessDocumentLineTest.php
@@ -22,6 +22,8 @@ namespace FacturaScripts\Test\Core\Model\Base;
 use FacturaScripts\Core\Lib\BusinessDocumentGenerator;
 use FacturaScripts\Core\Lib\Calculator;
 use FacturaScripts\Core\Model\PresupuestoCliente;
+use FacturaScripts\Core\Model\Retencion;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Test\Traits\DefaultSettingsTrait;
 use FacturaScripts\Test\Traits\LogErrorsTrait;
 use FacturaScripts\Test\Traits\RandomDataTrait;
@@ -114,5 +116,63 @@ final class BusinessDocumentLineTest extends TestCase
         $this->assertTrue($doc->delete(), 'document-cant-delete');
         $this->assertTrue($subject->getDefaultAddress()->delete(), 'address-cant-delete');
         $this->assertTrue($subject->delete(), 'customer-cant-delete');
+    }
+
+    public function testSetRetention(): void
+    {
+        // creamos una retención de prueba
+        $retencion = new Retencion();
+        $retencion->codretencion = 'T' . Tools::randomString(5);
+        $retencion->descripcion = 'Retención de prueba';
+        $retencion->porcentaje = 7;
+        $this->assertTrue($retencion->save(), 'retention-cant-save');
+
+        $subject = $this->getRandomCustomer();
+        $this->assertTrue($subject->save(), 'customer-cant-save');
+
+        $doc = new PresupuestoCliente();
+        $this->assertTrue($doc->setSubject($subject), 'document-cant-set-subject');
+        $this->assertTrue($doc->save(), 'document-cant-save');
+
+        $line = $doc->getNewLine();
+        $line->cantidad = 1;
+        $line->descripcion = 'Linea con retención';
+        $line->pvpunitario = 100;
+
+        // asignamos la retención de prueba y comprobamos codretencion e irpf
+        $line->setRetention($retencion->codretencion);
+        $this->assertEquals($retencion->codretencion, $line->codretencion, 'bad-codretencion');
+        $this->assertEquals((float)$retencion->porcentaje, $line->irpf, 'bad-irpf');
+
+        // quitamos la retención pasando null
+        $line->setRetention(null);
+        $this->assertNull($line->codretencion, 'codretencion-should-be-null');
+        $this->assertEquals(0.0, $line->irpf, 'irpf-should-be-zero');
+
+        // volvemos a asignarla y luego probamos con cadena vacía
+        $line->setRetention($retencion->codretencion);
+        $line->setRetention('');
+        $this->assertNull($line->codretencion, 'codretencion-should-be-null-with-empty-string');
+        $this->assertEquals(0.0, $line->irpf, 'irpf-should-be-zero-with-empty-string');
+
+        // probamos con un código de retención que no existe
+        $line->setRetention($retencion->codretencion);
+        $line->setRetention('CODIGO-NO-EXISTE');
+        $this->assertNull($line->codretencion, 'codretencion-should-be-null-with-unknown-code');
+        $this->assertEquals(0.0, $line->irpf, 'irpf-should-be-zero-with-unknown-code');
+
+        // guardamos la línea con la retención asignada y comprobamos que persiste
+        $line->setRetention($retencion->codretencion);
+        $this->assertTrue($line->save(), 'line-cant-save');
+
+        $loadedLine = $doc->getLines()[0];
+        $this->assertEquals($retencion->codretencion, $loadedLine->codretencion, 'bad-persisted-codretencion');
+        $this->assertEquals((float)$retencion->porcentaje, $loadedLine->irpf, 'bad-persisted-irpf');
+
+        // limpiamos
+        $this->assertTrue($doc->delete(), 'document-cant-delete');
+        $this->assertTrue($subject->getDefaultAddress()->delete(), 'address-cant-delete');
+        $this->assertTrue($subject->delete(), 'customer-cant-delete');
+        $this->assertTrue($retencion->delete(), 'retention-cant-delete');
     }
 }


### PR DESCRIPTION
- Se ha añadido la propiedad `codretencion` en `BusinessDocumentLine.php` para almacenar el código de la retención aplicada.
- Se ha implementado el método `setRetention` para gestionar la asignación de retenciones y su porcentaje correspondiente.
- Se han actualizado las pruebas en `BusinessDocumentLineTest.php` para verificar el correcto funcionamiento de las retenciones.
- Se han modificado los archivos XML de esquema para incluir la nueva columna `codretencion` en las líneas de documentos.
- Se han ajustado los archivos HTML y PHP relacionados para manejar la lógica de retenciones en la interfaz de usuario.

Estos cambios permiten una mejor gestión de las retenciones fiscales en los documentos generados.

https://facturascripts.com/issues/119-036-660 esto viene a raíz de esta cuestión