### PR TITLE
añadida la codificacion UTF-8 para poder importar ejercicios

### DIFF
--- a/Core/Lib/Accounting/AccountingPlanImport.php
+++ b/Core/Lib/Accounting/AccountingPlanImport.php
@@ -389,6 +389,7 @@ class AccountingPlanImport
     protected function processCsvData(string $filePath): bool
     {
         $csv = new Csv();
+        $csv->output_encoding = 'UTF-8';
         $csv->auto($filePath);
 
         // Verificar que el CSV tenga al menos 2 columnas (código y descripción)


### PR DESCRIPTION
## Descripción / Description

Se añadió la codificación UTF-8 para poder importar ejercicios con el mismo csv con el que se exportan

## Pruebas realizadas / Tests performed

- [x] He ejecutado `composer test`.
- [x] He ejecutado `composer cs-check`.
- [ ] He ejecutado `composer phpstan`.
- [x] He realizado pruebas manuales.

 Incompatibilidad con la versión de phpstan

## Compatibilidad / Compatibility

 Ninguno.

## Lista de comprobación / Checklist

- [x] El pull request contiene un único cambio coherente.
- [x] He revisado mi propio diff.
- [ ] He añadido o actualizado los tests necesarios.
- [ ] He actualizado la documentación cuando corresponde.
- [x] No he incluido credenciales, archivos generados ni cambios ajenos.
- [x] No he modificado directamente las [traducciones](https://facturascripts.com/traducciones).
